### PR TITLE
refactor: add contract folder struct

### DIFF
--- a/contracts/contracts/CAPE.sol
+++ b/contracts/contracts/CAPE.sol
@@ -7,8 +7,6 @@ pragma solidity ^0.8.0;
 /// @notice This is a notice.
 /// @dev Developers are awesome!
 
-import {Curve} from "./BN254.sol";
-
 contract CAPE {
     mapping(uint256 => bool) public nullifiers;
 

--- a/contracts/contracts/libraries/BN254.sol
+++ b/contracts/contracts/libraries/BN254.sol
@@ -12,7 +12,7 @@
 pragma solidity ^0.8.0;
 
 /// @notice Barreto-Naehrig curve over a 254 bit prime field
-library Curve {
+library BN254 {
     // use notation from https://datatracker.ietf.org/doc/draft-irtf-cfrg-pairing-friendly-curves/
     //
     // Elliptic curve is defined over a prime field GF(p), with embedding degree k.

--- a/contracts/contracts/mocks/TestBN254.sol
+++ b/contracts/contracts/mocks/TestBN254.sol
@@ -1,7 +1,7 @@
 //SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity ^0.8.0;
 
-import {Curve as C} from "./BN254.sol";
+import {BN254 as C} from "../libraries/BN254.sol";
 
 contract TestBN254 {
     constructor() {}

--- a/contracts/contracts/mocks/TestCAPE.sol
+++ b/contracts/contracts/mocks/TestCAPE.sol
@@ -1,7 +1,7 @@
 //SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.0;
 
-import "./CAPE.sol";
+import "../CAPE.sol";
 
 contract TestCAPE is CAPE {
     function _insertNullifier(uint256 _nullifier) public {

--- a/contracts/contracts/mocks/TestRecordsMerkleTree.sol
+++ b/contracts/contracts/mocks/TestRecordsMerkleTree.sol
@@ -2,8 +2,8 @@
 pragma solidity ^0.8.0;
 
 import "hardhat/console.sol";
-import "./Rescue.sol";
-import "./RecordsMerkleTree.sol";
+import "../Rescue.sol";
+import "../RecordsMerkleTree.sol";
 
 contract TestRecordsMerkleTree is RecordsMerkleTree {
     constructor(uint8 _height) RecordsMerkleTree(_height) {}

--- a/contracts/contracts/mocks/TestRescue.sol
+++ b/contracts/contracts/mocks/TestRescue.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 import "hardhat/console.sol";
-import "./Rescue.sol";
+import "../Rescue.sol";
 
 contract TestRescue is Rescue {
     function doNothing() public {}

--- a/contracts/contracts/mocks/TestRescueNonOptimized.sol
+++ b/contracts/contracts/mocks/TestRescueNonOptimized.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 import "hardhat/console.sol";
-import "./RescueNonOptimized.sol";
+import "../RescueNonOptimized.sol";
 
 contract TestRescueNonOptimized is RescueNonOptimized {
     function doNothing() public {}

--- a/contracts/contracts/mocks/TestTranscript.sol
+++ b/contracts/contracts/mocks/TestTranscript.sol
@@ -5,8 +5,8 @@ import "hardhat/console.sol";
 
 // TODO: we have name collisions in src/bindings/mod.rs
 // Consider not pulling everything to top-level
-import {Curve} from "./BN254.sol";
-import {Transcript} from "./Transcript.sol";
+import {BN254} from "../libraries/BN254.sol";
+import {Transcript} from "../verifier/Transcript.sol";
 
 contract TestTranscript {
     using Transcript for Transcript.TranscriptData;
@@ -53,7 +53,7 @@ contract TestTranscript {
 
     function testAppendCommitmentAndGet(
         Transcript.TranscriptData memory transcript,
-        Curve.G1Point memory comm
+        BN254.G1Point memory comm
     ) public pure returns (uint256) {
         transcript.appendCommitment(comm);
         return transcript.getAndAppendChallenge();
@@ -61,7 +61,7 @@ contract TestTranscript {
 
     function testAppendCommitmentsAndGet(
         Transcript.TranscriptData memory transcript,
-        Curve.G1Point[] memory comms
+        BN254.G1Point[] memory comms
     ) public pure returns (uint256) {
         transcript.appendCommitments(comms);
         return transcript.getAndAppendChallenge();

--- a/contracts/contracts/verifier/PlonkVerifier.sol
+++ b/contracts/contracts/verifier/PlonkVerifier.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {Curve} from "./BN254.sol";
+import {BN254} from "../libraries/BN254.sol";
 import "hardhat/console.sol";
 
 contract PlonkVerifier {}

--- a/contracts/contracts/verifier/Transcript.sol
+++ b/contracts/contracts/verifier/Transcript.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
 
 import "solidity-bytes-utils/contracts/BytesLib.sol";
 import "hardhat/console.sol";
-import {Curve} from "./BN254.sol";
+import {BN254} from "../libraries/BN254.sol";
 
 library Transcript {
     struct TranscriptData {
@@ -74,7 +74,7 @@ library Transcript {
 
     function appendCommitments(
         TranscriptData memory self,
-        Curve.G1Point[] memory comms
+        BN254.G1Point[] memory comms
     ) internal pure {
         for (uint256 i = 0; i < comms.length; i++) {
             appendCommitment(self, comms[i]);
@@ -83,13 +83,13 @@ library Transcript {
 
     function appendCommitment(
         TranscriptData memory self,
-        Curve.G1Point memory comm
+        BN254.G1Point memory comm
     ) internal pure {
         bytes memory commBytes = g1Serialize(comm);
         appendMessage(self, commBytes);
     }
 
-    function g1Serialize(Curve.G1Point memory point)
+    function g1Serialize(BN254.G1Point memory point)
         internal
         pure
         returns (bytes memory)
@@ -98,13 +98,13 @@ library Transcript {
 
         // Set the 254-th bit to 1 for infinity
         // https://docs.rs/ark-serialize/0.3.0/src/ark_serialize/flags.rs.html#117
-        if (Curve.isInfinity(point)) {
+        if (BN254.isInfinity(point)) {
             mask |= 0x4000000000000000000000000000000000000000000000000000000000000000;
         }
 
         // Set the 255-th bit to 1 for positive Y
         // https://docs.rs/ark-serialize/0.3.0/src/ark_serialize/flags.rs.html#118
-        if (!Curve.isYNegative(point)) {
+        if (!BN254.isYNegative(point)) {
             mask = 0x8000000000000000000000000000000000000000000000000000000000000000;
         }
 
@@ -141,6 +141,6 @@ library Transcript {
             0,
             48
         );
-        return Curve.fromLeBytesModOrder(randomBytes);
+        return BN254.fromLeBytesModOrder(randomBytes);
     }
 }

--- a/contracts/rust/src/bn254.rs
+++ b/contracts/rust/src/bn254.rs
@@ -22,7 +22,7 @@ async fn deploy_contract() -> Result<TestBN254<SignerMiddleware<Provider<Http>, 
     let client = get_funded_deployer().await.unwrap();
     let contract = deploy(
         client.clone(),
-        Path::new("../artifacts/contracts/TestBN254.sol/TestBN254"),
+        Path::new("../artifacts/contracts/mocks/TestBN254.sol/TestBN254"),
         (),
     )
     .await

--- a/contracts/rust/src/records_merkle_tree/mod.rs
+++ b/contracts/rust/src/records_merkle_tree/mod.rs
@@ -51,7 +51,7 @@ pub(crate) async fn get_contract_records_merkle_tree(
     let client = ethereum::get_funded_deployer().await.unwrap();
     let contract = ethereum::deploy(
         client.clone(),
-        Path::new("../artifacts/contracts/TestRecordsMerkleTree.sol/TestRecordsMerkleTree"),
+        Path::new("../artifacts/contracts/mocks/TestRecordsMerkleTree.sol/TestRecordsMerkleTree"),
         height,
     )
     .await

--- a/contracts/rust/src/transcript.rs
+++ b/contracts/rust/src/transcript.rs
@@ -20,7 +20,7 @@ async fn deploy() -> TestTranscript<SignerMiddleware<Provider<Http>, Wallet<Sign
     let client = ethereum::get_funded_deployer().await.unwrap();
     let contract = ethereum::deploy(
         client.clone(),
-        Path::new("../artifacts/contracts/TestTranscript.sol/TestTranscript"),
+        Path::new("../artifacts/contracts/mocks/TestTranscript.sol/TestTranscript"),
         (),
     )
     .await

--- a/contracts/rust/src/types.rs
+++ b/contracts/rust/src/types.rs
@@ -4,15 +4,15 @@ use ethers::prelude::*;
 
 abigen!(
     TestBN254,
-    "../artifacts/contracts/TestBN254.sol/TestBN254/abi.json",
+    "../artifacts/contracts/mocks/TestBN254.sol/TestBN254/abi.json",
     event_derives(serde::Deserialize, serde::Serialize);
 
     TestRecordsMerkleTree,
-    "../artifacts/contracts/TestRecordsMerkleTree.sol/TestRecordsMerkleTree/abi.json",
+    "../artifacts/contracts/mocks/TestRecordsMerkleTree.sol/TestRecordsMerkleTree/abi.json",
     event_derives(serde::Deserialize, serde::Serialize);
 
     TestTranscript,
-    "../artifacts/contracts/TestTranscript.sol/TestTranscript/abi.json",
+    "../artifacts/contracts/mocks/TestTranscript.sol/TestTranscript/abi.json",
     event_derives(serde::Deserialize, serde::Serialize);
 
     CAPE,
@@ -20,7 +20,7 @@ abigen!(
     event_derives(serde::Deserialize, serde::Serialize);
 
     // TestCAPE,
-    // "../artifacts/contracts/TestCAPE.sol/TestCAPE/abi.json",
+    // "../artifacts/contracts/mocks/TestCAPE.sol/TestCAPE/abi.json",
     // event_derives(serde::Deserialize, serde::Serialize);
 
     Greeter,


### PR DESCRIPTION
Major changes include:
- Rename `library Curve` to `library BN254` (since we will other struct such as `struct EdOnBn254` later)
- put all library to `libraries/`, test mock to `mocks/`, plonk verifier to `verifier/`, and updated import paths in Sol and Rust.
(later I will put interface into `interfaces/` in an upcoming PR)

```
contracts/contracts
├── CAPE.sol
├── Greeter.sol
├── RecordsMerkleTree.sol
├── Rescue.sol
├── RescueNonOptimized.sol
├── SimpleToken.sol
├── interfaces
├── libraries
│   └── BN254.sol
├── mocks
│   ├── TestBN254.sol
│   ├── TestCAPE.sol
│   ├── TestRecordsMerkleTree.sol
│   ├── TestRescue.sol
│   ├── TestRescueNonOptimized.sol
│   └── TestTranscript.sol
└── verifier
    ├── PlonkVerifier.sol
    └── Transcript.sol

4 directories, 15 files
```

folder structure partially inspired by [uniswap](https://github.com/Uniswap/v3-core/tree/main/contracts) and [aave](https://github.com/aave/protocol-v2/tree/master/contracts).