### PR TITLE
hardhat deploy, example of connecting to deployed contract from rust

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
     - [Separate hardhat node](#separate-hardhat-node)
     - [Hardhat node integrated in test command](#hardhat-node-integrated-in-test-command)
   - [Running scripts](#running-scripts)
+  - [Deployment](#deployment)
   - [Precompiled solidity binaries](#precompiled-solidity-binaries)
     - [Details about solidity compiler (solc) management](#details-about-solidity-compiler-solc-management)
   - [Ethereum contracts](#ethereum-contracts)
@@ -212,6 +213,16 @@ It's also possible to run the hardhat node and tests in one command
 Run a script that connects to the local network (on port 8545)
 
     hardhat run scripts/benchmark.js --network localhost
+
+## Deployment
+
+The CAPE contract can be deployed with
+
+    hardhat deploy
+
+The deployments are saved in `contracts/deployments`. If you deploy to localhost
+you have to remove `contracts/deployments/localhost` after you restart the geth
+node in order to re-deploy.
 
 ## Precompiled solidity binaries
 

--- a/contracts/.gitignore
+++ b/contracts/.gitignore
@@ -24,3 +24,5 @@ __pycache__/
 
 # typescript contract bindings
 typechain-types/
+
+deployments/localhost/

--- a/contracts/deploy/00_cape.ts
+++ b/contracts/deploy/00_cape.ts
@@ -1,0 +1,15 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { DeployFunction } from "hardhat-deploy/types";
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployments, getNamedAccounts } = hre;
+  const { deploy } = deployments;
+  const { deployer } = await getNamedAccounts();
+  await deploy("CAPE", {
+    from: deployer,
+    args: [],
+    log: true,
+  });
+};
+export default func;
+func.tags = ["CAPE"];

--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -1,6 +1,7 @@
 import "@nomiclabs/hardhat-ethers";
 import "@nomiclabs/hardhat-waffle";
 import "@typechain/hardhat";
+import "hardhat-deploy";
 import "hardhat-gas-reporter";
 import { TASK_COMPILE_SOLIDITY_GET_SOLC_BUILD } from "hardhat/builtin-tasks/task-names";
 import { HardhatUserConfig, subtask, task } from "hardhat/config";
@@ -36,6 +37,9 @@ subtask(TASK_COMPILE_SOLIDITY_GET_SOLC_BUILD, async (args: any, _hre, runSuper) 
 
 const config: HardhatUserConfig = {
   defaultNetwork: "localhost",
+  namedAccounts: {
+    deployer: 0,
+  },
   networks: {
     hardhat: {
       accounts: {

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -38,6 +38,7 @@
     "ethereum-waffle": "^3.4.0",
     "ethers": "^5.5.1",
     "hardhat": "^2.6.8",
+    "hardhat-deploy": "^0.9.14",
     "hardhat-gas-reporter": "^1.0.4",
     "hardhat-shorthand": "^1.0.0",
     "lodash": "^4.17.21",

--- a/contracts/tsconfig.json
+++ b/contracts/tsconfig.json
@@ -8,6 +8,6 @@
     "outDir": "dist",
     "baseUrl": "."
   },
-  "include": ["./scripts", "./test", "./typechain-types"],
+  "include": ["./scripts", "./test", "./typechain-types", "./deploy"],
   "files": ["./hardhat.config.ts"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,7 @@ importers:
       ethereum-waffle: ^3.4.0
       ethers: ^5.5.1
       hardhat: ^2.6.8
+      hardhat-deploy: ^0.9.14
       hardhat-gas-reporter: ^1.0.4
       hardhat-shorthand: ^1.0.0
       js-big-decimal: ^1.3.4
@@ -63,6 +64,7 @@ importers:
       ethereum-waffle: 3.4.0_typescript@4.4.4
       ethers: 5.5.1
       hardhat: 2.6.8
+      hardhat-deploy: 0.9.14_hardhat@2.6.8
       hardhat-gas-reporter: 1.0.4_87bb44b05626a2d879bb5b9564432f10
       hardhat-shorthand: 1.0.0
       lodash: 4.17.21
@@ -785,6 +787,10 @@ packages:
       - supports-color
     dev: true
 
+  /@metamask/safe-event-emitter/2.0.0:
+    resolution: {integrity: sha512-/kSXhY692qiV1MXu6EeOZvg5nECLclxNXcKCxJ3cXQgYuRymRHpdx/t7JXfsK+JLjwA1e1c1/SBrlQYpusC29Q==}
+    dev: true
+
   /@noble/bls12-381/1.0.1:
     resolution: {integrity: sha512-kZbZMEvXiosdAWTdfMUBRK8Gbk9jz6b7Psv1ciGfdxZ8yG9tMef+jgyCpdT/FdgI4e+e7KnE5QtrfjZmeIZA6Q==}
     dev: false
@@ -1060,93 +1066,17 @@ packages:
     dev: true
     optional: true
 
-  /@truffle/hdwallet-provider/1.7.0:
-    resolution: {integrity: sha512-nT7BPJJ2jPCLJc5uZdVtRnRMny5he5d3kO9Hi80ZSqe5xlnK905grBptM/+CwOfbeqHKQirI1btwm6r3wIBM8A==}
+  /@truffle/hdwallet-provider/2.0.0:
+    resolution: {integrity: sha512-jquMJCMeHYhvPyZiIhLSWGzGkGK7Xswbw9kcti3USPIMP/AhVNVPe8E0fPurBLUb/Wvl6VW/6Z514JsmzC/IQA==}
     dependencies:
       '@ethereumjs/common': 2.6.0
       '@ethereumjs/tx': 3.4.0
-      '@trufflesuite/web3-provider-engine': 15.0.14
       eth-sig-util: 3.0.1
       ethereum-cryptography: 0.1.3
       ethereum-protocol: 1.0.1
       ethereumjs-util: 6.2.1
       ethereumjs-wallet: 1.0.2
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
-    dev: true
-
-  /@trufflesuite/eth-json-rpc-filters/4.1.2-1:
-    resolution: {integrity: sha512-/MChvC5dw2ck9NU1cZmdovCz2VKbOeIyR4tcxDvA5sT+NaL0rA2/R5U0yI7zsbo1zD+pgqav77rQHTzpUdDNJQ==}
-    dependencies:
-      '@trufflesuite/eth-json-rpc-middleware': 4.4.2-1
-      await-semaphore: 0.1.3
-      eth-query: 2.1.2
-      json-rpc-engine: 5.4.0
-      lodash.flatmap: 4.5.0
-      safe-event-emitter: 1.0.1
-    dev: true
-
-  /@trufflesuite/eth-json-rpc-infura/4.0.3-0:
-    resolution: {integrity: sha512-xaUanOmo0YLqRsL0SfXpFienhdw5bpQ1WEXxMTRi57az4lwpZBv4tFUDvcerdwJrxX9wQqNmgUgd1BrR01dumw==}
-    dependencies:
-      '@trufflesuite/eth-json-rpc-middleware': 4.4.2-1
-      cross-fetch: 2.2.5
-      eth-json-rpc-errors: 1.1.1
-      json-rpc-engine: 5.4.0
-    dev: true
-
-  /@trufflesuite/eth-json-rpc-middleware/4.4.2-1:
-    resolution: {integrity: sha512-iEy9H8ja7/8aYES5HfrepGBKU9n/Y4OabBJEklVd/zIBlhCCBAWBqkIZgXt11nBXO/rYAeKwYuE3puH3ByYnLA==}
-    dependencies:
-      '@trufflesuite/eth-sig-util': 1.4.2
-      btoa: 1.2.1
-      clone: 2.1.2
-      eth-json-rpc-errors: 1.1.1
-      eth-query: 2.1.2
-      ethereumjs-block: 1.7.1
-      ethereumjs-tx: 1.3.7
-      ethereumjs-util: 5.2.1
-      ethereumjs-vm: 2.6.0
-      fetch-ponyfill: 4.1.0
-      json-rpc-engine: 5.4.0
-      json-stable-stringify: 1.0.1
-      pify: 3.0.0
-      safe-event-emitter: 1.0.1
-    dev: true
-
-  /@trufflesuite/eth-sig-util/1.4.2:
-    resolution: {integrity: sha512-+GyfN6b0LNW77hbQlH3ufZ/1eCON7mMrGym6tdYf7xiNw9Vv3jBO72bmmos1EId2NgBvPMhmYYm6DSLQFTmzrA==}
-    dependencies:
-      ethereumjs-abi: 0.6.8
-      ethereumjs-util: 5.2.1
-    dev: true
-
-  /@trufflesuite/web3-provider-engine/15.0.14:
-    resolution: {integrity: sha512-6/LoWvNMxYf0oaYzJldK2a9AdnkAdIeJhHW4nuUBAeO29eK9xezEaEYQ0ph1QRTaICxGxvn+1Azp4u8bQ8NEZw==}
-    dependencies:
-      '@ethereumjs/tx': 3.4.0
-      '@trufflesuite/eth-json-rpc-filters': 4.1.2-1
-      '@trufflesuite/eth-json-rpc-infura': 4.0.3-0
-      '@trufflesuite/eth-json-rpc-middleware': 4.4.2-1
-      '@trufflesuite/eth-sig-util': 1.4.2
-      async: 2.6.2
-      backoff: 2.5.0
-      clone: 2.1.2
-      cross-fetch: 2.2.5
-      eth-block-tracker: 4.4.3
-      eth-json-rpc-errors: 2.0.2
-      ethereumjs-block: 1.7.1
-      ethereumjs-util: 5.2.1
-      ethereumjs-vm: 2.6.0
-      json-stable-stringify: 1.0.1
-      promise-to-callback: 1.0.0
-      readable-stream: 2.3.7
-      request: 2.88.2
-      semaphore: 1.1.0
-      ws: 5.2.3
-      xhr: 2.6.0
-      xtend: 4.0.2
+      web3-provider-engine: 16.0.3
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -1674,6 +1604,12 @@ packages:
     resolution: {integrity: sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==}
     dev: true
 
+  /async-mutex/0.2.6:
+    resolution: {integrity: sha512-Hs4R+4SPgamu6rSGW8C7cV9gaWUKEHykfzCCvIRuaVv636Ju10ZdeUbvb4TBEW0INuq2DHZqXbK4Nd3yG4RaRw==}
+    dependencies:
+      tslib: 2.3.1
+    dev: true
+
   /async/1.5.2:
     resolution: {integrity: sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=}
     dev: true
@@ -1703,16 +1639,20 @@ packages:
     hasBin: true
     dev: true
 
-  /await-semaphore/0.1.3:
-    resolution: {integrity: sha512-d1W2aNSYcz/sxYO4pMGX9vq65qOTu0P800epMud+6cYYX0QcT7zyqcxec3VWzpgvdXo57UWmVbZpLMjX2m1I7Q==}
-    dev: true
-
   /aws-sign2/0.7.0:
     resolution: {integrity: sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=}
     dev: true
 
   /aws4/1.11.0:
     resolution: {integrity: sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==}
+    dev: true
+
+  /axios/0.21.4_debug@4.3.2:
+    resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
+    dependencies:
+      follow-redirects: 1.14.5
+    transitivePeerDependencies:
+      - debug
     dev: true
 
   /babel-code-frame/6.26.0:
@@ -3359,6 +3299,10 @@ packages:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
     dev: true
 
+  /encode-utf8/1.0.3:
+    resolution: {integrity: sha512-ucAnuBEhUK4boH2HjVYG5Q2mQyPorvv0u/ocS+zhdw0S8AlHYY+GOFhP1Gio5z4icpP2ivFSvhtFjQi8+T9ppw==}
+    dev: true
+
   /encodeurl/1.0.2:
     resolution: {integrity: sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=}
     engines: {node: '>= 0.8'}
@@ -3672,18 +3616,15 @@ packages:
       sync-request: 6.1.0
     dev: true
 
-  /eth-json-rpc-errors/1.1.1:
-    resolution: {integrity: sha512-WT5shJ5KfNqHi9jOZD+ID8I1kuYWNrigtZat7GOQkvwo99f8SzAVaEcWhJUv656WiZOAg3P1RiJQANtUmDmbIg==}
-    deprecated: 'Package renamed: https://www.npmjs.com/package/eth-rpc-errors'
+  /eth-json-rpc-filters/4.2.2:
+    resolution: {integrity: sha512-DGtqpLU7bBg63wPMWg1sCpkKCf57dJ+hj/k3zF26anXMzkmtSBDExL8IhUu7LUd34f0Zsce3PYNO2vV2GaTzaw==}
     dependencies:
-      fast-safe-stringify: 2.1.1
-    dev: true
-
-  /eth-json-rpc-errors/2.0.2:
-    resolution: {integrity: sha512-uBCRM2w2ewusRHGxN8JhcuOb2RN3ueAOYH/0BhqdFmQkZx5lj5+fLKTz0mIVOzd4FG5/kUksCzCD7eTEim6gaA==}
-    deprecated: 'Package renamed: https://www.npmjs.com/package/eth-rpc-errors'
-    dependencies:
-      fast-safe-stringify: 2.1.1
+      '@metamask/safe-event-emitter': 2.0.0
+      async-mutex: 0.2.6
+      eth-json-rpc-middleware: 6.0.0
+      eth-query: 2.1.2
+      json-rpc-engine: 6.1.0
+      pify: 5.0.0
     dev: true
 
   /eth-json-rpc-infura/3.2.1:
@@ -3693,6 +3634,15 @@ packages:
       eth-json-rpc-middleware: 1.6.0
       json-rpc-engine: 3.8.0
       json-rpc-error: 2.0.0
+    dev: true
+
+  /eth-json-rpc-infura/5.1.0:
+    resolution: {integrity: sha512-THzLye3PHUSGn1EXMhg6WTLW9uim7LQZKeKaeYsS9+wOBcamRiCQVGHa6D2/4P0oS0vSaxsBnU/J6qvn0MPdow==}
+    dependencies:
+      eth-json-rpc-middleware: 6.0.0
+      eth-rpc-errors: 3.0.0
+      json-rpc-engine: 5.4.0
+      node-fetch: 2.6.6
     dev: true
 
   /eth-json-rpc-middleware/1.6.0:
@@ -3711,6 +3661,22 @@ packages:
       json-stable-stringify: 1.0.1
       promise-to-callback: 1.0.0
       tape: 4.14.0
+    dev: true
+
+  /eth-json-rpc-middleware/6.0.0:
+    resolution: {integrity: sha512-qqBfLU2Uq1Ou15Wox1s+NX05S9OcAEL4JZ04VZox2NS0U+RtCMjSxzXhLFWekdShUPZ+P8ax3zCO2xcPrp6XJQ==}
+    dependencies:
+      btoa: 1.2.1
+      clone: 2.1.2
+      eth-query: 2.1.2
+      eth-rpc-errors: 3.0.0
+      eth-sig-util: 1.4.2
+      ethereumjs-util: 5.2.1
+      json-rpc-engine: 5.4.0
+      json-stable-stringify: 1.0.1
+      node-fetch: 2.6.6
+      pify: 3.0.0
+      safe-event-emitter: 1.0.1
     dev: true
 
   /eth-lib/0.1.29:
@@ -3743,6 +3709,12 @@ packages:
 
   /eth-rpc-errors/3.0.0:
     resolution: {integrity: sha512-iPPNHPrLwUlR9xCSYm7HHQjWBasor3+KZfRvwEWxMz3ca0yqnlBeJrnyphkGIXZ4J7AMAaOLmwy4AWhnxOiLxg==}
+    dependencies:
+      fast-safe-stringify: 2.1.1
+    dev: true
+
+  /eth-rpc-errors/4.0.3:
+    resolution: {integrity: sha512-Z3ymjopaoft7JDoxZcEb3pwdGh7yiYMhOwm2doUt6ASXlMavpNlK6Cre0+IMl2VSGyEU9rkiperQhp5iRxn5Pg==}
     dependencies:
       fast-safe-stringify: 2.1.1
     dev: true
@@ -4457,6 +4429,12 @@ packages:
     resolution: {integrity: sha1-SiksW8/4s5+mzAyxqFPYbyfu/3s=}
     dev: true
 
+  /fmix/0.1.0:
+    resolution: {integrity: sha1-x7vxJN7ELJ0ZHPuUfQqXeN2YbAw=}
+    dependencies:
+      imul: 1.0.1
+    dev: true
+
   /follow-redirects/1.14.5:
     resolution: {integrity: sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA==}
     engines: {node: '>=4.0'}
@@ -4509,6 +4487,15 @@ packages:
       mime-types: 2.1.34
     dev: true
 
+  /form-data/4.0.0:
+    resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
+    engines: {node: '>= 6'}
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      mime-types: 2.1.34
+    dev: true
+
   /forwarded/0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
@@ -4540,6 +4527,15 @@ packages:
       klaw: 1.3.1
       path-is-absolute: 1.0.1
       rimraf: 2.7.1
+    dev: true
+
+  /fs-extra/10.0.0:
+    resolution: {integrity: sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      graceful-fs: 4.2.8
+      jsonfile: 6.1.0
+      universalify: 2.0.0
     dev: true
 
   /fs-extra/4.0.3:
@@ -4882,6 +4878,41 @@ packages:
     dependencies:
       ajv: 6.12.6
       har-schema: 2.0.0
+    dev: true
+
+  /hardhat-deploy/0.9.14_hardhat@2.6.8:
+    resolution: {integrity: sha512-mCwXeXdqtrQN8dL1gOnoGUh0z9Jylfsh56UNVZJC0c8AhjlwjLPgGE3pzNmMuyy88pj9OX4qo53X57bW2W7NJQ==}
+    peerDependencies:
+      '@ethersproject/hardware-wallets': ^5.0.14
+      hardhat: ^2.0.0
+    dependencies:
+      '@ethersproject/abi': 5.5.0
+      '@ethersproject/abstract-signer': 5.5.0
+      '@ethersproject/address': 5.5.0
+      '@ethersproject/bignumber': 5.5.0
+      '@ethersproject/bytes': 5.5.0
+      '@ethersproject/constants': 5.5.0
+      '@ethersproject/contracts': 5.5.0
+      '@ethersproject/providers': 5.5.0
+      '@ethersproject/solidity': 5.5.0
+      '@ethersproject/transactions': 5.5.0
+      '@ethersproject/wallet': 5.5.0
+      '@types/qs': 6.9.7
+      axios: 0.21.4_debug@4.3.2
+      chalk: 4.1.2
+      chokidar: 3.5.2
+      debug: 4.3.2
+      enquirer: 2.3.6
+      form-data: 4.0.0
+      fs-extra: 10.0.0
+      hardhat: 2.6.8
+      match-all: 1.2.6
+      murmur-128: 0.2.1
+      qs: 6.10.1
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
     dev: true
 
   /hardhat-gas-reporter/1.0.4_87bb44b05626a2d879bb5b9564432f10:
@@ -5234,6 +5265,11 @@ packages:
     dependencies:
       parent-module: 1.0.1
       resolve-from: 4.0.0
+    dev: true
+
+  /imul/1.0.1:
+    resolution: {integrity: sha1-nVhnFh6LPelsLDjV3HyxAvNeKsk=}
+    engines: {node: '>=0.10.0'}
     dev: true
 
   /imurmurhash/0.1.4:
@@ -5731,6 +5767,14 @@ packages:
       safe-event-emitter: 1.0.1
     dev: true
 
+  /json-rpc-engine/6.1.0:
+    resolution: {integrity: sha512-NEdLrtrq1jUZyfjkr9OCz9EzCNhnRyWtt1PAnvnhwy6e8XETS0Dtc+ZNCO2gvuAoKsIn2+vCSowXTYE4CkgnAQ==}
+    engines: {node: '>=10.0.0'}
+    dependencies:
+      '@metamask/safe-event-emitter': 2.0.0
+      eth-rpc-errors: 4.0.3
+    dev: true
+
   /json-rpc-error/2.0.0:
     resolution: {integrity: sha1-p6+cICg4tekFxyUOVH8a/3cligI=}
     dependencies:
@@ -6106,10 +6150,6 @@ packages:
     resolution: {integrity: sha1-gteb/zCmfEAF/9XiUVMArZyk168=}
     dev: true
 
-  /lodash.flatmap/4.5.0:
-    resolution: {integrity: sha1-74y/QI9uSCaGYzRTBcaswLd4cC4=}
-    dev: true
-
   /lodash/4.17.20:
     resolution: {integrity: sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==}
     dev: true
@@ -6221,6 +6261,10 @@ packages:
     resolution: {integrity: sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==}
     engines: {node: '>=0.10.0'}
     hasBin: true
+    dev: true
+
+  /match-all/1.2.6:
+    resolution: {integrity: sha512-0EESkXiTkWzrQQntBu2uzKvLu6vVkUGz40nGPbSZuegcfE5UuSzNjLaIu76zJWuaT/2I3Z/8M06OlUOZLGwLlQ==}
     dev: true
 
   /mcl-wasm/0.7.9:
@@ -6570,6 +6614,14 @@ packages:
       varint: 5.0.2
     dev: true
     optional: true
+
+  /murmur-128/0.2.1:
+    resolution: {integrity: sha512-WseEgiRkI6aMFBbj8Cg9yBj/y+OdipwVC7zUo3W2W1JAJITwouUOtpqsmGSg67EQmwwSyod7hsVsWY5LsrfQVg==}
+    dependencies:
+      encode-utf8: 1.0.3
+      fmix: 0.1.0
+      imul: 1.0.1
+    dev: true
 
   /mute-stream/0.0.7:
     resolution: {integrity: sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=}
@@ -7102,6 +7154,11 @@ packages:
   /pify/3.0.0:
     resolution: {integrity: sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=}
     engines: {node: '>=4'}
+    dev: true
+
+  /pify/5.0.0:
+    resolution: {integrity: sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA==}
+    engines: {node: '>=10'}
     dev: true
 
   /pinkie-promise/2.0.1:
@@ -8127,7 +8184,7 @@ packages:
   /solidity-bytes-utils/0.8.0:
     resolution: {integrity: sha512-r109ZHEf7zTMm1ENW6/IJFDWilFR/v0BZnGuFgDHJUV80ByobnV2k3txvwQaJ9ApL+6XAfwqsw5VFzjALbQPCw==}
     dependencies:
-      '@truffle/hdwallet-provider': 1.7.0
+      '@truffle/hdwallet-provider': 2.0.0
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -9319,6 +9376,37 @@ packages:
       ws: 5.2.3
       xhr: 2.6.0
       xtend: 4.0.2
+    dev: true
+
+  /web3-provider-engine/16.0.3:
+    resolution: {integrity: sha512-Q3bKhGqLfMTdLvkd4TtkGYJHcoVQ82D1l8jTIwwuJp/sAp7VHnRYb9YJ14SW/69VMWoOhSpPLZV2tWb9V0WJoA==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      '@ethereumjs/tx': 3.4.0
+      async: 2.6.2
+      backoff: 2.5.0
+      clone: 2.1.2
+      cross-fetch: 2.2.5
+      eth-block-tracker: 4.4.3
+      eth-json-rpc-filters: 4.2.2
+      eth-json-rpc-infura: 5.1.0
+      eth-json-rpc-middleware: 6.0.0
+      eth-rpc-errors: 3.0.0
+      eth-sig-util: 1.4.2
+      ethereumjs-block: 1.7.1
+      ethereumjs-util: 5.2.1
+      ethereumjs-vm: 2.6.0
+      json-stable-stringify: 1.0.1
+      promise-to-callback: 1.0.0
+      readable-stream: 2.3.7
+      request: 2.88.2
+      semaphore: 1.1.0
+      ws: 5.2.3
+      xhr: 2.6.0
+      xtend: 4.0.2
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
     dev: true
 
   /web3-providers-http/1.2.11:


### PR DESCRIPTION
Enables to deploy the cape contract and adds an example of connecting to a deployed contract from within rust tests.

Deployments are saved to `contracts/deployments/`.

TODO 

- Read env var from deployment artifact.
- gitignore new artifacts (maybe just the dev chain deployments, the real deployments could be checked in)
- Create a function to "deploy or connect".