### PR TITLE
Solidity derive record commitment

### DIFF
--- a/contracts/contracts/RecordsMerkleTree.sol
+++ b/contracts/contracts/RecordsMerkleTree.sol
@@ -2,9 +2,9 @@
 pragma solidity ^0.8.0;
 
 import "hardhat/console.sol";
-import "./Rescue.sol";
+import "./libraries/RescueLib.sol";
 
-contract RecordsMerkleTree is Rescue {
+contract RecordsMerkleTree {
     enum Position {
         LEFT,
         MIDDLE,
@@ -249,7 +249,7 @@ contract RecordsMerkleTree is Rescue {
         // Remember position is computed with the remainder
 
         // Leaf node where the value is hash(0,_numLeaves,element)
-        uint256 val = hash(0, _numLeaves, element);
+        uint256 val = RescueLib.hash(0, _numLeaves, element);
         nodes[newNodeIndex] = Node(val, 0, 0, 0);
         _updateChildNode(
             nodes[previousNodeIndex],
@@ -360,7 +360,7 @@ contract RecordsMerkleTree is Rescue {
             nodes[rootNode.middle].val = valMiddle;
             nodes[rootNode.right].val = valRight;
 
-            return hash(valLeft, valMiddle, valRight);
+            return RescueLib.hash(valLeft, valMiddle, valRight);
         }
     }
 }

--- a/contracts/contracts/RescueNonOptimized.sol
+++ b/contracts/contracts/RescueNonOptimized.sol
@@ -234,10 +234,10 @@ contract RescueNonOptimized {
         return newState;
     }
 
-    // Computes the Rescue _permutation on some input
+    // Computes the Rescue permutation on some input
     // Recall that the scheduled key is precomputed in our case
-    // @param input input for the _permutation
-    // @return _permutation output
+    // @param input input for the permutation
+    // @return permutation output
     function _perm(
         uint256[_STATE_SIZE] memory input // TODO this should be made private/internal
     ) internal view returns (uint256[_STATE_SIZE] memory) {

--- a/contracts/contracts/libraries/RescueLib.sol
+++ b/contracts/contracts/libraries/RescueLib.sol
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import "hardhat/console.sol";
-
-contract Rescue {
+library RescueLib {
     /// The constants are obtained from the Sage script
     /// https://gitlab.com/translucence/crypto/marvellous/-/blob/b0885058f0348171befcf6cf30533812c9f49e15/rescue254.sage
 
@@ -151,13 +149,13 @@ contract Rescue {
     // Recall that the scheduled key is precomputed in our case
     // @param input input for the permutation
     // @return permutation output
-    function _perm(
+    function perm(
         uint256 s0,
         uint256 s1,
         uint256 s2,
         uint256 s3
     )
-        private
+        internal
         view
         returns (
             uint256,
@@ -759,8 +757,26 @@ contract Rescue {
         uint256 a,
         uint256 b,
         uint256 c
-    ) public returns (uint256 o) {
-        (o, a, b, c) = _perm(a % _PRIME, b % _PRIME, c % _PRIME, 0);
+    ) internal view returns (uint256 o) {
+        (o, a, b, c) = perm(a % _PRIME, b % _PRIME, c % _PRIME, 0);
         o %= _PRIME;
+    }
+
+    function commit(uint256[15] memory inputs) internal view returns (uint256) {
+        uint256 a;
+        uint256 b;
+        uint256 c;
+        uint256 d;
+
+        for (uint256 i = 0; i < 5; i++) {
+            (a, b, c, d) = perm(
+                (a + inputs[3 * i + 0]) % _PRIME,
+                (b + inputs[3 * i + 1]) % _PRIME,
+                (c + inputs[3 * i + 2]) % _PRIME,
+                d % _PRIME
+            );
+        }
+
+        return a % _PRIME;
     }
 }

--- a/contracts/contracts/mocks/TestCAPE.sol
+++ b/contracts/contracts/mocks/TestCAPE.sol
@@ -8,21 +8,32 @@ contract TestCAPE is CAPE {
         return _insertNullifier(nullifier);
     }
 
-    function checkBurn(bytes memory extraProofBoundData) public {
-        return _checkBurn(extraProofBoundData);
+    function checkBurn(BurnNote memory note) public {
+        return _checkBurn(note);
     }
 
-    function hasBurnPrefix(bytes memory extraProofBoundData)
+    function containsBurnPrefix(bytes memory extraProofBoundData)
         public
         returns (bool)
     {
-        return _hasBurnPrefix(extraProofBoundData);
+        return _containsBurnPrefix(extraProofBoundData);
     }
 
-    function hasBurnDestination(bytes memory extraProofBoundData)
+    function containsBurnDestination(bytes memory extraProofBoundData)
         public
         returns (bool)
     {
-        return _hasBurnDestination(extraProofBoundData);
+        return _containsBurnDestination(extraProofBoundData);
+    }
+
+    function containsBurnRecord(BurnNote memory note) public returns (bool) {
+        return _containsBurnRecord(note);
+    }
+
+    function deriveRecordCommitment(RecordOpening memory ro)
+        public
+        returns (uint256)
+    {
+        return _deriveRecordCommitment(ro);
     }
 }

--- a/contracts/contracts/mocks/TestRecordsMerkleTree.sol
+++ b/contracts/contracts/mocks/TestRecordsMerkleTree.sol
@@ -2,8 +2,8 @@
 pragma solidity ^0.8.0;
 
 import "hardhat/console.sol";
-import "../Rescue.sol";
 import "../RecordsMerkleTree.sol";
+import "../libraries/RescueLib.sol";
 
 contract TestRecordsMerkleTree is RecordsMerkleTree {
     constructor(uint8 height) RecordsMerkleTree(height) {}

--- a/contracts/contracts/mocks/TestRescue.sol
+++ b/contracts/contracts/mocks/TestRescue.sol
@@ -2,8 +2,16 @@
 pragma solidity ^0.8.0;
 
 import "hardhat/console.sol";
-import "../Rescue.sol";
+import "../libraries/RescueLib.sol";
 
-contract TestRescue is Rescue {
+contract TestRescue {
     function doNothing() public {}
+
+    function hash(
+        uint256 a,
+        uint256 b,
+        uint256 c
+    ) public returns (uint256) {
+        return RescueLib.hash(a, b, c);
+    }
 }

--- a/contracts/test/benchmarks/test-records-merkle-tree.js
+++ b/contracts/test/benchmarks/test-records-merkle-tree.js
@@ -34,7 +34,7 @@ describe("Records Merkle Tree Benchmarks", function () {
       let doNothingGasUsed = doNothingTxReceipt.gasUsed;
 
       // Total gas used to insert all the records, read from and store into the frontier
-      expect(totalGasUsed).to.be.equal(2772946);
+      expect(totalGasUsed).to.be.equal(2772947);
 
       // Gas used just to handle the frontier (no records inserted)
       expect(emptyGasUsed).to.be.equal(159189);
@@ -45,11 +45,11 @@ describe("Records Merkle Tree Benchmarks", function () {
 
       // Gas used to handle the frontier and insert records but without "base" cost
       let updateRecordsMerkleTreeWithoutBaseCost = totalGasUsed - doNothingGasUsed;
-      expect(updateRecordsMerkleTreeWithoutBaseCost).to.be.equal(2751784);
+      expect(updateRecordsMerkleTreeWithoutBaseCost).to.be.equal(2751785);
 
       // Gas used to insert the records
       let insertRecordsGasUsed = totalGasUsed - emptyGasUsed;
-      expect(insertRecordsGasUsed).to.be.equal(2613757);
+      expect(insertRecordsGasUsed).to.be.equal(2613758);
     });
   });
 });

--- a/contracts/test/benchmarks/test-rescue.js
+++ b/contracts/test/benchmarks/test-rescue.js
@@ -4,7 +4,7 @@ const { ethers } = require("hardhat");
 describe("Rescue benchmarks", function () {
   describe("Gas spent for computing the Rescue function", function () {
     for (const [contractName, gas] of [
-      ["TestRescue", 87164],
+      ["TestRescue", 87214],
       ["TestRescueNonOptimized", 620060],
     ]) {
       it(`checks gas usage of ${contractName}.hash`, async function () {


### PR DESCRIPTION
- ~Likely to change a bit once types are done.~
- [x] Should we have the reveal map as uint256 instead of boolean array in the contract? (edit: on second thought, maybe the boolean array is more convenient for inspecting, edit2: the conversion from boolean array to U256 is now done in solidity so this isn't urgent)
- [x] Calls to rescue sponge function.
- ~Needs public `RecordOpening::derive_record_commitment` for test.~ (edit: use `From` trait)
- [x] Pass tests.
- [ ] A test where a valid burn note is checked.

Closes #63