### PR TITLE
Reverted tx matcher: show strings when matching fails

### DIFF
--- a/contracts/rust/src/bn254.rs
+++ b/contracts/rust/src/bn254.rs
@@ -161,11 +161,11 @@ async fn test_validate_g1_point() -> Result<()> {
         contract: &TestBN254<SignerMiddleware<Provider<Http>, Wallet<SigningKey>>>,
         bad_p: G1Point,
     ) {
-        assert!(contract
+        contract
             .validate_g1_point(bad_p)
             .call()
             .await
-            .should_revert_with_message("Bn254: invalid G1 point"));
+            .should_revert_with_message("Bn254: invalid G1 point");
     }
 
     // x = 0 should fail

--- a/contracts/rust/src/cape.rs
+++ b/contracts/rust/src/cape.rs
@@ -525,7 +525,7 @@ mod tests {
         note.transfer_note.aux_info.extra_proof_bound_data = extra.into();
 
         let call = contract.check_burn(note).call().await;
-        assert!(call.should_revert_with_message("Bad burn tag"));
+        call.should_revert_with_message("Bad burn tag");
     }
 
     #[tokio::test]
@@ -540,7 +540,7 @@ mod tests {
         note.transfer_note.aux_info.extra_proof_bound_data = extra.into();
 
         let call = contract.check_burn(note).call().await;
-        assert!(call.should_revert_with_message("Bad burn destination"));
+        call.should_revert_with_message("Bad burn destination");
     }
 
     #[tokio::test]
@@ -558,7 +558,7 @@ mod tests {
         note.transfer_note.output_commitments.push(U256::from(2));
 
         let call = contract.check_burn(note).call().await;
-        assert!(call.should_revert_with_message("Bad record commitment"));
+        call.should_revert_with_message("Bad record commitment");
     }
 
     // TODO Add test for check_burn that passes
@@ -623,7 +623,7 @@ mod tests {
         note.aux_info.extra_proof_bound_data = extra.into();
 
         let call = contract.check_transfer(note).call().await;
-        assert!(call.should_revert_with_message("Burn prefix in transfer note"));
+        call.should_revert_with_message("Burn prefix in transfer note");
     }
 
     #[tokio::test]
@@ -666,11 +666,11 @@ mod tests {
         let mut ro = sol::RecordOpening::default();
         ro.asset_def.policy.reveal_map = U256::from(2).pow(12.into());
 
-        assert!(contract
+        contract
             .derive_record_commitment(ro)
             .call()
             .await
-            .should_revert_with_message("Reveal map exceeds 12 bits"))
+            .should_revert_with_message("Reveal map exceeds 12 bits")
     }
 
     #[tokio::test]

--- a/contracts/rust/src/root_store.rs
+++ b/contracts/rust/src/root_store.rs
@@ -23,11 +23,11 @@ async fn test_root_store() -> Result<()> {
     assert!(!contract.contains_root(roots[0]).call().await?);
 
     // check reverts if root not found
-    assert!(contract
+    contract
         .check_contains_root(roots[0])
         .call()
         .await
-        .should_revert_with_message("Root not found"));
+        .should_revert_with_message("Root not found");
 
     contract.add_root(roots[0]).send().await?.await?;
 


### PR DESCRIPTION
The idea is to make it a bit easier to know why the tests fail. 

If we reduce it to a boolean value then we lose some information that can be very useful for figuring out how the tests failed.