### PR TITLE
Check transfer note does not have burn prefix

### DIFF
--- a/contracts/contracts/CAPE.sol
+++ b/contracts/contracts/CAPE.sol
@@ -252,6 +252,7 @@ contract CAPE {
             if (noteType == NoteType.TRANSFER) {
                 TransferNote memory note = newBlock.transferNotes[transferIdx];
                 _checkMerkleRootContained(note.auxInfo.merkleRoot);
+                _checkTransfer(note);
                 if (_publish(note.inputNullifiers)) {
                     // TODO collect note.outputCommitments
                     // TODO extract proof for batch verification
@@ -307,6 +308,14 @@ contract CAPE {
         internal
     {
         // TODO
+    }
+
+    function _checkTransfer(TransferNote memory note) internal pure {
+        // TODO consider moving _checkMerkleRootContained into _check[NoteType] functions
+        require(
+            !_containsBurnPrefix(note.auxInfo.extraProofBoundData),
+            "Burn prefix in transfer note"
+        );
     }
 
     function _checkBurn(BurnNote memory note) internal view {

--- a/contracts/contracts/mocks/TestCAPE.sol
+++ b/contracts/contracts/mocks/TestCAPE.sol
@@ -8,12 +8,17 @@ contract TestCAPE is CAPE {
         return _insertNullifier(nullifier);
     }
 
-    function checkBurn(BurnNote memory note) public {
+    function checkTransfer(TransferNote memory note) public view {
+        return _checkTransfer(note);
+    }
+
+    function checkBurn(BurnNote memory note) public view {
         return _checkBurn(note);
     }
 
     function containsBurnPrefix(bytes memory extraProofBoundData)
         public
+        view
         returns (bool)
     {
         return _containsBurnPrefix(extraProofBoundData);
@@ -21,17 +26,23 @@ contract TestCAPE is CAPE {
 
     function containsBurnDestination(bytes memory extraProofBoundData)
         public
+        view
         returns (bool)
     {
         return _containsBurnDestination(extraProofBoundData);
     }
 
-    function containsBurnRecord(BurnNote memory note) public returns (bool) {
+    function containsBurnRecord(BurnNote memory note)
+        public
+        view
+        returns (bool)
+    {
         return _containsBurnRecord(note);
     }
 
     function deriveRecordCommitment(RecordOpening memory ro)
         public
+        view
         returns (uint256)
     {
         return _deriveRecordCommitment(ro);

--- a/contracts/rust/src/cape.rs
+++ b/contracts/rust/src/cape.rs
@@ -451,6 +451,31 @@ mod tests {
     // main block validaton loop.
 
     #[tokio::test]
+    async fn test_check_transfer_note_with_burn_prefix_rejected() {
+        let contract = deploy_cape_test().await;
+        let mut note = sol::TransferNote::default();
+        let extra = [
+            DOM_SEP_CAPE_BURN.to_vec(),
+            hex::decode("0000000000000000000000000000000000000000").unwrap(),
+        ]
+        .concat();
+        note.aux_info.extra_proof_bound_data = extra.into();
+
+        let call = contract.check_transfer(note).call().await;
+        assert!(call.should_revert_with_message("Burn prefix in transfer note"));
+    }
+
+    #[tokio::test]
+    async fn test_check_transfer_without_burn_prefix_accepted() {
+        let contract = deploy_cape_test().await;
+        let note = sol::TransferNote::default();
+        assert!(contract.check_transfer(note).call().await.is_ok());
+    }
+
+    // TODO integration test to check if check_transfer is hooked up correctly in
+    // main block validaton loop.
+
+    #[tokio::test]
     async fn test_derive_record_commitment() {
         let contract = deploy_cape_test().await;
         let mut rng = ark_std::test_rng();


### PR DESCRIPTION
Added an extra function even though it is very small. I think it makes
the main validation loop more readable to not litter it with require
statemens. We can add all the checks (for merkle root and anything else
we would like to add) into the _check[NoteType] functions.

Close #137.