### PR TITLE
Cache cargo dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,8 @@ jobs:
       - name: Install Tools
         run: |
           apk add git
+          # alpine tar is not compatible: https://stackoverflow.com/a/64187955
+          apk add --no-cache tar
 
       - uses: actions/checkout@v2
         name: Checkout Repository
@@ -35,6 +37,17 @@ jobs:
           git config --global url."https://ancient123:${{ secrets.ORG_GITHUB_PAT }}@github.com".insteadOf git://github.com
           git config --global url."https://ancient123:${{ secrets.ORG_GITHUB_PAT }}@github.com".insteadOf ssh://git@github.com
           git config --global url."https://dl.cloudsmith.io/${{ secrets.CLOUDSMITH_ENTITLEMENT }}/".insteadOf https://dl.cloudsmith.io/basic/
+
+      - name: Cache cargo
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git
+            target
+          # todo: add nix key, for example:  nix-instantiate shell.nix | sha256sum  | head -c 10
+          key: cape-v3-${{ hashFiles('Cargo.lock') }}
 
       - name: Linting
         run: nix-shell --run "prepend-timestamps lint-ci"


### PR DESCRIPTION
To review please refer to the total diff. I left the remaining commits as illustrations if anyone is curious.

- The build time is reduced from about 5 min to 2.5 min if `Cargo.lock` is unchanged.
- The action https://github.com/Swatinem/rust-cache doesn't seem to play nicely with nix because there is no `rustc` in our environment.
- Caching with `actions/cache@v2` works. It uses about 1.5GB for the cache and the maximum total cache for repo is 10GB. It will [evict old caches](https://docs.github.com/en/actions/advanced-guides/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy) if we save more. 
- At the moment we also re-use the cache if we update our `shell.nix`. Is that a problem that we need to address right away?
- We currently use the `release` profile for tests but cargo clippy uses `debug`. This increases the uncompressed size of the cache from about 2.5GB to 5GB. I couldn't figure out how to make `cargo-clippy` use the `release` profile. It works for `cargo clippy` on the CI, but that in turn doesn't work for some uf us on local machines:
```
└─○ cargo clippy --release --workspace -- -D warnings
error: failed to parse lock file at: /Users/alex/work/cape/Cargo.lock
Caused by:
package `ethers` is specified twice in the lockfile
```