### PR TITLE
Deploy contract with linked RescueLib 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -561,6 +561,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-recursion"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cda8f4bcc10624c4e85bc66b3f452cca98cfa5ca002dc83a16aad2367641bea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-scoped"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1088,6 +1099,7 @@ dependencies = [
  "ark-poly-commit",
  "ark-serialize",
  "ark-std",
+ "async-recursion",
  "async-std",
  "async-trait",
  "bincode",

--- a/README.md
+++ b/README.md
@@ -220,8 +220,15 @@ The CAPE contract can be deployed with
     hardhat deploy
 
 The deployments are saved in `contracts/deployments`. If you deploy to localhost
-you have to remove `contracts/deployments/localhost` after you restart the geth
-node in order to re-deploy.
+you have to use `hardhat deploy --reset` after you restart the geth node in
+order to re-deploy.
+
+### Linking to deployed contracts
+
+In order to avoid re-deploying the library contracts for each test you can pass
+the address obtained by running `hardhat deploy` as an env var
+
+    env RESCUE_LIB_ADDRESS=0x5FbDB2315678afecb367f032d93F642f64180aa3 cargo test --release
 
 ## Precompiled solidity binaries
 

--- a/contracts/contracts/libraries/RescueLib.sol
+++ b/contracts/contracts/libraries/RescueLib.sol
@@ -704,12 +704,12 @@ library RescueLib {
         uint256 a,
         uint256 b,
         uint256 c
-    ) internal view returns (uint256 o) {
+    ) public view returns (uint256 o) {
         (o, a, b, c) = perm(a % _PRIME, b % _PRIME, c % _PRIME, 0);
         o %= _PRIME;
     }
 
-    function commit(uint256[15] memory inputs) internal view returns (uint256) {
+    function commit(uint256[15] memory inputs) public view returns (uint256) {
         uint256 a;
         uint256 b;
         uint256 c;

--- a/contracts/deploy/00_cape.ts
+++ b/contracts/deploy/00_cape.ts
@@ -5,12 +5,23 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployments, getNamedAccounts } = hre;
   const { deploy } = deployments;
   const { deployer } = await getNamedAccounts();
+
+  let rescueLib = await deploy("RescueLib", {
+    from: deployer,
+    args: [],
+    log: true,
+  });
+
   const treeDepth = 26;
   const nRoots = 10;
+
   await deploy("CAPE", {
     from: deployer,
     args: [treeDepth, nRoots],
     log: true,
+    libraries: {
+      RescueLib: rescueLib.address,
+    },
   });
 };
 export default func;

--- a/contracts/rust/Cargo.toml
+++ b/contracts/rust/Cargo.toml
@@ -37,6 +37,7 @@ async-std = { version = "1.10.0", features = ["unstable", "attributes"] }
 async-trait = "0.1.51"
 futures = "0.3.16"
 strum_macros = "0.20.1"
+async-recursion = "1.0.0"
 
 # copied from jellyfish
 [dependencies.ark-poly-commit]

--- a/contracts/test/benchmarks/test-records-merkle-tree.js
+++ b/contracts/test/benchmarks/test-records-merkle-tree.js
@@ -8,7 +8,12 @@ describe("Records Merkle Tree Benchmarks", function () {
     beforeEach(async function () {
       [owner] = await ethers.getSigners();
 
-      const RMT = await ethers.getContractFactory("TestRecordsMerkleTree");
+      let rescue = await (await ethers.getContractFactory("RescueLib")).deploy();
+      const RMT = await ethers.getContractFactory("TestRecordsMerkleTree", {
+        libraries: {
+          RescueLib: rescue.address,
+        },
+      });
       TREE_HEIGHT = 20;
       rmtContract = await RMT.deploy(TREE_HEIGHT);
 
@@ -18,8 +23,7 @@ describe("Records Merkle Tree Benchmarks", function () {
       await rmtContract.deployed();
     });
 
-    // TODO re-enable once we have have split contract deployment
-    it.skip("shows how much gas is spent by updateRecordsMerkleTree", async function () {
+    it("shows how much gas is spent by updateRecordsMerkleTree", async function () {
       let elems = [1, 2, 3, 4, 5];
 
       const txEmpty = await rmtContract.testUpdateRecordsMerkleTree([]);
@@ -34,8 +38,10 @@ describe("Records Merkle Tree Benchmarks", function () {
       const doNothingTxReceipt = await doNothingTx.wait();
       let doNothingGasUsed = doNothingTxReceipt.gasUsed;
 
+      // TODO It is really troublesome to update this test if the gas usage changes!
+
       // Total gas used to insert all the records, read from and store into the frontier
-      expect(totalGasUsed).to.be.equal(2772947);
+      expect(totalGasUsed).to.be.equal(2791063);
 
       // Gas used just to handle the frontier (no records inserted)
       expect(emptyGasUsed).to.be.equal(159189);
@@ -46,11 +52,11 @@ describe("Records Merkle Tree Benchmarks", function () {
 
       // Gas used to handle the frontier and insert records but without "base" cost
       let updateRecordsMerkleTreeWithoutBaseCost = totalGasUsed - doNothingGasUsed;
-      expect(updateRecordsMerkleTreeWithoutBaseCost).to.be.equal(2751785);
+      expect(updateRecordsMerkleTreeWithoutBaseCost).to.be.equal(2769901);
 
       // Gas used to insert the records
       let insertRecordsGasUsed = totalGasUsed - emptyGasUsed;
-      expect(insertRecordsGasUsed).to.be.equal(2613758);
+      expect(insertRecordsGasUsed).to.be.equal(2631874);
     });
   });
 });

--- a/contracts/test/benchmarks/test-rescue.js
+++ b/contracts/test/benchmarks/test-rescue.js
@@ -4,13 +4,18 @@ const { ethers } = require("hardhat");
 describe("Rescue benchmarks", function () {
   describe("Gas spent for computing the Rescue function", function () {
     for (const [contractName, gas] of [
-      ["TestRescue", 87214],
+      ["TestRescue", 90363],
       ["TestRescueNonOptimized", 620060],
     ]) {
-      // TODO re-enable once we have have split contract deployment
-      it.skip(`checks gas usage of ${contractName}.hash`, async function () {
-        const Rescue = await ethers.getContractFactory(contractName);
-        let rescueContract = await Rescue.deploy();
+      it(`checks gas usage of ${contractName}.hash`, async function () {
+        const libraries = {};
+        if (contractName == "TestRescue") {
+          let rescueLib = await (await ethers.getContractFactory("RescueLib")).deploy();
+          libraries["RescueLib"] = rescueLib.address;
+        }
+        const factory = await ethers.getContractFactory(contractName, { libraries });
+
+        let rescueContract = await factory.deploy();
 
         // Polling interval in ms.
         rescueContract.provider.pollingInterval = 20;

--- a/contracts/test/cape.spec.ts
+++ b/contracts/test/cape.spec.ts
@@ -7,7 +7,12 @@ describe("CAPE", function () {
     let cape: TestCAPE;
 
     beforeEach(async function () {
-      let capeFactory = await ethers.getContractFactory("TestCAPE");
+      let rescue = await (await ethers.getContractFactory("RescueLib")).deploy();
+      let capeFactory = await ethers.getContractFactory("TestCAPE", {
+        libraries: {
+          RescueLib: rescue.address,
+        },
+      });
       const TREE_HEIGHT = 20;
       const N_ROOTS = 3;
       cape = await capeFactory.deploy(TREE_HEIGHT, N_ROOTS);

--- a/contracts/test/records-merkle-tree.spec.ts
+++ b/contracts/test/records-merkle-tree.spec.ts
@@ -10,7 +10,12 @@ describe("Records Merkle Tree tests", function () {
   };
 
   beforeEach(async function () {
-    rmtFactory = await ethers.getContractFactory("TestRecordsMerkleTree");
+    let rescue = await (await ethers.getContractFactory("RescueLib")).deploy();
+    rmtFactory = await ethers.getContractFactory("TestRecordsMerkleTree", {
+      libraries: {
+        RescueLib: rescue.address,
+      },
+    });
   });
 
   it("inserts all 27 leaves into a merkle tree of height 3", async function () {

--- a/flake.nix
+++ b/flake.nix
@@ -126,7 +126,7 @@
             SOLCX_BINARY_PATH = "${mySolc}/bin";
             SOLC_VERSION = mySolc.version;
             SOLC_PATH = "${mySolc}/bin/solc";
-            SOLC_OPTIMIZER_RUNS = "10000"; # TODO increase this once we have split up contract deployment
+            SOLC_OPTIMIZER_RUNS = "1000000";
 
             shellHook = ''
               echo "Ensuring node dependencies are installed"


### PR DESCRIPTION
# Notes
- Added a new crate `async-recursion` to enable calling async functions recursively. This is used to call `deploy` from within `deploy` if the contract requires a liked library and that library address is not provided by an env var. This dependency could be removed at the expense of some extra code, should anyone think it poses a problem.
- At the moment this supports linking to an already deployed contract via `RESCUE_LIB_ADDRESS` env var or re-deploying the library each time we deploy a contract that uses it. It sounds like a good idea to deploy once and re-use but it does not affect the test duration significantly (`cargo test --release` takes about 15 seconds for me either way). So we could consider it an unnecessary complication at the moment and remove this functionality to connect to the already deployed library. (edit: I think this will still be useful and cut down on test runtime when running tests against slow networks, like rinkeby)
- The code does not support adding more libraries without making changes to the rust code but the required changes should be simple and straightforward. Only the `link_unliked_libraries` function would have to be modified.

# Tasks
- [x] Deploy example linked contract.
  - [x] Create example contract.
  - [x] Workout how to compute placeholder hash in rust https://docs.soliditylang.org/en/latest/using-the-compiler.html#library-linking .
```
# ... __$49241ae84077e655d18086a6f3556db8f2$__ ...
> ethers.utils.keccak256(ethers.utils.toUtf8Bytes("contracts/libraries/TestLib.sol:TestLib")).slice(0,36)
'0x49241ae84077e655d18086a6f3556db8f2' 
```
  - [x] Write a function to deploy library followed by the linked contract or deploy the library once per test run and make available via env var. This may reduce the number of transactions significantly but it may or may not have significant impact on test runtime.
- [x] Link RescueLib if needed.
- [x] ~~(maybe) Generalize to easily support multiple libraries. This may not be needed because we don't plan on adding many more libraries that need to be deployed separately.~~ For now we would have to add a few lines of code if we do add another library to link against it. I think this is acceptable at the moment because we aren't planning to add so many libraries.
- [x] Fix typescript tests: this needs library linking too now.

Close #142 