### PR TITLE
Improve solidity compilation process

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1104,7 +1104,6 @@ dependencies = [
  "async-trait",
  "bincode",
  "ethers 0.6.0 (git+https://github.com/gakonst/ethers-rs?branch=master)",
- "ethers-contract-abigen 0.6.0 (git+https://github.com/gakonst/ethers-rs)",
  "futures",
  "generic-array 0.14.4",
  "hex",

--- a/bin/build-abi
+++ b/bin/build-abi
@@ -1,40 +1,50 @@
-#!/usr/bin/env bash
-set -euo pipefail
+#!/usr/bin/env python
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
 
-echo "Compiling contracts ..."
+try:
+    subprocess.check_call(["hardhat", "compile"])
+except subprocess.CalledProcessError as exc:
+    print("Command 'hardhat compile' failed")
+    sys.exit(exc.returncode)
 
-cd $CONTRACTS_DIR
+# hardhat removes files in artifacts directory when compiling -> put these files elsewhere
+contracts_dir = Path(os.environ["CONTRACTS_DIR"])
+abi_dir = contracts_dir / "abi"
+artifacts_dir = contracts_dir / "artifacts"
 
-hardhat compile
+# For each solidity file (respectively its artifact output directory)
+for directory in artifacts_dir.rglob("*.sol"):
 
-# for recursive globbing
-shopt -s globstar
-
-# glob empty if no match, avoid matches like "*.sol"
-shopt -s nullglob
-
-# For each solidity file (or its artifact output directory)
-for directory in artifacts/**/*.sol; do
-
-    # For each contract in the solidity file
-    for combined in $directory/*.json; do
-
-        if [[ $combined == *.dbg.json ]]; then
+    for hardhat_json in directory.glob("*.json"):
+        if str(hardhat_json).endswith(".dbg.json"):
             continue
-        fi
 
-        basename_json="${combined##*/}"
-        basename="${basename_json/%.json}"
+        contract_name = hardhat_json.stem
+        contract_file = hardhat_json.parent
+        out_dir = abi_dir / contract_file.relative_to(artifacts_dir) / contract_name
 
-        outdir="$directory/$basename"
+        abi_out = out_dir / "abi.json"
 
-        echo "$combined -> $outdir"
-        mkdir -p "$outdir"
+        if abi_out.exists() and abi_out.stat().st_mtime > hardhat_json.stat().st_mtime:
+            print(f"Up to date: {contract_name}")
+            continue
 
-        # extract .abi and .bytecode fields
-        cat "$combined" | jq -r .abi > "$outdir/abi.json"
-        cat "$combined" | jq -r .bytecode > "$outdir/bin.txt"
-    done
-done
+        print(f"Extracting ABI for {contract_name}")
 
-echo "Finished extracting ABIs"
+        os.makedirs(out_dir, exist_ok=True)
+
+        with open(hardhat_json) as f:
+            output = json.load(f)
+
+        with open(abi_out, "w") as f:
+            json.dump(output["abi"], f)
+
+        with open(out_dir / "bin.txt", "w") as f:
+            print(output["bytecode"], file=f)
+
+
+print("Finished extracting ABIs")

--- a/contracts/.gitignore
+++ b/contracts/.gitignore
@@ -26,3 +26,6 @@ __pycache__/
 typechain-types/
 
 deployments/localhost/
+
+# TODO: remove this when build-abi script is removed
+/abi/

--- a/contracts/rust/Cargo.toml
+++ b/contracts/rust/Cargo.toml
@@ -47,6 +47,3 @@ default-features = false
 
 [dev-dependencies]
 proptest = "1.0.0"
-
-[build-dependencies]
-ethers-contract-abigen = { git = "https://github.com/gakonst/ethers-rs" }

--- a/contracts/rust/src/bn254.rs
+++ b/contracts/rust/src/bn254.rs
@@ -23,7 +23,7 @@ async fn deploy_contract() -> Result<TestBN254<SignerMiddleware<Provider<Http>, 
     let client = get_funded_deployer().await.unwrap();
     let contract = deploy(
         client.clone(),
-        Path::new("../artifacts/contracts/mocks/TestBN254.sol/TestBN254"),
+        Path::new("../abi/contracts/mocks/TestBN254.sol/TestBN254"),
         (),
     )
     .await

--- a/contracts/rust/src/cape.rs
+++ b/contracts/rust/src/cape.rs
@@ -285,7 +285,7 @@ mod tests {
         let client = get_funded_deployer().await.unwrap();
         let call = deploy(
             client.clone(),
-            Path::new("../artifacts/contracts/mocks/TestCAPE.sol/TestCAPE"),
+            Path::new("../abi/contracts/mocks/TestCAPE.sol/TestCAPE"),
             CAPEConstructorArgs::new(5, 2).generic_into::<(u8, u64)>(),
         )
         .await;
@@ -768,7 +768,7 @@ mod tests {
             let client = get_funded_deployer().await.unwrap();
             let contract = deploy(
                 client.clone(),
-                Path::new("../artifacts/contracts/mocks/TestCapeTypes.sol/TestCapeTypes"),
+                Path::new("../abi/contracts/mocks/TestCapeTypes.sol/TestCapeTypes"),
                 (),
             )
             .await

--- a/contracts/rust/src/cape_e2e_tests.rs
+++ b/contracts/rust/src/cape_e2e_tests.rs
@@ -74,7 +74,7 @@ async fn test_2user_maybe_submit(should_submit: bool) -> Result<()> {
         let contract_address: Address = deploy(
             client.clone(),
             // TODO using mock contract to be able to manually add root
-            Path::new("../artifacts/contracts/mocks/TestCAPE.sol/TestCAPE"),
+            Path::new("../abi/contracts/mocks/TestCAPE.sol/TestCAPE"),
             CAPEConstructorArgs::new(
                 MERKLE_HEIGHT,
                 CapeContractState::RECORD_ROOT_HISTORY_SIZE as u64,

--- a/contracts/rust/src/ethereum.rs
+++ b/contracts/rust/src/ethereum.rs
@@ -82,7 +82,7 @@ async fn link_unlinked_libraries<M: 'static + Middleware>(
             Ok(val) => val.parse::<Address>()?,
             Err(_) => deploy(
                 client.clone(),
-                Path::new("../artifacts/contracts/libraries/RescueLib.sol/RescueLib"),
+                Path::new("../abi/contracts/libraries/RescueLib.sol/RescueLib"),
                 (),
             )
             .await?

--- a/contracts/rust/src/records_merkle_tree/mod.rs
+++ b/contracts/rust/src/records_merkle_tree/mod.rs
@@ -51,7 +51,7 @@ pub(crate) async fn get_contract_records_merkle_tree(
     let client = ethereum::get_funded_deployer().await.unwrap();
     let contract = ethereum::deploy(
         client.clone(),
-        Path::new("../artifacts/contracts/mocks/TestRecordsMerkleTree.sol/TestRecordsMerkleTree"),
+        Path::new("../abi/contracts/mocks/TestRecordsMerkleTree.sol/TestRecordsMerkleTree"),
         height,
     )
     .await

--- a/contracts/rust/src/records_merkle_tree/rescue.rs
+++ b/contracts/rust/src/records_merkle_tree/rescue.rs
@@ -52,7 +52,7 @@ mod tests {
         let client = ethereum::get_funded_deployer().await.unwrap();
         let contract = ethereum::deploy(
             client.clone(),
-            Path::new("../artifacts/contracts/mocks/TestRescue.sol/TestRescue"),
+            Path::new("../abi/contracts/mocks/TestRescue.sol/TestRescue"),
             (),
         )
         .await

--- a/contracts/rust/src/root_store.rs
+++ b/contracts/rust/src/root_store.rs
@@ -11,7 +11,7 @@ async fn test_root_store() -> Result<()> {
     let client = get_funded_deployer().await?;
     let contract = deploy(
         client.clone(),
-        Path::new("../artifacts/contracts/mocks/TestRootStore.sol/TestRootStore"),
+        Path::new("../abi/contracts/mocks/TestRootStore.sol/TestRootStore"),
         (3u64,), /* num_roots */
     )
     .await?;

--- a/contracts/rust/src/transcript.rs
+++ b/contracts/rust/src/transcript.rs
@@ -20,7 +20,7 @@ async fn deploy() -> TestTranscript<SignerMiddleware<Provider<Http>, Wallet<Sign
     let client = ethereum::get_funded_deployer().await.unwrap();
     let contract = ethereum::deploy(
         client.clone(),
-        Path::new("../artifacts/contracts/mocks/TestTranscript.sol/TestTranscript"),
+        Path::new("../abi/contracts/mocks/TestTranscript.sol/TestTranscript"),
         (),
     )
     .await

--- a/contracts/rust/src/types.rs
+++ b/contracts/rust/src/types.rs
@@ -22,43 +22,43 @@ const GATE_WIDTH: usize = 4;
 
 abigen!(
     TestBN254,
-    "../artifacts/contracts/mocks/TestBN254.sol/TestBN254/abi.json",
+    "../abi/contracts/mocks/TestBN254.sol/TestBN254/abi.json",
     event_derives(serde::Deserialize, serde::Serialize);
 
     TestRecordsMerkleTree,
-    "../artifacts/contracts/mocks/TestRecordsMerkleTree.sol/TestRecordsMerkleTree/abi.json",
+    "../abi/contracts/mocks/TestRecordsMerkleTree.sol/TestRecordsMerkleTree/abi.json",
     event_derives(serde::Deserialize, serde::Serialize);
 
     TestRescue,
-    "../artifacts/contracts/mocks/TestRescue.sol/TestRescue/abi.json",
+    "../abi/contracts/mocks/TestRescue.sol/TestRescue/abi.json",
     event_derives(serde::Deserialize, serde::Serialize);
 
     TestRootStore,
-    "../artifacts/contracts/mocks/TestRootStore.sol/TestRootStore/abi.json",
+    "../abi/contracts/mocks/TestRootStore.sol/TestRootStore/abi.json",
     event_derives(serde::Deserialize, serde::Serialize);
 
     TestTranscript,
-    "../artifacts/contracts/mocks/TestTranscript.sol/TestTranscript/abi.json",
+    "../abi/contracts/mocks/TestTranscript.sol/TestTranscript/abi.json",
     event_derives(serde::Deserialize, serde::Serialize);
 
     CAPE,
-    "../artifacts/contracts/CAPE.sol/CAPE/abi.json",
+    "../abi/contracts/CAPE.sol/CAPE/abi.json",
     event_derives(serde::Deserialize, serde::Serialize);
 
     PlonkVerifier,
-    "../artifacts/contracts/verifier/PlonkVerifier.sol/PlonkVerifier/abi.json",
+    "../abi/contracts/verifier/PlonkVerifier.sol/PlonkVerifier/abi.json",
     event_derives(serde::Deserialize, serde::Serialize);
 
     TestCapeTypes,
-    "../artifacts/contracts/mocks/TestCapeTypes.sol/TestCapeTypes/abi.json",
+    "../abi/contracts/mocks/TestCapeTypes.sol/TestCapeTypes/abi.json",
     event_derives(serde::Deserialize, serde::Serialize);
 
     TestCAPE,
-    "../artifacts/contracts/mocks/TestCAPE.sol/TestCAPE/abi.json",
+    "../abi/contracts/mocks/TestCAPE.sol/TestCAPE/abi.json",
     event_derives(serde::Deserialize, serde::Serialize);
 
     Greeter,
-    "../artifacts/contracts/Greeter.sol/Greeter/abi.json",
+    "../abi/contracts/Greeter.sol/Greeter/abi.json",
     event_derives(serde::Deserialize, serde::Serialize);
 );
 

--- a/contracts/rust/tests/ethereum_test.rs
+++ b/contracts/rust/tests/ethereum_test.rs
@@ -8,7 +8,7 @@ async fn deploy_contract() -> Result<Greeter<SignerMiddleware<Provider<Http>, Wa
     let client = get_funded_deployer().await.unwrap();
     let contract = deploy(
         client.clone(),
-        Path::new("../artifacts/contracts/Greeter.sol/Greeter"),
+        Path::new("../abi/contracts/Greeter.sol/Greeter"),
         ("Initial Greeting".to_string(),),
     )
     .await

--- a/treefmt.toml
+++ b/treefmt.toml
@@ -12,6 +12,7 @@ includes = [
   "**/*.py",
   "bin/hdwallet-derive",
   "bin/make-genesis-block",
+  "bin/build-abi",
 ]
 
 [formatter.prettier]


### PR DESCRIPTION
- Move extracted ABI files into their own directory to prevent
  `hardhat compile` from deleting them.
- Rewrite build-abi script in python to avoid calling jq twice for each
  file. This makes the abi extraction part of the script a lot faster.
- Check timestmaps of abi files and only update if source is newer.

I don't know why we're getting a small change in `Cargo.lock`.

Close #215 