### PR TITLE
Run tests against rinkeby

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ for that purpose.
 
 To connect to various chains use `RPC_URL` and `MNEMONIC` env vars. For example
 
-    env MNEMONIC=$RINKEBY_MNEMONIC RPC_URL=$RINKEBY_URL cargo test
+    env MNEMONIC="$RINKEBY_MNEMONIC" RPC_URL=$RINKEBY_URL cargo test
 
 To watch the rust files and compile on changes
 
@@ -457,6 +457,14 @@ batch_verify:  2759316.285714286 gas  ------ 2084.7296774480005 USD
 ```
 > hardhat --network rinkeby run contracts/scripts/benchmarks.js
 ```
+
+To run the hardhat tests against rinkeby
+
+    hardhat test --network rinkeby
+
+To run an end-to-end test against rinkeby
+
+    cape-test-rinkeby
 
 # Goerli
 

--- a/bin/cape-test-rinkeby
+++ b/bin/cape-test-rinkeby
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# TODO sometimes fails with
+#       message: replacement transaction underpriced
+
+env MNEMONIC="$RINKEBY_MNEMONIC" RPC_URL="$RINKEBY_URL" \
+    cargo test --release  "cape_e2e_tests::test_2user_and_submit" \
+    -- --test-threads=1 # Otherwise fails with nonce too low error

--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -52,13 +52,11 @@ const config: HardhatUserConfig = {
     rinkeby: {
       url: process.env.RINKEBY_URL,
       gasPrice: 2_000_000_000,
-      gas: 25_000_000,
       accounts: { mnemonic: process.env.RINKEBY_MNEMONIC },
     },
     goerli: {
       url: process.env.GOERLI_URL,
       gasPrice: 2_000_000_000,
-      gas: 25_000_000,
       accounts: { mnemonic: process.env.GOERLI_MNEMONIC },
     },
     localhost: {

--- a/contracts/test/cape.spec.ts
+++ b/contracts/test/cape.spec.ts
@@ -22,7 +22,8 @@ describe("CAPE", function () {
       let elem = ethers.utils.randomBytes(32);
       expect(await cape.nullifiers(elem)).to.be.false;
 
-      await cape.insertNullifier(elem);
+      let tx = await cape.insertNullifier(elem);
+      await tx.wait();
       expect(await cape.nullifiers(elem)).to.be.true;
     });
 
@@ -31,7 +32,8 @@ describe("CAPE", function () {
       let elem2 = ethers.utils.randomBytes(32);
       expect(elem1).not.equal(elem2);
 
-      await cape.insertNullifier(elem1);
+      let tx = await cape.insertNullifier(elem1);
+      await tx.wait();
       expect(await cape.insertNullifier(elem2)).not.to.throw;
     });
   });


### PR DESCRIPTION
- Fix hardhat tests against rinkeby (was missing awaits for transactions). This only (?) seems to cause a problem against slower networks because our local chains mine the transactions quickly enough.
- [x] Run `test_2user_and_submit against` rinkeby

To test put `RINKEBY_MNEMONIC` and  `RINKEBY_URL` in `.env` (see readme for instructions). Then run 

```
hardhat --network rinkeby test
cape-test-rinkeby
```

The tests are quite slow.



Close #54 