### PR TITLE
Arbitrum: don't set gas in hardhat config

### DIFF
--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -66,7 +66,6 @@ const config: HardhatUserConfig = {
     arbitrum: {
       url: `https://rinkeby.arbitrum.io/rpc`,
       gasPrice: 1_000_000_000,
-      gas: 25_000_000,
       accounts: { mnemonic: process.env.RINKEBY_MNEMONIC },
     },
     // Network config from


### PR DESCRIPTION
This fixes the test

    Records Merkle Tree tests
      shows that inserting too many leaves triggers an error

Similarly to what we found in
- https://github.com/SpectrumXYZ/cape/pull/271

The remaining failures in `hardhat test --network arbitrum` are caused
by checking exact gas costs which differ on arbitrum and concern the
following tests.

    Records Merkle Tree Benchmarks
      The Records Merkle root is updated with the frontier.
        1) shows how much gas is spent by updateRecordsMerkleTree

    Rescue benchmarks
      Gas spent for computing the Rescue function
        2) checks gas usage of TestRescue.hash
        3) checks gas usage of TestRescueNonOptimized.hash

Part of
-  #25