### PR TITLE
Contract: implement sponsor CAPE Asset

### DIFF
--- a/contracts/contracts/AssetRegistry.sol
+++ b/contracts/contracts/AssetRegistry.sol
@@ -1,0 +1,64 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+// TODO Remove once functions are implemented
+/* solhint-disable no-unused-vars */
+
+contract AssetRegistry {
+    mapping(bytes32 => address) public assets;
+
+    // TODO Types can't be shared between contracts unless we put them in a library
+    // or they are defined in a contract we inherit from. The EdOnBn254Point
+    // does not really belong into this contract. It works fine the way it is
+    // now because on only this contract and CAPE need it. If we also need it in
+    // another contract and we can consider putting this type into a solidity
+    // library.
+    struct EdOnBn254Point {
+        uint256 x;
+        uint256 y;
+    }
+
+    struct AssetDefinition {
+        uint256 code;
+        AssetPolicy policy;
+    }
+
+    struct AssetPolicy {
+        EdOnBn254Point auditorPk;
+        EdOnBn254Point credPk;
+        EdOnBn254Point freezerPk;
+        uint256 revealMap;
+        uint64 revealThreshold;
+    }
+
+    function _lookup(AssetDefinition memory assetDefinition) internal view returns (address) {
+        bytes32 key = keccak256(abi.encode(assetDefinition));
+        return assets[key];
+    }
+
+    /// @notice Check if an asset is already registered
+    /// @param assetDefinition describing the asset
+    /// @return true if the asset type is registered, false otherwise
+    function isCapeAssetRegistered(AssetDefinition memory assetDefinition)
+        public
+        view
+        returns (bool)
+    {
+        return _lookup(assetDefinition) != address(0);
+    }
+
+    /// @notice Create a new asset type associated to an ERC20 token and
+    ///         register it in the registry.
+    /// @param erc20Address erc20 token address of corresponding to the asset type.
+    /// @param newAsset asset type to be registered in the contract.
+    /// @dev will revert if asset is already registered
+    function sponsorCapeAsset(address erc20Address, AssetDefinition memory newAsset) public {
+        // TODO check if real token (figure out if this is nececssary/useful:
+        //      the contract could still do whatever it wants even if it has
+        //      the right interface)
+        require(erc20Address != address(0), "Bad asset address");
+        require(!isCapeAssetRegistered(newAsset), "Asset already registered");
+        bytes32 key = keccak256(abi.encode(newAsset));
+        assets[key] = erc20Address;
+    }
+}

--- a/contracts/contracts/CAPE.sol
+++ b/contracts/contracts/CAPE.sol
@@ -13,13 +13,14 @@ import "./libraries/AccumulatingArray.sol";
 import "./libraries/BN254.sol";
 import "./libraries/RescueLib.sol";
 import "./interfaces/IPlonkVerifier.sol";
+import "./AssetRegistry.sol";
 import "./RecordsMerkleTree.sol";
 import "./RootStore.sol";
 
 // TODO Remove once functions are implemented
 /* solhint-disable no-unused-vars */
 
-contract CAPE is RecordsMerkleTree, RootStore {
+contract CAPE is RecordsMerkleTree, RootStore, AssetRegistry {
     mapping(uint256 => bool) public nullifiers;
     uint64 public height;
 
@@ -28,11 +29,6 @@ contract CAPE is RecordsMerkleTree, RootStore {
     bytes public constant CAPE_BURN_MAGIC_BYTES = "TRICAPE burn";
 
     event BlockCommitted(uint64 indexed height, bool[] includedNotes);
-
-    struct EdOnBn254Point {
-        uint256 x;
-        uint256 y;
-    }
 
     struct AuditMemo {
         EdOnBn254Point ephemeralKey;
@@ -107,19 +103,6 @@ contract CAPE is RecordsMerkleTree, RootStore {
         EdOnBn254Point txnMemoVerKey;
     }
 
-    struct AssetDefinition {
-        uint256 code;
-        AssetPolicy policy;
-    }
-
-    struct AssetPolicy {
-        EdOnBn254Point auditorPk;
-        EdOnBn254Point credPk;
-        EdOnBn254Point freezerPk;
-        uint256 revealMap;
-        uint64 revealThreshold;
-    }
-
     struct RecordOpening {
         uint64 amount;
         AssetDefinition assetDef;
@@ -192,22 +175,6 @@ contract CAPE is RecordsMerkleTree, RootStore {
         _insertNullifier(nullifier);
         return true;
     }
-
-    /// @notice Check if an asset is already registered
-    /// @param erc20Address erc20 token address corresponding to the asset type.
-    /// @param newAsset asset type.
-    /// @return true if the asset type is registered, false otherwise
-    function isCapeAssetRegistered(address erc20Address, AssetDefinition memory newAsset)
-        public
-        returns (bool)
-    {
-        return true;
-    }
-
-    /// @notice create a new asset type associated to some erc20 token and register it in the contract so that it can be used later for wrapping.
-    /// @param erc20Address erc20 token address of corresponding to the asset type.
-    /// @param newAsset asset type to be registered in the contract.
-    function sponsorCapeAsset(address erc20Address, AssetDefinition memory newAsset) public {}
 
     /// @notice allows to wrap some erc20 tokens into some CAPE asset defined in the record opening
     /// @param ro record opening that will be inserted in the records merkle tree once the deposit is validated.

--- a/contracts/rust/src/asset_registry.rs
+++ b/contracts/rust/src/asset_registry.rs
@@ -1,0 +1,64 @@
+#![cfg(test)]
+use std::path::Path;
+
+use anyhow::Result;
+use ethers::prelude::Address;
+
+use crate::assertion::Matcher;
+use crate::ethereum::{deploy, get_funded_deployer};
+use crate::types::{self as sol, AssetRegistry};
+
+#[tokio::test]
+async fn test_asset_registry() -> Result<()> {
+    let client = get_funded_deployer().await?;
+    let contract = deploy(
+        client.clone(),
+        Path::new("../abi/contracts/AssetRegistry.sol/AssetRegistry"),
+        (),
+    )
+    .await?;
+    let contract = AssetRegistry::new(contract.address(), client);
+
+    let address = Address::random();
+    let asset_def = sol::AssetDefinition::default();
+
+    // Fails for default/zero address
+    contract
+        .sponsor_cape_asset(Address::zero(), asset_def.clone())
+        .call()
+        .await
+        .should_revert_with_message("Bad asset address");
+
+    // Unknown asset is not registered
+    let registered = contract
+        .is_cape_asset_registered(asset_def.clone())
+        .call()
+        .await
+        .unwrap();
+    assert!(!registered);
+
+    // Register the asset
+    contract
+        .sponsor_cape_asset(address, asset_def.clone())
+        .send()
+        .await?
+        .await?;
+
+    // Asset is now registered
+    let registered = contract
+        .is_cape_asset_registered(asset_def.clone())
+        .call()
+        .await
+        .unwrap();
+
+    assert!(registered);
+
+    // Asset cannot be registered again
+    contract
+        .sponsor_cape_asset(address, asset_def.clone())
+        .call()
+        .await
+        .should_revert_with_message("Asset already registered");
+
+    Ok(())
+}

--- a/contracts/rust/src/lib.rs
+++ b/contracts/rust/src/lib.rs
@@ -2,6 +2,7 @@
 extern crate num_derive;
 
 mod assertion;
+mod asset_registry;
 mod bn254;
 pub mod cape;
 #[cfg(test)]

--- a/contracts/rust/src/types.rs
+++ b/contracts/rust/src/types.rs
@@ -21,6 +21,10 @@ use std::convert::TryInto;
 const GATE_WIDTH: usize = 4;
 
 abigen!(
+    AssetRegistry,
+    "../abi/contracts/AssetRegistry.sol/AssetRegistry/abi.json",
+    event_derives(serde::Deserialize, serde::Serialize);
+
     TestBN254,
     "../abi/contracts/mocks/TestBN254.sol/TestBN254/abi.json",
     event_derives(serde::Deserialize, serde::Serialize);


### PR DESCRIPTION
Moved EdOnBn254Point, AssetDefinition and AssetPolicy into the registry contract. The types can't be shared between contracts unless we put them in a library or they are defined in a contract we inherit from.

The EdOnBn254Point does not really belong into this contract. It works fine the way it is now but if we also need it in another contract and we could consider putting into a types library.

# TODO

- [x] register cape asset
- [x] sponsor cape asset

For reference/review this is the workflow code

```rust
    /// getter for registrar
    pub fn is_cape_asset_registered(&self, asset_def: &AssetDefinition) -> bool {
        self.wrapped_erc20_registrar.contains_key(asset_def)
    }

    /// Create a new asset type for an ERC20 and register it to the contract.
    pub fn sponsor_cape_asset(&mut self, erc20_addr: Address, new_asset: AssetDefinition) {
        assert!(
            !self.is_cape_asset_registered(&new_asset),
            "this CAPE asset is already registered"
        );
        // check correct ERC20 address.
        let _ = Erc20Contract::at(erc20_addr);

        self.wrapped_erc20_registrar.insert(new_asset, erc20_addr);
    }
```

Close #122 
Close #123 