### PR TITLE
Fix documentation for smart contract

### DIFF
--- a/doc/notion/smart_contract_sequence_diagram.puml
+++ b/doc/notion/smart_contract_sequence_diagram.puml
@@ -31,7 +31,7 @@ Block <i>b</i> is a list of transactions that contains <i>tx</i>.
 end note
 
 
-R -> CapeContract: submit_cape_block(b)
+R -> CapeContract: submit_cape_block(b,[])
 end group
 
 group Unwrapping: AAP record -> USDC token


### PR DESCRIPTION
The sequence diagram mentioned the frontier as an argument for submitting the block.
Now the frontier is maintained directly by the CAPE contract.