### PR TITLE
Contract: verify domestic asset code

### DIFF
--- a/contracts/contracts/mocks/TestCAPE.sol
+++ b/contracts/contracts/mocks/TestCAPE.sol
@@ -62,8 +62,15 @@ contract TestCAPE is CAPE {
         return _computeMaxCommitments(newBlock);
     }
 
-    function checkAssetCode(RecordOpening memory ro, address erc20Address) public view {
-        _checkAssetCode(ro, erc20Address);
+    function checkForeignAssetCode(uint256 assetDefinitionCode, address erc20Address) public view {
+        _checkForeignAssetCode(assetDefinitionCode, erc20Address);
+    }
+
+    function checkDomesticAssetCode(uint256 assetDefinitionCode, uint256 internalAssetCode)
+        public
+        view
+    {
+        _checkDomesticAssetCode(assetDefinitionCode, internalAssetCode);
     }
 
     function computeAssetDescription(address erc20Address, address sponsor)

--- a/contracts/contracts/mocks/TestCapeTypes.sol
+++ b/contracts/contracts/mocks/TestCapeTypes.sol
@@ -17,7 +17,7 @@ contract TestCapeTypes {
         return root;
     }
 
-    function checkAssetCode(uint256 code) public pure returns (uint256) {
+    function checkForeignAssetCode(uint256 code) public pure returns (uint256) {
         return code;
     }
 


### PR DESCRIPTION
- Requires flipping endianness of internal asset code in contract to match jellyfish code.
- [x] Requires change in jf to not use sha512.
- (edit: added to this PR) Follow up #390 
- Follow up #389 

Close #353
Close #390