### PR TITLE
Feat/t121 implement depositor erc20 fun

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1034,6 +1034,8 @@ dependencies = [
  "bincode",
  "commit",
  "ethers 0.6.0 (git+https://github.com/gakonst/ethers-rs?branch=master)",
+ "ethers-contract 0.6.0 (git+https://github.com/gakonst/ethers-rs?branch=master)",
+ "ethers-core 0.6.0 (git+https://github.com/gakonst/ethers-rs?branch=master)",
  "futures",
  "generic-array 0.14.5",
  "hex",

--- a/contracts/contracts/AssetRegistry.sol
+++ b/contracts/contracts/AssetRegistry.sol
@@ -44,7 +44,7 @@ contract AssetRegistry {
     /// @param newAsset asset type to be registered in the contract.
     /// @dev will revert if asset is already registered
     function sponsorCapeAsset(address erc20Address, AssetDefinition memory newAsset) public {
-        // TODO check if real token (figure out if this is nececssary/useful:
+        // TODO check if real token (figure out if this is necessary/useful):
         //      the contract could still do whatever it wants even if it has
         //      the right interface)
         require(erc20Address != address(0), "Bad asset address");

--- a/contracts/contracts/Queue.sol
+++ b/contracts/contracts/Queue.sol
@@ -1,0 +1,33 @@
+//SPDX-License-Identifier: Unlicensed
+pragma solidity ^0.8.0;
+
+contract Queue {
+    mapping(uint256 => uint256) internal _queue;
+    uint256 internal _queueSize;
+
+    constructor() {
+        _queueSize = 0;
+    }
+
+    // These functions must be internal
+    function _pushToQueue(uint256 recordCommitment) internal {
+        _queue[_queueSize] = recordCommitment;
+        _queueSize += 1;
+    }
+
+    function _isQueueEmpty() internal returns (bool) {
+        return (_queueSize == 0);
+    }
+
+    function _getQueueSize() internal returns (uint256) {
+        return _queueSize;
+    }
+
+    function _getQueueElem(uint256 index) internal view returns (uint256) {
+        return _queue[index];
+    }
+
+    function _emptyQueue() internal {
+        _queueSize = 0;
+    }
+}

--- a/contracts/contracts/libraries/AccumulatingArray.sol
+++ b/contracts/contracts/libraries/AccumulatingArray.sol
@@ -41,4 +41,8 @@ library AccumulatingArray {
         }
         return out;
     }
+
+    function isEmpty(Data memory self) internal pure returns (bool) {
+        return (self.index == 0);
+    }
 }

--- a/contracts/contracts/mocks/TestCAPE.sol
+++ b/contracts/contracts/mocks/TestCAPE.sol
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: Unlicense
+//SPDX-License-Identifier: Unlicensed
 pragma solidity ^0.8.0;
 
 import "../CAPE.sol";
@@ -83,5 +83,14 @@ contract TestCAPE is CAPE {
         returns (bytes memory)
     {
         return _computeAssetDescription(erc20Address, sponsor);
+    }
+
+    // Functions to access the pending deposits queue
+    function getPendingDepositsAtIndex(uint256 index) public returns (uint256) {
+        return _queue[index];
+    }
+
+    function isPendingDepositsQueueEmpty() public returns (bool) {
+        return _isQueueEmpty();
     }
 }

--- a/contracts/contracts/mocks/TestQueue.sol
+++ b/contracts/contracts/mocks/TestQueue.sol
@@ -1,0 +1,26 @@
+//SPDX-License-Identifier: Unlicensed
+pragma solidity ^0.8.0;
+
+import {Queue} from "../Queue.sol";
+
+contract TestQueue is Queue {
+    function isQueueEmpty() public returns (bool) {
+        return _isQueueEmpty();
+    }
+
+    function getQueueSize() public returns (uint256) {
+        return _getQueueSize();
+    }
+
+    function pushToQueue(uint256 recordCommitment) public {
+        _pushToQueue(recordCommitment);
+    }
+
+    function getQueueElem(uint256 index) public returns (uint256) {
+        return _getQueueElem(index);
+    }
+
+    function emptyQueue() public {
+        _emptyQueue();
+    }
+}

--- a/contracts/rust/Cargo.toml
+++ b/contracts/rust/Cargo.toml
@@ -19,7 +19,12 @@ universal-param = { git = "ssh://git@github.com/SpectrumXYZ/universal-param.git"
 zerok-macros = { git = "ssh://git@github.com/SpectrumXYZ/zerok-macros.git" }
 arbitrary = { version="1.0", features=["derive"] }
 arbitrary-wrappers = { git = "ssh://git@github.com/SpectrumXYZ/arbitrary-wrappers.git" }
-ethers = { git = "https://github.com/gakonst/ethers-rs", branch = "master" }
+
+# We need the legacy feature in order to avoid gas estimation issues. See https://github.com/gakonst/ethers-rs/issues/825
+ethers = { features=["legacy"], git = "https://github.com/gakonst/ethers-rs", branch = "master" }
+ethers-core = { features=["legacy"], git = "https://github.com/gakonst/ethers-rs", branch = "master" }
+ethers-contract = { features=["legacy"], git = "https://github.com/gakonst/ethers-rs", branch = "master" }
+
 itertools = "0.10.1" # needed for jf-aap to compile
 ark-std = "0.3.0"
 serde_json = "1.0.67"

--- a/contracts/rust/src/cape/note_types.rs
+++ b/contracts/rust/src/cape/note_types.rs
@@ -1,0 +1,216 @@
+#![cfg(test)]
+
+use crate::assertion::Matcher;
+use crate::cape::{CapeBlock, DOM_SEP_CAPE_BURN};
+use crate::deploy::deploy_cape_test;
+use crate::ledger::CapeLedger;
+use crate::types as sol;
+use crate::types::{GenericInto, MerkleRootSol};
+use anyhow::Result;
+use ethers::prelude::U256;
+use jf_aap::keys::UserPubKey;
+use jf_aap::utils::TxnsParams;
+use jf_aap::TransactionNote;
+use reef::Ledger;
+
+// TODO add a test to check if includedNotes is computed correctly
+
+#[test]
+fn test_note_types() {
+    // TODO
+    // let rng = ark_std::test_rng();
+    // assert_eq!(get_note_type(TransferNote::rand_for_test(&rng)), 0u8);
+    // assert_eq!(get_note_type(FreezeNote::rand_for_test(&rng)), 1u8);
+    // assert_eq!(get_note_type(MintNote::rand_for_test(&rng)), 2u8);
+    // assert_eq!(get_note_type(create_test_burn_note(&rng)), 3u8);
+}
+
+#[tokio::test]
+async fn test_contains_burn_prefix() {
+    let contract = deploy_cape_test().await;
+
+    let dom_sep_str = std::str::from_utf8(DOM_SEP_CAPE_BURN).unwrap();
+    for (input, expected) in [
+        ("", false),
+        ("x", false),
+        ("TRICAPE bur", false),
+        ("more data but but still not a burn", false),
+        (dom_sep_str, true),
+        (&(dom_sep_str.to_owned() + "more stuff"), true),
+    ] {
+        assert_eq!(
+            contract
+                .contains_burn_prefix(input.as_bytes().to_vec().into())
+                .call()
+                .await
+                .unwrap(),
+            expected
+        )
+    }
+}
+
+#[tokio::test]
+async fn test_contains_burn_destination() {
+    let contract = deploy_cape_test().await;
+
+    for (input, expected) in [
+        (
+            // ok, zero address from byte 12 to 32
+            "ffffffffffffffffffffffff0000000000000000000000000000000000000000",
+            true,
+        ),
+        (
+            // ok, with more data
+            "ffffffffffffffffffffffff0000000000000000000000000000000000000000ff",
+            true,
+        ),
+        (
+            // wrong address
+            "ffffffffffffffffffffffff0000000000000000000000000000000000000001",
+            false,
+        ),
+        (
+            // address too short
+            "ffffffffffffffffffffffff00000000000000000000000000000000000000",
+            false,
+        ),
+    ] {
+        assert_eq!(
+            contract
+                .contains_burn_destination(hex::decode(input).unwrap().into())
+                .call()
+                .await
+                .unwrap(),
+            expected
+        )
+    }
+}
+
+#[tokio::test]
+async fn test_contains_burn_record() {
+    let contract = deploy_cape_test().await;
+
+    assert!(!contract
+        .contains_burn_record(sol::BurnNote::default())
+        .call()
+        .await
+        .unwrap());
+
+    // TODO test with a valid note
+    // let mut rng = ark_std::test_rng();
+    // let note = TransferNote::...
+    // let burned_ro = RecordOpening::rand_for_test(&mut rng);
+    // let burn_note = BurnNote::generate(note, burned_ro);
+    // assert!(contract.contains_burn_record(burn_note).call().await.unwrap());
+}
+
+#[tokio::test]
+async fn test_check_burn_bad_prefix() {
+    let contract = deploy_cape_test().await;
+    let mut note = sol::BurnNote::default();
+    let extra = [
+        hex::decode("ffffffffffffffffffffffff").unwrap(),
+        hex::decode(b"0000000000000000000000000000000000000000").unwrap(),
+    ]
+    .concat();
+    note.transfer_note.aux_info.extra_proof_bound_data = extra.into();
+
+    let call = contract.check_burn(note).call().await;
+    call.should_revert_with_message("Bad burn tag");
+}
+
+#[tokio::test]
+async fn test_check_burn_bad_destination() {
+    let contract = deploy_cape_test().await;
+    let mut note = sol::BurnNote::default();
+    let extra = [
+        DOM_SEP_CAPE_BURN.to_vec(),
+        hex::decode("000000000000000000000000000000000000000f").unwrap(),
+    ]
+    .concat();
+    note.transfer_note.aux_info.extra_proof_bound_data = extra.into();
+
+    let call = contract.check_burn(note).call().await;
+    call.should_revert_with_message("Bad burn destination");
+}
+
+#[tokio::test]
+async fn test_check_burn_bad_record_commitment() {
+    let contract = deploy_cape_test().await;
+    let mut note = sol::BurnNote::default();
+    let extra = [
+        DOM_SEP_CAPE_BURN.to_vec(),
+        hex::decode("0000000000000000000000000000000000000000").unwrap(),
+    ]
+    .concat();
+    note.transfer_note.aux_info.extra_proof_bound_data = extra.into();
+
+    note.transfer_note.output_commitments.push(U256::from(1));
+    note.transfer_note.output_commitments.push(U256::from(2));
+
+    let call = contract.check_burn(note).call().await;
+    call.should_revert_with_message("Bad record commitment");
+}
+
+// TODO Add test for check_burn that passes
+
+// TODO integration test to check if check_burn is hooked up correctly in
+// main block validation loop.
+
+#[tokio::test]
+async fn test_check_transfer_expired_note_triggers_an_error() -> Result<()> {
+    let rng = &mut ark_std::test_rng();
+    let params = TxnsParams::generate_txns(rng, 1, 0, 0, CapeLedger::merkle_height());
+    let miner = UserPubKey::default();
+
+    let tx = params.txns[0].clone();
+    let root = tx.merkle_root();
+
+    let cape_block = CapeBlock::generate(params.txns, vec![], miner.address())?;
+    let valid_until = match tx {
+        TransactionNote::Transfer(note) => note.aux_info.valid_until,
+        TransactionNote::Mint(_) => todo!(),
+        TransactionNote::Freeze(_) => todo!(),
+    };
+
+    // Set the height to expire note
+    let contract = deploy_cape_test().await;
+    contract.set_height(valid_until + 1).send().await?.await?;
+
+    contract
+        .add_root(root.generic_into::<MerkleRootSol>().0)
+        .send()
+        .await?
+        .await?;
+
+    let call = contract
+        .submit_cape_block(cape_block.into(), vec![])
+        .call()
+        .await;
+
+    call.should_revert_with_message("Expired note");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_check_transfer_note_with_burn_prefix_rejected() {
+    let contract = deploy_cape_test().await;
+    let mut note = sol::TransferNote::default();
+    let extra = [
+        DOM_SEP_CAPE_BURN.to_vec(),
+        hex::decode("0000000000000000000000000000000000000000").unwrap(),
+    ]
+    .concat();
+    note.aux_info.extra_proof_bound_data = extra.into();
+
+    let call = contract.check_transfer(note).call().await;
+    call.should_revert_with_message("Burn prefix in transfer note");
+}
+
+#[tokio::test]
+async fn test_check_transfer_without_burn_prefix_accepted() {
+    let contract = deploy_cape_test().await;
+    let note = sol::TransferNote::default();
+    assert!(contract.check_transfer(note).call().await.is_ok());
+}

--- a/contracts/rust/src/cape/submit_block.rs
+++ b/contracts/rust/src/cape/submit_block.rs
@@ -1,0 +1,249 @@
+#![cfg(test)]
+
+use crate::assertion::Matcher;
+use crate::cape::CapeBlock;
+use crate::deploy::deploy_cape_test;
+use crate::ledger::CapeLedger;
+use crate::types as sol;
+use crate::types::{GenericInto, MerkleRootSol, NullifierSol};
+use anyhow::Result;
+use ethers::prelude::U256;
+use jf_aap::keys::UserPubKey;
+use jf_aap::structs::{AssetCodeSeed, InternalAssetCode};
+use jf_aap::utils::TxnsParams;
+use rand::Rng;
+use reef::Ledger;
+
+#[tokio::test]
+async fn test_compute_max_commitments() {
+    let contract = deploy_cape_test().await;
+    let rng = &mut ark_std::test_rng();
+
+    for _run in 0..10 {
+        let mut num_comms = 0;
+
+        let burn_notes = (0..rng.gen_range(0..2))
+            .map(|_| {
+                let mut note = sol::BurnNote::default();
+                let n = rng.gen_range(0..10);
+                note.transfer_note.output_commitments = [U256::from(0)].repeat(n);
+                num_comms += n;
+                note
+            })
+            .collect();
+
+        let transfer_notes = (0..rng.gen_range(0..2))
+            .map(|_| {
+                let mut note = sol::TransferNote::default();
+                let n = rng.gen_range(0..10);
+                note.output_commitments = [U256::from(0)].repeat(n);
+                num_comms += n;
+                note
+            })
+            .collect();
+
+        let freeze_notes = (0..rng.gen_range(0..2))
+            .map(|_| {
+                let mut note = sol::FreezeNote::default();
+                let n = rng.gen_range(0..10);
+                note.output_commitments = [U256::from(0)].repeat(n);
+                num_comms += n;
+                note
+            })
+            .collect();
+
+        let mint_notes = (0..rng.gen_range(0..2))
+            .map(|_| {
+                num_comms += 2; // change and mint
+                sol::MintNote::default()
+            })
+            .collect();
+
+        let cape_block = sol::CapeBlock {
+            transfer_notes,
+            mint_notes,
+            freeze_notes,
+            burn_notes,
+            note_types: vec![],
+            miner_addr: UserPubKey::default().address().into(),
+        };
+
+        let max_comms_sol = contract
+            .compute_max_commitments(cape_block)
+            .call()
+            .await
+            .unwrap();
+
+        assert_eq!(max_comms_sol, U256::from(num_comms));
+    }
+}
+
+#[tokio::test]
+async fn test_submit_empty_block_to_cape_contract() -> Result<()> {
+    let contract = deploy_cape_test().await;
+
+    // Create an empty block transactions
+    let rng = &mut ark_std::test_rng();
+    let params = TxnsParams::generate_txns(rng, 0, 0, 0, CapeLedger::merkle_height());
+    let miner = UserPubKey::default();
+
+    let cape_block = CapeBlock::generate(params.txns, vec![], miner.address())?;
+
+    // Submitting an empty block does not yield a reject from the contract
+    contract
+        .submit_cape_block(cape_block.into(), vec![])
+        .send()
+        .await?
+        .await?;
+
+    // The height is incremented anyways.
+    assert_eq!(contract.block_height().call().await?, 1u64);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_submit_block_to_cape_contract() -> Result<()> {
+    let contract = deploy_cape_test().await;
+
+    // Create three transactions
+    let rng = &mut ark_std::test_rng();
+    let num_transfer_txn = 1;
+    let num_mint_txn = 1;
+    let num_freeze_txn = 1;
+    let params = TxnsParams::generate_txns(
+        rng,
+        num_transfer_txn,
+        num_mint_txn,
+        num_freeze_txn,
+        CapeLedger::merkle_height(),
+    );
+    let miner = UserPubKey::default();
+
+    let nf = params.txns[0].nullifiers()[0];
+    let root = params.txns[0].merkle_root();
+
+    // temporarily no burn txn yet.
+    let cape_block = CapeBlock::generate(params.txns, vec![], miner.address())?;
+
+    // Check that some nullifier is not yet inserted
+    assert!(
+        !contract
+            .nullifiers(nf.generic_into::<NullifierSol>().0)
+            .call()
+            .await?
+    );
+
+    // TODO should not require to manually submit the root here
+    contract
+        .add_root(root.generic_into::<MerkleRootSol>().0)
+        .send()
+        .await?
+        .await?;
+
+    // Submit to the contract
+    contract
+        .submit_cape_block(cape_block.into(), vec![])
+        .send()
+        .await?
+        .await?;
+
+    // Check that now the nullifier has been inserted
+    assert!(
+        contract
+            .nullifiers(nf.generic_into::<NullifierSol>().0)
+            .call()
+            .await?
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_block_height() -> Result<()> {
+    let contract = deploy_cape_test().await;
+    assert_eq!(contract.block_height().call().await?, 0u64);
+
+    let rng = &mut ark_std::test_rng();
+    let params = TxnsParams::generate_txns(rng, 1, 0, 0, CapeLedger::merkle_height());
+    let miner = UserPubKey::default();
+
+    let root = params.txns[0].merkle_root();
+    let cape_block = CapeBlock::generate(params.txns, vec![], miner.address())?;
+
+    // TODO should not require to manually submit the root here
+    contract
+        .add_root(root.generic_into::<MerkleRootSol>().0)
+        .send()
+        .await?
+        .await?;
+
+    contract
+        .submit_cape_block(cape_block.into(), vec![])
+        .send()
+        .await?
+        .await?;
+
+    assert_eq!(contract.block_height().call().await?, 1u64);
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_event_block_committed() -> Result<()> {
+    let contract = deploy_cape_test().await;
+
+    let rng = &mut ark_std::test_rng();
+    let params = TxnsParams::generate_txns(rng, 1, 0, 0, CapeLedger::merkle_height());
+    let miner = UserPubKey::default();
+
+    let root = params.txns[0].merkle_root();
+    let cape_block = CapeBlock::generate(params.txns, vec![], miner.address())?;
+
+    // TODO should not require to manually submit the root here
+    contract
+        .add_root(root.generic_into::<MerkleRootSol>().0)
+        .send()
+        .await?
+        .await?;
+
+    contract
+        .submit_cape_block(cape_block.into(), vec![])
+        .send()
+        .await?
+        .await?;
+
+    let logs = contract
+        .block_committed_filter()
+        .from_block(0u64)
+        .query()
+        .await?;
+    assert_eq!(logs[0].height, 1);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_check_domestic_asset_code_in_submit_cape_block() -> Result<()> {
+    let contract = deploy_cape_test().await;
+    let rng = &mut ark_std::test_rng();
+    let params = TxnsParams::generate_txns(rng, 0, 1, 0, CapeLedger::merkle_height());
+
+    contract
+        .add_root(params.merkle_root.generic_into::<MerkleRootSol>().0)
+        .send()
+        .await?
+        .await?;
+
+    let mut block = CapeBlock::generate(params.txns, vec![], UserPubKey::default().address())?;
+
+    // Set a wrong internal asset code on the mint note
+    block.mint_notes[0].mint_internal_asset_code =
+        InternalAssetCode::new(AssetCodeSeed::generate(rng), b"description");
+
+    contract
+        .submit_cape_block(block.into(), vec![])
+        .call()
+        .await
+        .should_revert_with_message("Wrong domestic asset code");
+
+    Ok(())
+}

--- a/contracts/rust/src/cape/wrapping.rs
+++ b/contracts/rust/src/cape/wrapping.rs
@@ -1,0 +1,234 @@
+#![cfg(test)]
+
+use crate::assertion::Matcher;
+use crate::deploy::deploy_cape_test;
+use crate::state::{erc20_asset_description, Erc20Code, EthereumAddr};
+use crate::types as sol;
+use crate::types::{AssetCodeSol, GenericInto};
+use anyhow::Result;
+use ethers::prelude::Address;
+use jf_aap::structs::{AssetCode, AssetCodeSeed, RecordOpening};
+
+mod errors_when_calling_deposit_erc20 {
+    use super::*;
+    use crate::deploy::{deploy_cape_test, deploy_erc20_token};
+    use crate::state::{erc20_asset_description, Erc20Code, EthereumAddr};
+    use crate::types as sol;
+    use anyhow::Result;
+    use ethers::prelude::U256;
+    use jf_aap::keys::UserPubKey;
+    use jf_aap::structs::{AssetCode, AssetDefinition, AssetPolicy, FreezeFlag, RecordOpening};
+
+    enum WrongCallDepositErc20 {
+        AssetTypeNotRegistered,
+        WrongAssetDefinition,
+        SkipApproval,
+    }
+
+    async fn call_deposit_erc20_with_error_helper(
+        expected_error_message: &str,
+        wrong_call: WrongCallDepositErc20,
+    ) -> Result<()> {
+        let cape_contract = deploy_cape_test().await;
+
+        // Deploy ERC20 token contract. The caller of this method receives 1000 * 10**18 tokens
+        let erc20_token_contract = deploy_erc20_token().await;
+
+        let owner_of_erc20_tokens_client = erc20_token_contract.client().clone();
+        let owner_of_erc20_tokens_client_address = owner_of_erc20_tokens_client.address();
+        let erc20_address = erc20_token_contract.address();
+
+        // Approve
+        let contract_address = cape_contract.address();
+        let deposited_amount = 1000;
+
+        let amount_u256 = U256::from(deposited_amount);
+
+        match wrong_call {
+            WrongCallDepositErc20::AssetTypeNotRegistered
+            | WrongCallDepositErc20::WrongAssetDefinition => {
+                erc20_token_contract
+                    .approve(contract_address, amount_u256)
+                    .send()
+                    .await?
+                    .await?;
+            }
+            WrongCallDepositErc20::SkipApproval => {}
+        };
+
+        // Call CAPE contract function
+
+        // Sponsor asset type
+        let rng = &mut ark_std::test_rng();
+        let erc20_code = Erc20Code(EthereumAddr(erc20_address.to_fixed_bytes()));
+        let sponsor = owner_of_erc20_tokens_client_address;
+
+        let description =
+            erc20_asset_description(&erc20_code, &EthereumAddr(sponsor.to_fixed_bytes()));
+        let asset_code = AssetCode::new_foreign(&description);
+        let asset_def = AssetDefinition::new(asset_code, AssetPolicy::rand_for_test(rng)).unwrap();
+        let asset_def_sol = asset_def.clone().generic_into::<sol::AssetDefinition>();
+
+        match wrong_call {
+            WrongCallDepositErc20::SkipApproval | WrongCallDepositErc20::WrongAssetDefinition => {
+                cape_contract
+                    .sponsor_cape_asset(erc20_address, asset_def_sol)
+                    .send()
+                    .await?
+                    .await?;
+            }
+            WrongCallDepositErc20::AssetTypeNotRegistered => {}
+        }
+
+        let asset_def_for_ro = match wrong_call {
+            WrongCallDepositErc20::SkipApproval | WrongCallDepositErc20::AssetTypeNotRegistered => {
+                asset_def
+            }
+            WrongCallDepositErc20::WrongAssetDefinition => AssetDefinition::rand_for_test(rng),
+        };
+
+        // Build record opening
+        let ro = RecordOpening::new(
+            rng,
+            deposited_amount,
+            asset_def_for_ro,
+            UserPubKey::default(),
+            FreezeFlag::Unfrozen,
+        );
+
+        // We call the CAPE contract from the address that owns the ERC20 tokens
+        let call = cape_contract
+            .deposit_erc_20(
+                ro.clone().generic_into::<sol::RecordOpening>(),
+                erc20_address,
+            )
+            .from(owner_of_erc20_tokens_client_address)
+            .call()
+            .await;
+
+        call.should_revert_with_message(&expected_error_message);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn the_asset_code_is_incorrect() -> Result<()> {
+        call_deposit_erc20_with_error_helper(
+            "Wrong foreign asset code",
+            WrongCallDepositErc20::WrongAssetDefinition,
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn the_asset_type_is_not_registered() -> Result<()> {
+        call_deposit_erc20_with_error_helper(
+            "asset definition not registered",
+            WrongCallDepositErc20::AssetTypeNotRegistered,
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn the_erc20_token_were_not_approved_before_calling_deposit_erc20() -> Result<()> {
+        call_deposit_erc20_with_error_helper(
+            "ERC20: transfer amount exceeds allowance",
+            WrongCallDepositErc20::SkipApproval,
+        )
+        .await
+    }
+}
+
+#[tokio::test]
+async fn test_erc20_description() -> Result<()> {
+    let contract = deploy_cape_test().await;
+    let sponsor = Address::random();
+    let asset_address = Address::random();
+    let asset_code = Erc20Code(EthereumAddr(asset_address.to_fixed_bytes()));
+    let description = erc20_asset_description(&asset_code, &EthereumAddr(sponsor.to_fixed_bytes()));
+    let ret = contract
+        .compute_asset_description(asset_address, sponsor)
+        .call()
+        .await?;
+    assert_eq!(ret.to_vec(), description);
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_check_foreign_asset_code() -> Result<()> {
+    let contract = deploy_cape_test().await;
+
+    // Fails for random record opening with random asset code.
+    let rng = &mut ark_std::test_rng();
+    let ro = RecordOpening::rand_for_test(rng);
+    contract
+        .check_foreign_asset_code(
+            ro.asset_def.code.generic_into::<sol::AssetCodeSol>().0,
+            Address::random(),
+        )
+        .call()
+        .await
+        .should_revert_with_message("Wrong foreign asset code");
+
+    let erc20_address = Address::random();
+    // This is the first account from the test mnemonic
+    // TODO define elsewhere to make it usable from other tests
+    let sponsor = "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266".parse::<Address>()?;
+    let erc20_code = Erc20Code(EthereumAddr(erc20_address.to_fixed_bytes()));
+
+    // Fails for domestic asset code.
+    let domestic_asset_code =
+        AssetCode::new_domestic(AssetCodeSeed::generate(rng), erc20_address.as_bytes());
+    contract
+        .check_foreign_asset_code(
+            domestic_asset_code.generic_into::<AssetCodeSol>().0,
+            erc20_address,
+        )
+        .from(sponsor)
+        .call()
+        .await
+        .should_revert_with_message("Wrong foreign asset code");
+
+    // Fails if txn sender address does not match sponsor in asset code.
+    let description_wrong_sponsor = erc20_asset_description(
+        &erc20_code,
+        &EthereumAddr(Address::random().to_fixed_bytes()),
+    );
+    let asset_code_wrong_sponsor = AssetCode::new_foreign(&description_wrong_sponsor);
+    contract
+        .check_foreign_asset_code(
+            asset_code_wrong_sponsor.generic_into::<AssetCodeSol>().0,
+            sponsor,
+        )
+        .from(sponsor)
+        .call()
+        .await
+        .should_revert_with_message("Wrong foreign asset code");
+
+    let description = erc20_asset_description(&erc20_code, &EthereumAddr(sponsor.to_fixed_bytes()));
+    let asset_code = AssetCode::new_foreign(&description);
+
+    // Fails for random erc20 address.
+    contract
+        .check_foreign_asset_code(
+            asset_code.generic_into::<sol::AssetCodeSol>().0,
+            Address::random(),
+        )
+        .from(sponsor)
+        .call()
+        .await
+        .should_revert_with_message("Wrong foreign asset code");
+
+    // Passes for correctly derived asset code
+    contract
+        .check_foreign_asset_code(
+            asset_code.generic_into::<sol::AssetCodeSol>().0,
+            erc20_address,
+        )
+        .from(sponsor)
+        .call()
+        .await
+        .should_not_revert();
+
+    Ok(())
+}

--- a/contracts/rust/src/deploy.rs
+++ b/contracts/rust/src/deploy.rs
@@ -1,0 +1,69 @@
+use crate::cape::CAPEConstructorArgs;
+use crate::ethereum::{deploy, get_funded_deployer};
+use crate::state::CAPE_MERKLE_HEIGHT;
+use crate::types::{GenericInto, Greeter, SimpleToken, TestCAPE, TestQueue};
+use anyhow::Result;
+use ethers::prelude::{k256::ecdsa::SigningKey, Address, Http, Provider, SignerMiddleware, Wallet};
+use std::path::Path;
+
+pub async fn deploy_cape_test() -> TestCAPE<SignerMiddleware<Provider<Http>, Wallet<SigningKey>>> {
+    let client = get_funded_deployer().await.unwrap();
+    // deploy the PlonkVerifier
+    let verifier = deploy(
+        client.clone(),
+        Path::new("../abi/contracts/verifier/PlonkVerifier.sol/PlonkVerifier"),
+        (),
+    )
+    .await
+    .unwrap();
+
+    // deploy TestCAPE.sol
+    let contract = deploy(
+        client.clone(),
+        Path::new("../abi/contracts/mocks/TestCAPE.sol/TestCAPE"),
+        CAPEConstructorArgs::new(CAPE_MERKLE_HEIGHT, 10, verifier.address())
+            .generic_into::<(u8, u64, Address)>(),
+    )
+    .await
+    .unwrap();
+    TestCAPE::new(contract.address(), client)
+}
+
+pub async fn deploy_queue_test() -> TestQueue<SignerMiddleware<Provider<Http>, Wallet<SigningKey>>>
+{
+    let client = get_funded_deployer().await.unwrap();
+    let call = deploy(
+        client.clone(),
+        Path::new("../abi/contracts/mocks/TestQueue.sol/TestQueue"),
+        (),
+    )
+    .await;
+    let contract = call.unwrap();
+    TestQueue::new(contract.address(), client)
+}
+
+pub async fn deploy_erc20_token(
+) -> SimpleToken<SignerMiddleware<Provider<Http>, Wallet<SigningKey>>> {
+    let client = get_funded_deployer().await.unwrap();
+    let call = deploy(
+        client.clone(),
+        Path::new("../abi/contracts/SimpleToken.sol/SimpleToken"),
+        (),
+    )
+    .await;
+    let contract = call.unwrap();
+    SimpleToken::new(contract.address(), client)
+}
+
+pub async fn deploy_greeter_contract(
+) -> Result<Greeter<SignerMiddleware<Provider<Http>, Wallet<SigningKey>>>> {
+    let client = get_funded_deployer().await.unwrap();
+    let contract = deploy(
+        client.clone(),
+        Path::new("../abi/contracts/Greeter.sol/Greeter"),
+        ("Initial Greeting".to_string(),),
+    )
+    .await
+    .unwrap();
+    Ok(Greeter::new(contract.address(), client))
+}

--- a/contracts/rust/src/helpers.rs
+++ b/contracts/rust/src/helpers.rs
@@ -3,6 +3,13 @@ use ark_ff::{BigInteger, PrimeField};
 use ark_serialize::*;
 use ethers::prelude::*;
 use jf_aap::structs::Nullifier;
+use jf_aap::NodeValue;
+
+// TODO create a function should_revert similar to the one in the `assertion` module
+pub fn eth_transaction_has_been_mined(receipt: &TransactionReceipt) -> bool {
+    let status = receipt.status.unwrap();
+    status == U64::from(1)
+}
 
 pub fn convert_u256_to_bytes_le(num: U256) -> Vec<u8> {
     let mut u8_arr = [0u8; 32];
@@ -12,6 +19,17 @@ pub fn convert_u256_to_bytes_le(num: U256) -> Vec<u8> {
 
 pub fn convert_fr254_to_u256(f: Fr254) -> U256 {
     U256::from(f.into_repr().to_bytes_be().as_slice())
+}
+
+pub fn compare_merkle_root_from_contract_and_jf_tree(
+    contract_root_value: U256,
+    jellyfish_mt_root_value: NodeValue,
+) -> bool {
+    convert_u256_to_bytes_le(contract_root_value).as_slice()
+        == jellyfish_mt_root_value
+            .to_scalar()
+            .into_repr()
+            .to_bytes_le()
 }
 
 pub fn convert_nullifier_to_u256(n: &Nullifier) -> U256 {

--- a/contracts/rust/src/lib.rs
+++ b/contracts/rust/src/lib.rs
@@ -7,11 +7,13 @@ mod bn254;
 pub mod cape;
 #[cfg(test)]
 mod cape_e2e_tests;
+pub mod deploy;
 mod ed_on_bn254;
 pub mod ethereum;
 pub mod helpers;
 pub mod ledger;
 mod plonk_verifier;
+mod queue;
 mod records_merkle_tree;
 mod root_store;
 pub mod state;

--- a/contracts/rust/src/queue.rs
+++ b/contracts/rust/src/queue.rs
@@ -1,0 +1,53 @@
+#![cfg(test)]
+use crate::deploy::deploy_queue_test;
+use anyhow::Result;
+use ethers::prelude::U256;
+
+#[tokio::test]
+async fn test_asset_pending_deposits_queue() -> Result<()> {
+    let contract = deploy_queue_test().await;
+
+    // At the beginning the queue is empty
+    let is_queue_empty = contract.is_queue_empty().call().await?;
+    assert!(is_queue_empty);
+
+    // Check the queue size
+    let queue_size = contract.get_queue_size().call().await?;
+    assert_eq!(queue_size, U256::from(0));
+
+    let queue_values = vec![U256::from(3), U256::from(7), U256::from(1), U256::from(23)];
+
+    // We insert the values in the queue
+    for v in queue_values.clone() {
+        contract.push_to_queue(v).send().await?.await?;
+    }
+
+    // We check the queue is not empty
+    let is_queue_empty = contract.is_queue_empty().call().await?;
+    assert!(!is_queue_empty);
+
+    // Check the queue size again
+    let l = queue_values.len();
+    let queue_size = contract.get_queue_size().call().await?;
+    assert_eq!(queue_size, U256::from(l));
+
+    // We get all the elements of the queue one by one
+    let mut new_queue = vec![];
+    for i in 0..l {
+        let element = contract.get_queue_elem(U256::from(i)).call().await?;
+        new_queue.push(element);
+    }
+
+    // We check the queue is still NOT empty
+    let is_queue_empty = contract.is_queue_empty().call().await?;
+    assert!(!is_queue_empty);
+
+    // We check we got all the elements
+    assert_eq!(queue_values, new_queue);
+
+    // We empty the queue and check it is empty
+    contract.empty_queue().send().await?.await?;
+    assert!(contract.is_queue_empty().call().await?);
+
+    Ok(())
+}

--- a/contracts/rust/src/records_merkle_tree/mod.rs
+++ b/contracts/rust/src/records_merkle_tree/mod.rs
@@ -133,10 +133,8 @@ fn parse_flattened_frontier(flattened_frontier: &[Fr254], uid: u64) -> MerkleFro
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::helpers::{convert_fr254_to_u256, convert_u256_to_bytes_le};
+    use crate::helpers::{compare_merkle_root_from_contract_and_jf_tree, convert_fr254_to_u256};
     use ark_ed_on_bn254::Fq as Fr254;
-    use ark_ff::BigInteger;
-    use ark_ff::PrimeField;
     use ark_std::UniformRand;
     use jf_primitives::merkle_tree::{MerkleTree, NodeValue};
 
@@ -152,8 +150,7 @@ mod tests {
 
         assert_eq!(
             should_be_equal,
-            (convert_u256_to_bytes_le(root_value_u256).as_slice()
-                == root_fr254.to_scalar().into_repr().to_bytes_le())
+            compare_merkle_root_from_contract_and_jf_tree(root_value_u256, root_fr254)
         );
     }
 

--- a/contracts/rust/src/types.rs
+++ b/contracts/rust/src/types.rs
@@ -83,6 +83,15 @@ abigen!(
     TestVerifyingKeys,
     "../abi/contracts/mocks/TestVerifyingKeys.sol/TestVerifyingKeys/abi.json",
     event_derives(serde::Deserialize, serde::Serialize);
+
+    SimpleToken,
+    "../abi/contracts/SimpleToken.sol/SimpleToken/abi.json",
+    event_derives(serde::Deserialize, serde::Serialize);
+
+    TestQueue,
+    "../abi/contracts/mocks/TestQueue.sol/TestQueue/abi.json",
+    event_derives(serde::Deserialize, serde::Serialize);
+
 );
 
 impl From<ark_bn254::G1Affine> for G1Point {
@@ -228,7 +237,7 @@ impl From<jf_plonk::testing_apis::Challenges<Fr>> for Challenges {
     }
 }
 
-/// a helper trait to help with fully-qualified generic into synatx:
+/// a helper trait to help with fully-qualified generic into syntax:
 /// `x.generic_into::<DestType>();`
 /// This is particularly helpful in a chained `generic_into()` statements.
 pub trait GenericInto {
@@ -264,7 +273,7 @@ macro_rules! jf_conversion_for_u256_new_type {
                 let mut bytes = vec![0u8; 32];
                 v_sol.0.to_little_endian(&mut bytes);
                 let v: $jf_type = CanonicalDeserialize::deserialize(&bytes[..])
-                    .expect("Failed to deserialze U256.");
+                    .expect("Failed to deserialize U256.");
                 v
             }
         }

--- a/contracts/rust/tests/wrapping.rs
+++ b/contracts/rust/tests/wrapping.rs
@@ -1,0 +1,332 @@
+/// This file contains integration tests for the CAPE contract.
+use anyhow::Result;
+use cap_rust_sandbox::cape::CapeBlock;
+use cap_rust_sandbox::deploy::{deploy_cape_test, deploy_erc20_token};
+use cap_rust_sandbox::helpers::{
+    compare_merkle_root_from_contract_and_jf_tree, eth_transaction_has_been_mined,
+};
+use cap_rust_sandbox::ledger::CapeLedger;
+use cap_rust_sandbox::state::{erc20_asset_description, Erc20Code, EthereumAddr};
+use cap_rust_sandbox::types as sol;
+use cap_rust_sandbox::types::{
+    GenericInto, MerkleRootSol, RecordOpening as RecordOpeningSol, SimpleToken, TestCAPE,
+};
+use ethers::abi::AbiDecode;
+use ethers::prelude::{
+    k256::ecdsa::SigningKey, Http, Provider, SignerMiddleware, Wallet, H160, U256,
+};
+use jf_aap::keys::UserPubKey;
+use jf_aap::structs::{
+    AssetCode, AssetDefinition, AssetPolicy, FreezeFlag, RecordCommitment, RecordOpening,
+};
+use jf_aap::utils::TxnsParams;
+use jf_aap::{MerkleTree, NodeValue};
+use reef::Ledger;
+use std::sync::Arc;
+
+fn generate_cape_block_and_merkle_root(tree_height: u8) -> Result<(CapeBlock, NodeValue)> {
+    let rng = &mut ark_std::test_rng();
+    let num_transfer_txn = 1;
+    let num_mint_txn = 1;
+    let num_freeze_txn = 1;
+    let params = TxnsParams::generate_txns(
+        rng,
+        num_transfer_txn,
+        num_mint_txn,
+        num_freeze_txn,
+        tree_height,
+    );
+    let miner = UserPubKey::default();
+
+    let root = params.txns[0].merkle_root();
+
+    let cape_block = CapeBlock::generate(params.txns, vec![], miner.address())?;
+    Ok((cape_block, root))
+}
+
+#[derive(Clone)]
+struct ContractsInfo {
+    cape_contract: TestCAPE<SignerMiddleware<Provider<Http>, Wallet<SigningKey>>>,
+    erc20_token_contract: SimpleToken<SignerMiddleware<Provider<Http>, Wallet<SigningKey>>>,
+    cape_contract_for_erc20_owner: TestCAPE<SignerMiddleware<Provider<Http>, Wallet<SigningKey>>>,
+    erc20_token_address: H160,
+    owner_of_erc20_tokens_client: SignerMiddleware<Provider<Http>, Wallet<SigningKey>>,
+    owner_of_erc20_tokens_client_address: H160,
+}
+
+// TODO try to parametrize the struct with the trait M:Middleware
+impl ContractsInfo {
+    pub async fn new(
+        cape_contract_ref: &TestCAPE<SignerMiddleware<Provider<Http>, Wallet<SigningKey>>>,
+        erc20_token_contract_ref: &SimpleToken<
+            SignerMiddleware<Provider<Http>, Wallet<SigningKey>>,
+        >,
+    ) -> Self {
+        let cape_contract = cape_contract_ref.clone();
+        let erc20_token_contract = erc20_token_contract_ref.clone();
+
+        let erc20_token_address = erc20_token_contract.address();
+        let owner_of_erc20_tokens_client = erc20_token_contract.client().clone();
+        let owner_of_erc20_tokens_client_address = owner_of_erc20_tokens_client.address();
+
+        let cape_contract_for_erc20_owner = TestCAPE::new(
+            cape_contract_ref.address(),
+            Arc::from(owner_of_erc20_tokens_client.clone()),
+        );
+
+        Self {
+            cape_contract,
+            erc20_token_contract,
+            cape_contract_for_erc20_owner,
+            erc20_token_address,
+            owner_of_erc20_tokens_client,
+            owner_of_erc20_tokens_client_address,
+        }
+    }
+}
+
+async fn check_pending_deposits_queue_at_index(
+    queue_index: usize,
+    log_id: usize,
+    ro: RecordOpening,
+    contracts_info: ContractsInfo,
+) -> Result<()> {
+    let block_id = 0;
+    let logs = contracts_info
+        .cape_contract_for_erc20_owner
+        .erc_20_tokens_deposited_filter()
+        .from_block(block_id)
+        .query()
+        .await?;
+    let ro_bytes = logs[log_id].ro_bytes.clone();
+    let ro_sol: RecordOpeningSol = AbiDecode::decode(ro_bytes).unwrap();
+    let expected_ro = RecordOpening::from(ro_sol);
+    assert_eq!(expected_ro, ro);
+    assert_eq!(
+        logs[log_id].erc_20_token_address,
+        contracts_info.erc20_token_address
+    );
+    assert_eq!(
+        logs[log_id].from,
+        contracts_info.owner_of_erc20_tokens_client_address
+    );
+
+    let deposit_record_commitment_contract = contracts_info
+        .cape_contract
+        .get_pending_deposits_at_index(U256::from(queue_index))
+        .call()
+        .await?;
+    let deposit_record_commitment = RecordCommitment::from(&ro);
+    let expected_deposit_record_commitment_sol = deposit_record_commitment
+        .clone()
+        .generic_into::<sol::RecordCommitmentSol>()
+        .0;
+    assert_eq!(
+        deposit_record_commitment_contract,
+        expected_deposit_record_commitment_sol
+    );
+
+    Ok(())
+}
+
+async fn call_and_check_deposit_erc20(
+    register_asset: bool,
+    deposited_amount: u64,
+    expected_owner_balance_before_call: &str,
+    expected_owner_balance_after_call: &str,
+    expected_contract_balance_after_call: u64,
+    contracts_info: ContractsInfo,
+) -> Result<RecordOpening> {
+    let balance_caller = contracts_info
+        .erc20_token_contract
+        .balance_of(contracts_info.owner_of_erc20_tokens_client_address)
+        .call()
+        .await?;
+
+    assert_eq!(
+        balance_caller,
+        U256::from_dec_str(expected_owner_balance_before_call)?
+    );
+
+    // Approve
+    let contract_address = contracts_info.cape_contract.address();
+
+    let amount_u256 = U256::from(deposited_amount);
+    contracts_info
+        .erc20_token_contract
+        .approve(contract_address, amount_u256)
+        .send()
+        .await?
+        .await?;
+
+    // Call CAPE contract function
+
+    // Sponsor asset type
+    let rng = &mut ark_std::test_rng();
+    let erc20_code = Erc20Code(EthereumAddr(
+        contracts_info.erc20_token_address.to_fixed_bytes(),
+    ));
+
+    // TODO the sponsor should be different from the erc20 tokens owner
+    let sponsor = contracts_info.owner_of_erc20_tokens_client_address;
+
+    let description = erc20_asset_description(&erc20_code, &EthereumAddr(sponsor.to_fixed_bytes()));
+    let asset_code = AssetCode::new_foreign(&description);
+    let asset_def = AssetDefinition::new(asset_code, AssetPolicy::rand_for_test(rng)).unwrap();
+    let asset_def_sol = asset_def.clone().generic_into::<sol::AssetDefinition>();
+
+    if register_asset {
+        contracts_info
+            .cape_contract
+            .sponsor_cape_asset(contracts_info.erc20_token_address, asset_def_sol)
+            .send()
+            .await?
+            .await?;
+    }
+
+    // Build record opening
+    let ro = RecordOpening::new(
+        rng,
+        deposited_amount,
+        asset_def,
+        UserPubKey::default(),
+        FreezeFlag::Unfrozen,
+    );
+
+    // We call the CAPE contract from the address that owns the ERC20 tokens
+    contracts_info
+        .cape_contract_for_erc20_owner
+        .deposit_erc_20(
+            ro.clone().generic_into::<sol::RecordOpening>(),
+            contracts_info.erc20_token_address,
+        )
+        .send()
+        .await?
+        .await?;
+
+    // Check the money has been transferred
+    let balance_owner_erc20 = contracts_info
+        .erc20_token_contract
+        .balance_of(contracts_info.owner_of_erc20_tokens_client_address)
+        .call()
+        .await?;
+    assert_eq!(
+        balance_owner_erc20,
+        U256::from_dec_str(expected_owner_balance_after_call)?
+    );
+
+    let balance_contract_erc20 = contracts_info
+        .erc20_token_contract
+        .balance_of(contract_address)
+        .call()
+        .await?;
+    assert_eq!(
+        balance_contract_erc20,
+        U256::from(expected_contract_balance_after_call)
+    );
+
+    Ok(ro)
+}
+
+#[tokio::test]
+async fn integration_test_wrapping_erc20_tokens() -> Result<()> {
+    // Create a block containing three transactions
+    // Note: we build the block at the beginning of this function because it is time consuming and
+    // triggers some timeout with the ethereum client if done after deploying the contracts.
+    let (cape_block, root) =
+        generate_cape_block_and_merkle_root(CapeLedger::merkle_height()).unwrap();
+
+    // Deploy CAPE contract
+    let cape_contract = deploy_cape_test().await;
+
+    // Deploy ERC20 token contract. The caller of this method receives 1000 * 10**18 tokens
+    let erc20_token_contract = deploy_erc20_token().await;
+
+    let contracts_info = ContractsInfo::new(&cape_contract, &erc20_token_contract).await;
+
+    let ro1 = call_and_check_deposit_erc20(
+        true,
+        1000u64,
+        "1000000000000000000000",
+        "999999999999999999000",
+        1000u64,
+        contracts_info.clone(),
+    )
+    .await?;
+
+    let ro2 = call_and_check_deposit_erc20(
+        false,
+        2000u64,
+        "999999999999999999000",
+        "999999999999999997000",
+        3000u64,
+        contracts_info.clone(),
+    )
+    .await?;
+
+    // Check that the pending deposits queue has been updated correctly
+    check_pending_deposits_queue_at_index(0, 0, ro1.clone(), contracts_info.clone()).await?;
+
+    check_pending_deposits_queue_at_index(1, 1, ro2.clone(), contracts_info).await?;
+
+    assert!(
+        !cape_contract
+            .is_pending_deposits_queue_empty()
+            .call()
+            .await?
+    );
+
+    // Now we submit a new block to the contract and check that the records merkle tree is updated correctly
+    cape_contract
+        .add_root(root.generic_into::<MerkleRootSol>().0)
+        .send()
+        .await?
+        .await?;
+
+    // Submit to the contract
+    let receipt = cape_contract
+        .submit_cape_block(cape_block.clone().into(), vec![])
+        .gas(U256::from(10_000_000))
+        .send()
+        .await?
+        .await;
+
+    assert!(eth_transaction_has_been_mined(&receipt.unwrap().unwrap()));
+
+    // Check the block has been processed.
+    assert_eq!(cape_contract.block_height().call().await?, 1u64);
+
+    // Handle local version of the records merkle tree
+    let mut mt = MerkleTree::new(CapeLedger::merkle_height()).unwrap();
+
+    // Add the output commitments of the transactions
+    let output_commitments = cape_block.get_list_of_input_record_commitments();
+    for comm in output_commitments {
+        mt.push(comm.to_field_element());
+    }
+
+    // Add the deposit record commitments
+    let rc1 = RecordCommitment::from(&ro1);
+    mt.push(rc1.to_field_element());
+    let rc2 = RecordCommitment::from(&ro2);
+    mt.push(rc2.to_field_element());
+
+    // Check the merkle tree root has been updated correctly
+    let cape_contract_root_value = cape_contract.get_root_value().call().await?;
+    let mt_root_value = mt.commitment().root_value;
+
+    assert!(compare_merkle_root_from_contract_and_jf_tree(
+        cape_contract_root_value,
+        mt_root_value
+    ));
+
+    // Check that the pending deposits queue is empty
+    let is_queue_empty = cape_contract
+        .is_pending_deposits_queue_empty()
+        .call()
+        .await?;
+
+    assert!(is_queue_empty);
+
+    Ok(())
+}


### PR DESCRIPTION
Implemented the logic to send the ERC20 tokens to the CAPE contract. 

Closes #121 and #154.

List of files that have been moved only (without any further change) (cc  @sveitser)
* contracts/rust/src/cape/mod.rs
* contracts/rust/src/cape/note_types.rs
* contracts/rust/src/cape/submit_block.rs
