### PR TITLE
[Draft] Update dependencies as far as they will go

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1046,9 +1046,9 @@ checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
 
 [[package]]
 name = "camino"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d74260d9bf6944e2208aa46841b4b8f0d7ffc0849a06837b2f510337f86b2b"
+checksum = "6f3132262930b0522068049f5870a856ab8affc80c70d08b6ecb785771a6fc23"
 dependencies = [
  "serde",
 ]
@@ -1069,7 +1069,7 @@ dependencies = [
  "async-std",
  "async-trait",
  "bincode",
- "ethers 0.6.0 (git+https://github.com/gakonst/ethers-rs?branch=master)",
+ "ethers",
  "futures",
  "generic-array 0.14.5",
  "hex",
@@ -1089,14 +1089,14 @@ dependencies = [
  "sha3",
  "strum_macros",
  "tokio",
- "zerok_lib 0.1.0 (git+ssh://git@github.com/SpectrumXYZ/spectrum.git?rev=b86e2e0ef24aa313a51a82875309f562fe0184d0)",
+ "zerok_lib",
 ]
 
 [[package]]
 name = "cape-workflow"
 version = "0.1.0"
 dependencies = [
- "ethers 0.6.0 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers",
  "itertools 0.10.3",
  "jf-aap",
  "jf-rescue",
@@ -1141,7 +1141,7 @@ dependencies = [
  "tracing-futures",
  "tracing-subscriber 0.2.25",
  "tracing-test",
- "zerok_lib 0.1.0 (git+ssh://git@github.com/SpectrumXYZ/spectrum.git?rev=80d568119b72c7ea33728fa48ad45215869fe345)",
+ "zerok_lib",
 ]
 
 [[package]]
@@ -1186,9 +1186,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chacha20"
-version = "0.7.3"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f08493fa7707effc63254c66c6ea908675912493cd67952eda23c09fae2610b1"
+checksum = "01b72a433d0cf2aef113ba70f62634c56fddb0f244e6377185c56a7cadbd8f91"
 dependencies = [
  "cfg-if 1.0.0",
  "cipher 0.3.0",
@@ -1197,24 +1197,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "chacha20"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01b72a433d0cf2aef113ba70f62634c56fddb0f244e6377185c56a7cadbd8f91"
-dependencies = [
- "cfg-if 1.0.0",
- "cipher 0.3.0",
- "cpufeatures",
-]
-
-[[package]]
 name = "chacha20poly1305"
-version = "0.8.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6547abe025f4027edacd9edaa357aded014eecec42a5070d9b885c3c334aba2"
+checksum = "3b84ed6d1d5f7aa9bdde921a5090e0ca4d934d250ea3b402a5fab3a994e28a2a"
 dependencies = [
  "aead 0.4.3",
- "chacha20 0.7.3",
+ "chacha20",
  "cipher 0.3.0",
  "poly1305",
  "zeroize",
@@ -1542,14 +1531,14 @@ dependencies = [
 
 [[package]]
 name = "crypto_box"
-version = "0.6.1"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a41c3b5488899ea68ee2dd99e089b95629c6407150bda8e56f2602d78fec8e4"
+checksum = "5c2b974d4124d78e9d061e06ff1d3a2aaef9d925b5f23bb3e0b9410240279f16"
 dependencies = [
- "chacha20 0.7.3",
+ "chacha20",
  "chacha20poly1305",
  "rand_core 0.6.3",
- "salsa20",
+ "salsa20 0.9.0",
  "x25519-dalek",
  "xsalsa20poly1305",
  "zeroize",
@@ -1937,10 +1926,12 @@ dependencies = [
 [[package]]
 name = "ethabi"
 version = "16.0.0"
-source = "git+https://github.com/rust-ethereum/ethabi?branch=master#5781964ae40a7e16fafe7d1bfcc39cb17989e3c5"
+source = "git+https://github.com/rust-ethereum/ethabi?branch=master#c622438f9fd2ac2f9b3c38ecb1ca760c069d9ec2"
 dependencies = [
  "ethereum-types",
  "hex",
+ "once_cell",
+ "regex",
  "serde",
  "serde_json",
  "sha3",
@@ -1978,50 +1969,24 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs?branch=master#77dcccb7bae83a896a319e116bd34a6844b896ba"
+source = "git+https://github.com/gakonst/ethers-rs?rev=e0ee03328332776f5f18a52b968ea3f62df982cb#e0ee03328332776f5f18a52b968ea3f62df982cb"
 dependencies = [
- "ethers-addressbook 0.1.0 (git+https://github.com/gakonst/ethers-rs?branch=master)",
- "ethers-contract 0.6.0 (git+https://github.com/gakonst/ethers-rs?branch=master)",
- "ethers-core 0.6.0 (git+https://github.com/gakonst/ethers-rs?branch=master)",
- "ethers-etherscan 0.2.0 (git+https://github.com/gakonst/ethers-rs?branch=master)",
- "ethers-middleware 0.6.0 (git+https://github.com/gakonst/ethers-rs?branch=master)",
- "ethers-providers 0.6.0 (git+https://github.com/gakonst/ethers-rs?branch=master)",
- "ethers-signers 0.6.0 (git+https://github.com/gakonst/ethers-rs?branch=master)",
- "ethers-solc 0.1.0 (git+https://github.com/gakonst/ethers-rs?branch=master)",
-]
-
-[[package]]
-name = "ethers"
-version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#77dcccb7bae83a896a319e116bd34a6844b896ba"
-dependencies = [
- "ethers-addressbook 0.1.0 (git+https://github.com/gakonst/ethers-rs)",
- "ethers-contract 0.6.0 (git+https://github.com/gakonst/ethers-rs)",
- "ethers-core 0.6.0 (git+https://github.com/gakonst/ethers-rs)",
- "ethers-etherscan 0.2.0 (git+https://github.com/gakonst/ethers-rs)",
- "ethers-middleware 0.6.0 (git+https://github.com/gakonst/ethers-rs)",
- "ethers-providers 0.6.0 (git+https://github.com/gakonst/ethers-rs)",
- "ethers-signers 0.6.0 (git+https://github.com/gakonst/ethers-rs)",
- "ethers-solc 0.1.0 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-addressbook",
+ "ethers-contract",
+ "ethers-core",
+ "ethers-etherscan",
+ "ethers-middleware",
+ "ethers-providers",
+ "ethers-signers",
+ "ethers-solc",
 ]
 
 [[package]]
 name = "ethers-addressbook"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/ethers-rs?branch=master#77dcccb7bae83a896a319e116bd34a6844b896ba"
+source = "git+https://github.com/gakonst/ethers-rs?rev=e0ee03328332776f5f18a52b968ea3f62df982cb#e0ee03328332776f5f18a52b968ea3f62df982cb"
 dependencies = [
- "ethers-core 0.6.0 (git+https://github.com/gakonst/ethers-rs?branch=master)",
- "once_cell",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "ethers-addressbook"
-version = "0.1.0"
-source = "git+https://github.com/gakonst/ethers-rs#77dcccb7bae83a896a319e116bd34a6844b896ba"
-dependencies = [
- "ethers-core 0.6.0 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-core",
  "once_cell",
  "serde",
  "serde_json",
@@ -2030,30 +1995,12 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs?branch=master#77dcccb7bae83a896a319e116bd34a6844b896ba"
+source = "git+https://github.com/gakonst/ethers-rs?rev=e0ee03328332776f5f18a52b968ea3f62df982cb#e0ee03328332776f5f18a52b968ea3f62df982cb"
 dependencies = [
- "ethers-contract-abigen 0.6.0 (git+https://github.com/gakonst/ethers-rs?branch=master)",
- "ethers-contract-derive 0.6.0 (git+https://github.com/gakonst/ethers-rs?branch=master)",
- "ethers-core 0.6.0 (git+https://github.com/gakonst/ethers-rs?branch=master)",
- "ethers-providers 0.6.0 (git+https://github.com/gakonst/ethers-rs?branch=master)",
- "futures-util",
- "hex",
- "once_cell",
- "pin-project",
- "serde",
- "serde_json",
- "thiserror",
-]
-
-[[package]]
-name = "ethers-contract"
-version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#77dcccb7bae83a896a319e116bd34a6844b896ba"
-dependencies = [
- "ethers-contract-abigen 0.6.0 (git+https://github.com/gakonst/ethers-rs)",
- "ethers-contract-derive 0.6.0 (git+https://github.com/gakonst/ethers-rs)",
- "ethers-core 0.6.0 (git+https://github.com/gakonst/ethers-rs)",
- "ethers-providers 0.6.0 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-contract-abigen",
+ "ethers-contract-derive",
+ "ethers-core",
+ "ethers-providers",
  "futures-util",
  "hex",
  "once_cell",
@@ -2066,36 +2013,13 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs?branch=master#77dcccb7bae83a896a319e116bd34a6844b896ba"
+source = "git+https://github.com/gakonst/ethers-rs?rev=e0ee03328332776f5f18a52b968ea3f62df982cb#e0ee03328332776f5f18a52b968ea3f62df982cb"
 dependencies = [
  "Inflector",
  "anyhow",
  "cfg-if 1.0.0",
  "dunce",
- "ethers-core 0.6.0 (git+https://github.com/gakonst/ethers-rs?branch=master)",
- "getrandom 0.2.4",
- "hex",
- "once_cell",
- "proc-macro2",
- "quote",
- "reqwest",
- "serde",
- "serde_json",
- "syn",
- "url",
- "walkdir",
-]
-
-[[package]]
-name = "ethers-contract-abigen"
-version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#77dcccb7bae83a896a319e116bd34a6844b896ba"
-dependencies = [
- "Inflector",
- "anyhow",
- "cfg-if 1.0.0",
- "dunce",
- "ethers-core 0.6.0 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-core",
  "getrandom 0.2.4",
  "hex",
  "once_cell",
@@ -2112,24 +2036,10 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs?branch=master#77dcccb7bae83a896a319e116bd34a6844b896ba"
+source = "git+https://github.com/gakonst/ethers-rs?rev=e0ee03328332776f5f18a52b968ea3f62df982cb#e0ee03328332776f5f18a52b968ea3f62df982cb"
 dependencies = [
- "ethers-contract-abigen 0.6.0 (git+https://github.com/gakonst/ethers-rs?branch=master)",
- "ethers-core 0.6.0 (git+https://github.com/gakonst/ethers-rs?branch=master)",
- "hex",
- "proc-macro2",
- "quote",
- "serde_json",
- "syn",
-]
-
-[[package]]
-name = "ethers-contract-derive"
-version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#77dcccb7bae83a896a319e116bd34a6844b896ba"
-dependencies = [
- "ethers-contract-abigen 0.6.0 (git+https://github.com/gakonst/ethers-rs)",
- "ethers-core 0.6.0 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-contract-abigen",
+ "ethers-core",
  "hex",
  "proc-macro2",
  "quote",
@@ -2140,35 +2050,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs?branch=master#77dcccb7bae83a896a319e116bd34a6844b896ba"
-dependencies = [
- "arrayvec 0.7.2",
- "bytes 1.1.0",
- "cargo_metadata",
- "convert_case",
- "ecdsa",
- "elliptic-curve",
- "ethabi",
- "generic-array 0.14.5",
- "hex",
- "k256",
- "once_cell",
- "proc-macro2",
- "quote",
- "rand 0.8.4",
- "rlp",
- "rlp-derive",
- "serde",
- "serde_json",
- "syn",
- "thiserror",
- "tiny-keccak",
-]
-
-[[package]]
-name = "ethers-core"
-version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#77dcccb7bae83a896a319e116bd34a6844b896ba"
+source = "git+https://github.com/gakonst/ethers-rs?rev=e0ee03328332776f5f18a52b968ea3f62df982cb#e0ee03328332776f5f18a52b968ea3f62df982cb"
 dependencies = [
  "arrayvec 0.7.2",
  "bytes 1.1.0",
@@ -2196,22 +2078,9 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "0.2.0"
-source = "git+https://github.com/gakonst/ethers-rs?branch=master#77dcccb7bae83a896a319e116bd34a6844b896ba"
+source = "git+https://github.com/gakonst/ethers-rs?rev=e0ee03328332776f5f18a52b968ea3f62df982cb#e0ee03328332776f5f18a52b968ea3f62df982cb"
 dependencies = [
- "ethers-core 0.6.0 (git+https://github.com/gakonst/ethers-rs?branch=master)",
- "reqwest",
- "serde",
- "serde-aux",
- "serde_json",
- "thiserror",
-]
-
-[[package]]
-name = "ethers-etherscan"
-version = "0.2.0"
-source = "git+https://github.com/gakonst/ethers-rs#77dcccb7bae83a896a319e116bd34a6844b896ba"
-dependencies = [
- "ethers-core 0.6.0 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-core",
  "reqwest",
  "serde",
  "serde-aux",
@@ -2222,37 +2091,14 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs?branch=master#77dcccb7bae83a896a319e116bd34a6844b896ba"
+source = "git+https://github.com/gakonst/ethers-rs?rev=e0ee03328332776f5f18a52b968ea3f62df982cb#e0ee03328332776f5f18a52b968ea3f62df982cb"
 dependencies = [
  "async-trait",
- "ethers-contract 0.6.0 (git+https://github.com/gakonst/ethers-rs?branch=master)",
- "ethers-core 0.6.0 (git+https://github.com/gakonst/ethers-rs?branch=master)",
- "ethers-etherscan 0.2.0 (git+https://github.com/gakonst/ethers-rs?branch=master)",
- "ethers-providers 0.6.0 (git+https://github.com/gakonst/ethers-rs?branch=master)",
- "ethers-signers 0.6.0 (git+https://github.com/gakonst/ethers-rs?branch=master)",
- "futures-util",
- "instant",
- "reqwest",
- "serde",
- "serde_json",
- "thiserror",
- "tokio",
- "tracing",
- "tracing-futures",
- "url",
-]
-
-[[package]]
-name = "ethers-middleware"
-version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#77dcccb7bae83a896a319e116bd34a6844b896ba"
-dependencies = [
- "async-trait",
- "ethers-contract 0.6.0 (git+https://github.com/gakonst/ethers-rs)",
- "ethers-core 0.6.0 (git+https://github.com/gakonst/ethers-rs)",
- "ethers-etherscan 0.2.0 (git+https://github.com/gakonst/ethers-rs)",
- "ethers-providers 0.6.0 (git+https://github.com/gakonst/ethers-rs)",
- "ethers-signers 0.6.0 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-contract",
+ "ethers-core",
+ "ethers-etherscan",
+ "ethers-providers",
+ "ethers-signers",
  "futures-util",
  "instant",
  "reqwest",
@@ -2268,40 +2114,11 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs?branch=master#77dcccb7bae83a896a319e116bd34a6844b896ba"
+source = "git+https://github.com/gakonst/ethers-rs?rev=e0ee03328332776f5f18a52b968ea3f62df982cb#e0ee03328332776f5f18a52b968ea3f62df982cb"
 dependencies = [
  "async-trait",
  "auto_impl",
- "ethers-core 0.6.0 (git+https://github.com/gakonst/ethers-rs?branch=master)",
- "futures-channel",
- "futures-core",
- "futures-timer",
- "futures-util",
- "hex",
- "parking_lot",
- "pin-project",
- "reqwest",
- "serde",
- "serde_json",
- "thiserror",
- "tracing",
- "tracing-futures",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-timer",
- "web-sys",
- "ws_stream_wasm",
-]
-
-[[package]]
-name = "ethers-providers"
-version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#77dcccb7bae83a896a319e116bd34a6844b896ba"
-dependencies = [
- "async-trait",
- "auto_impl",
- "ethers-core 0.6.0 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-core",
  "futures-channel",
  "futures-core",
  "futures-timer",
@@ -2326,35 +2143,14 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs?branch=master#77dcccb7bae83a896a319e116bd34a6844b896ba"
+source = "git+https://github.com/gakonst/ethers-rs?rev=e0ee03328332776f5f18a52b968ea3f62df982cb#e0ee03328332776f5f18a52b968ea3f62df982cb"
 dependencies = [
  "async-trait",
  "coins-bip32",
  "coins-bip39",
  "elliptic-curve",
  "eth-keystore",
- "ethers-core 0.6.0 (git+https://github.com/gakonst/ethers-rs?branch=master)",
- "futures-executor",
- "futures-util",
- "hex",
- "home",
- "rand 0.8.4",
- "semver 1.0.4",
- "sha2 0.9.9",
- "thiserror",
-]
-
-[[package]]
-name = "ethers-signers"
-version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs#77dcccb7bae83a896a319e116bd34a6844b896ba"
-dependencies = [
- "async-trait",
- "coins-bip32",
- "coins-bip39",
- "elliptic-curve",
- "eth-keystore",
- "ethers-core 0.6.0 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-core",
  "futures-executor",
  "futures-util",
  "hex",
@@ -2368,39 +2164,11 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/ethers-rs?branch=master#77dcccb7bae83a896a319e116bd34a6844b896ba"
+source = "git+https://github.com/gakonst/ethers-rs?rev=e0ee03328332776f5f18a52b968ea3f62df982cb#e0ee03328332776f5f18a52b968ea3f62df982cb"
 dependencies = [
  "colored",
  "dunce",
- "ethers-core 0.6.0 (git+https://github.com/gakonst/ethers-rs?branch=master)",
- "getrandom 0.2.4",
- "glob",
- "hex",
- "home",
- "md-5",
- "num_cpus",
- "once_cell",
- "rayon",
- "regex",
- "semver 1.0.4",
- "serde",
- "serde_json",
- "sha2 0.9.9",
- "solang-parser",
- "thiserror",
- "tiny-keccak",
- "tracing",
- "walkdir",
-]
-
-[[package]]
-name = "ethers-solc"
-version = "0.1.0"
-source = "git+https://github.com/gakonst/ethers-rs#77dcccb7bae83a896a319e116bd34a6844b896ba"
-dependencies = [
- "colored",
- "dunce",
- "ethers-core 0.6.0 (git+https://github.com/gakonst/ethers-rs)",
+ "ethers-core",
  "getrandom 0.2.4",
  "glob",
  "hex",
@@ -3200,7 +2968,7 @@ checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 [[package]]
 name = "jf-aap"
 version = "0.0.1"
-source = "git+ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git?rev=c9ded9359d82447ec5644c8df2921c16ba26c660#c9ded9359d82447ec5644c8df2921c16ba26c660"
+source = "git+ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git?rev=9e8f3a5ba77dcc523539689716cfe878d196469e#9e8f3a5ba77dcc523539689716cfe878d196469e"
 dependencies = [
  "anyhow",
  "ark-bls12-377",
@@ -3240,7 +3008,7 @@ dependencies = [
 [[package]]
 name = "jf-plonk"
 version = "0.0.1"
-source = "git+ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git?rev=c9ded9359d82447ec5644c8df2921c16ba26c660#c9ded9359d82447ec5644c8df2921c16ba26c660"
+source = "git+ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git?rev=9e8f3a5ba77dcc523539689716cfe878d196469e#9e8f3a5ba77dcc523539689716cfe878d196469e"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-381",
@@ -3271,7 +3039,7 @@ dependencies = [
 [[package]]
 name = "jf-primitives"
 version = "0.0.1"
-source = "git+ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git?rev=c9ded9359d82447ec5644c8df2921c16ba26c660#c9ded9359d82447ec5644c8df2921c16ba26c660"
+source = "git+ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git?rev=9e8f3a5ba77dcc523539689716cfe878d196469e#9e8f3a5ba77dcc523539689716cfe878d196469e"
 dependencies = [
  "ark-ec",
  "ark-ff",
@@ -3294,7 +3062,7 @@ dependencies = [
 [[package]]
 name = "jf-rescue"
 version = "0.0.1"
-source = "git+ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git?rev=c9ded9359d82447ec5644c8df2921c16ba26c660#c9ded9359d82447ec5644c8df2921c16ba26c660"
+source = "git+ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git?rev=9e8f3a5ba77dcc523539689716cfe878d196469e#9e8f3a5ba77dcc523539689716cfe878d196469e"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-381",
@@ -3322,7 +3090,7 @@ dependencies = [
 [[package]]
 name = "jf-utils"
 version = "0.0.1"
-source = "git+ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git?rev=c9ded9359d82447ec5644c8df2921c16ba26c660#c9ded9359d82447ec5644c8df2921c16ba26c660"
+source = "git+ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git?rev=9e8f3a5ba77dcc523539689716cfe878d196469e#9e8f3a5ba77dcc523539689716cfe878d196469e"
 dependencies = [
  "anyhow",
  "ark-ec",
@@ -3339,7 +3107,7 @@ dependencies = [
 [[package]]
 name = "jf-utils-derive"
 version = "0.1.0"
-source = "git+ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git?rev=c9ded9359d82447ec5644c8df2921c16ba26c660#c9ded9359d82447ec5644c8df2921c16ba26c660"
+source = "git+ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git?rev=9e8f3a5ba77dcc523539689716cfe878d196469e#9e8f3a5ba77dcc523539689716cfe878d196469e"
 dependencies = [
  "ark-serialize",
  "ark-std",
@@ -3349,18 +3117,18 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.55"
+version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cc9ffccd38c451a86bf13657df244e9c3f37493cce8e5e21e940963777acc84"
+checksum = "a38fc24e30fd564ce974c02bf1d337caddff65be6cc4735a1f7eab22a7440f04"
 dependencies = [
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "k256"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7511aa19fa182a8a4885760c4e5675b17173b02ae86ec5d376d34f5278c874b9"
+checksum = "1cc5937366afd3b38071f400d1ce5bd8b1d40b5083cc14e6f8dbcc4032a7f5bb"
 dependencies = [
  "cfg-if 1.0.0",
  "ecdsa",
@@ -3387,9 +3155,9 @@ dependencies = [
 
 [[package]]
 name = "lalrpop"
-version = "0.19.6"
+version = "0.19.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15174f1c529af5bf1283c3bc0058266b483a67156f79589fab2a25e23cf8988"
+checksum = "852b75a095da6b69da8c5557731c3afd06525d4f655a4fc1c799e2ec8bc4dce4"
 dependencies = [
  "ascii-canvas",
  "atty",
@@ -3410,9 +3178,9 @@ dependencies = [
 
 [[package]]
 name = "lalrpop-util"
-version = "0.19.6"
+version = "0.19.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e58cce361efcc90ba8a0a5f982c741ff86b603495bb15a998412e957dcd278"
+checksum = "d6d265705249fe209280676d8f68887859fa42e1d34f342fc05bd47726a5e188"
 dependencies = [
  "regex",
 ]
@@ -3425,9 +3193,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.112"
+version = "0.2.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
+checksum = "eef78b64d87775463c549fbd80e19249ef436ea3bf1de2a1eb7e717ec7fab1e9"
 
 [[package]]
 name = "libnghttp2-sys"
@@ -4532,7 +4300,7 @@ dependencies = [
  "bincode",
  "cap-rust-sandbox",
  "dirs",
- "ethers 0.6.0 (git+https://github.com/gakonst/ethers-rs?branch=master)",
+ "ethers",
  "jf-aap",
  "jf-primitives",
  "lazy_static",
@@ -4546,7 +4314,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber 0.3.6",
- "zerok_lib 0.1.0 (git+ssh://git@github.com/SpectrumXYZ/spectrum.git?rev=b86e2e0ef24aa313a51a82875309f562fe0184d0)",
+ "zerok_lib",
 ]
 
 [[package]]
@@ -4803,6 +4571,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ecbd2eb639fd7cab5804a0837fe373cc2172d15437e804c054a9fb885cb923b0"
 dependencies = [
  "cipher 0.3.0",
+]
+
+[[package]]
+name = "salsa20"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0fbb5f676da676c260ba276a8f43a8dc67cf02d1438423aeb1c677a7212686"
+dependencies = [
+ "cipher 0.3.0",
  "zeroize",
 ]
 
@@ -4841,7 +4618,7 @@ dependencies = [
  "hmac 0.11.0",
  "password-hash",
  "pbkdf2",
- "salsa20",
+ "salsa20 0.8.1",
  "sha2 0.9.9",
 ]
 
@@ -4958,9 +4735,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.74"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2bb9cd061c5865d345bb02ca49fcef1391741b672b54a0bf7b679badec3142"
+checksum = "c059c05b48c5c0067d4b4b2b4f0732dd65feb52daf7e0ea09cd87e7dadc1af79"
 dependencies = [
  "itoa 1.0.1",
  "ryu",
@@ -4980,12 +4757,12 @@ dependencies = [
 
 [[package]]
 name = "serde_urlencoded"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 0.4.8",
+ "itoa 1.0.1",
  "ryu",
  "serde",
 ]
@@ -5028,9 +4805,18 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
+checksum = "c1da05c97445caa12d05e848c4a4fcbbea29e748ac28f7e80e9b010392063770"
+dependencies = [
+ "sha1_smol",
+]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
 
 [[package]]
 name = "sha2"
@@ -5127,9 +4913,9 @@ dependencies = [
 
 [[package]]
 name = "siphasher"
-version = "0.3.7"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "533494a8f9b724d33625ab53c6c4800f7cc445895924a8ef649222dcb76e938b"
+checksum = "a86232ab60fa71287d7f2ddae4a7073f6b7aac33631c3015abb556f08c6d0a3e"
 
 [[package]]
 name = "slab"
@@ -5178,9 +4964,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dc90fe6c7be1a323296982db1836d1ea9e47b6839496dde9a541bc496df3516"
+checksum = "0f82496b90c36d70af5fcd482edaa2e0bd16fade569de1330405fecbbdac736b"
 dependencies = [
  "libc",
  "winapi",
@@ -5331,9 +5117,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "structopt"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b9788f4202aa75c240ecc9c15c65185e6a39ccdeb0fd5d008b98825464c87c"
+checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
 dependencies = [
  "clap",
  "lazy_static",
@@ -5409,9 +5195,9 @@ checksum = "45f6ee7c7b87caf59549e9fe45d6a69c75c8019e79e212a835c5da0e92f0ba08"
 
 [[package]]
 name = "syn"
-version = "1.0.85"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a684ac3dcd8913827e18cd09a68384ee66c1de24157e3c556c9ab16d85695fb7"
+checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6143,9 +5929,9 @@ checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
+checksum = "25f1af7423d8588a3d840681122e72e6a24ddbcb3f0ec385cac0d12d24256c06"
 dependencies = [
  "cfg-if 1.0.0",
  "serde",
@@ -6155,9 +5941,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a317bf8f9fba2476b4b2c85ef4c4af8ff39c3c7f0cdfeed4f82c34a880aa837b"
+checksum = "8b21c0df030f5a177f3cba22e9bc4322695ec43e7257d865302900290bcdedca"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -6170,9 +5956,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8d7523cb1f2a4c96c1317ca690031b714a51cc14e05f712446691f413f5d39"
+checksum = "2eb6ec270a31b1d3c7e266b999739109abce8b6c87e4b31fcfcd788b65267395"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -6182,9 +5968,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56146e7c495528bf6587663bea13a8eb588d39b36b679d83972e1a2dbbdacf9"
+checksum = "2f4203d69e40a52ee523b2529a773d5ffc1dc0071801c87b3d270b471b80ed01"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6192,9 +5978,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
+checksum = "bfa8a30d46208db204854cadbb5d4baf5fcf8071ba5bf48190c3e59937962ebc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6205,9 +5991,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
+checksum = "3d958d035c4438e28c70e4321a2911302f10135ce78a9c7834c0cab4123d06a2"
 
 [[package]]
 name = "wasm-timer"
@@ -6226,9 +6012,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.55"
+version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38eb105f1c59d9eaa6b5cdc92b859d85b926e82cb2e0945cd0c9259faa6fe9fb"
+checksum = "c060b319f29dd25724f09a2ba1418f142f539b2be99fbf4d2d5a8f7330afb8eb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6382,14 +6168,14 @@ dependencies = [
 
 [[package]]
 name = "xsalsa20poly1305"
-version = "0.7.2"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e0f69b133860e3614a4d4fdd6f0d7fe3219e9d67a7e8cd537676a4ebc8313db"
+checksum = "e68bcb965d6c650091450b95cea12f07dcd299a01c15e2f9433b0813ea3c0886"
 dependencies = [
  "aead 0.4.3",
  "poly1305",
  "rand_core 0.6.3",
- "salsa20",
+ "salsa20 0.9.0",
  "subtle",
  "zeroize",
 ]
@@ -6418,17 +6204,7 @@ dependencies = [
 [[package]]
 name = "zerok-macros"
 version = "0.1.0"
-source = "git+ssh://git@github.com/SpectrumXYZ/spectrum.git?rev=80d568119b72c7ea33728fa48ad45215869fe345#80d568119b72c7ea33728fa48ad45215869fe345"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "zerok-macros"
-version = "0.1.0"
-source = "git+ssh://git@github.com/SpectrumXYZ/spectrum.git?rev=b86e2e0ef24aa313a51a82875309f562fe0184d0#b86e2e0ef24aa313a51a82875309f562fe0184d0"
+source = "git+ssh://git@github.com/SpectrumXYZ/spectrum.git?rev=42e0ec823e30d7b32fed56d12bf2abf0a392458a#42e0ec823e30d7b32fed56d12bf2abf0a392458a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6438,7 +6214,7 @@ dependencies = [
 [[package]]
 name = "zerok_lib"
 version = "0.1.0"
-source = "git+ssh://git@github.com/SpectrumXYZ/spectrum.git?rev=80d568119b72c7ea33728fa48ad45215869fe345#80d568119b72c7ea33728fa48ad45215869fe345"
+source = "git+ssh://git@github.com/SpectrumXYZ/spectrum.git?rev=42e0ec823e30d7b32fed56d12bf2abf0a392458a#42e0ec823e30d7b32fed56d12bf2abf0a392458a"
 dependencies = [
  "arbitrary",
  "ark-ff",
@@ -6452,7 +6228,7 @@ dependencies = [
  "atomic_store",
  "bincode",
  "bitvec 0.20.4",
- "chacha20 0.8.1",
+ "chacha20",
  "chrono",
  "futures",
  "generic-array 0.14.5",
@@ -6489,62 +6265,5 @@ dependencies = [
  "tide",
  "tracing",
  "zeroize",
- "zerok-macros 0.1.0 (git+ssh://git@github.com/SpectrumXYZ/spectrum.git?rev=80d568119b72c7ea33728fa48ad45215869fe345)",
-]
-
-[[package]]
-name = "zerok_lib"
-version = "0.1.0"
-source = "git+ssh://git@github.com/SpectrumXYZ/spectrum.git?rev=b86e2e0ef24aa313a51a82875309f562fe0184d0#b86e2e0ef24aa313a51a82875309f562fe0184d0"
-dependencies = [
- "arbitrary",
- "ark-ff",
- "ark-serialize",
- "ark-std",
- "async-scoped",
- "async-std",
- "async-trait",
- "async-tungstenite 0.15.0",
- "async_executors",
- "atomic_store",
- "bincode",
- "bitvec 0.20.4",
- "chacha20 0.8.1",
- "chrono",
- "futures",
- "generic-array 0.14.5",
- "hex",
- "hmac 0.11.0",
- "itertools 0.10.3",
- "jf-aap",
- "jf-plonk",
- "jf-primitives",
- "jf-utils",
- "lazy_static",
- "mnemonic",
- "phaselock",
- "procfs",
- "rand 0.7.3",
- "rand_chacha 0.3.1",
- "rayon",
- "rpassword",
- "rust-argon2",
- "rustyline",
- "serde",
- "serde_cbor",
- "serde_derive",
- "serde_json",
- "serde_with",
- "sha3",
- "snafu",
- "strum",
- "strum_macros",
- "surf",
- "tagged-base64",
- "tempdir",
- "threshold_crypto",
- "tide",
- "tracing",
- "zeroize",
- "zerok-macros 0.1.0 (git+ssh://git@github.com/SpectrumXYZ/spectrum.git?rev=b86e2e0ef24aa313a51a82875309f562fe0184d0)",
+ "zerok-macros",
 ]

--- a/contracts/rust/Cargo.toml
+++ b/contracts/rust/Cargo.toml
@@ -7,13 +7,13 @@ edition = "2018"
 doctest = false
 
 [dependencies]
-jf-plonk = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "c9ded9359d82447ec5644c8df2921c16ba26c660"}
-jf-primitives = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "c9ded9359d82447ec5644c8df2921c16ba26c660"}
-jf-aap = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "c9ded9359d82447ec5644c8df2921c16ba26c660"}
-jf-rescue = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "c9ded9359d82447ec5644c8df2921c16ba26c660"}
-jf-utils = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "c9ded9359d82447ec5644c8df2921c16ba26c660"}
-zerok_lib = { git = "ssh://git@github.com/SpectrumXYZ/spectrum.git", rev = "b86e2e0ef24aa313a51a82875309f562fe0184d0" }
-ethers = { git = "https://github.com/gakonst/ethers-rs", branch = "master" }
+jf-plonk = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "9e8f3a5ba77dcc523539689716cfe878d196469e"}
+jf-primitives = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "9e8f3a5ba77dcc523539689716cfe878d196469e"}
+jf-aap = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "9e8f3a5ba77dcc523539689716cfe878d196469e"}
+jf-rescue = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "9e8f3a5ba77dcc523539689716cfe878d196469e"}
+jf-utils = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "9e8f3a5ba77dcc523539689716cfe878d196469e"}
+zerok_lib = { git = "ssh://git@github.com/SpectrumXYZ/spectrum.git", rev = "42e0ec823e30d7b32fed56d12bf2abf0a392458a" }
+ethers = { git = "https://github.com/gakonst/ethers-rs", rev = "e0ee03328332776f5f18a52b968ea3f62df982cb" }
 itertools = "0.10.1" # needed for jf-aap to compile
 ark-std = "0.3.0"
 serde_json = "1.0.67"

--- a/doc/workflow/Cargo.toml
+++ b/doc/workflow/Cargo.toml
@@ -4,10 +4,10 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-jf-aap = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "c9ded9359d82447ec5644c8df2921c16ba26c660" }
-jf-utils = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "c9ded9359d82447ec5644c8df2921c16ba26c660" }
-jf-rescue = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "c9ded9359d82447ec5644c8df2921c16ba26c660" }
-ethers = { git = "https://github.com/gakonst/ethers-rs", features = ["abigen"] }
+jf-aap = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "9e8f3a5ba77dcc523539689716cfe878d196469e" }
+jf-utils = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "9e8f3a5ba77dcc523539689716cfe878d196469e" }
+jf-rescue = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "9e8f3a5ba77dcc523539689716cfe878d196469e" }
+ethers = { git = "https://github.com/gakonst/ethers-rs", rev = "e0ee03328332776f5f18a52b968ea3f62df982cb", features = ["abigen"] }
 
 serde_json = "1.0.67"
 serde = { version = "1.0.124", features = ["derive"] }

--- a/relayer/Cargo.toml
+++ b/relayer/Cargo.toml
@@ -12,9 +12,9 @@ bincode = "1.3.3"
 cap-rust-sandbox = { path = "../contracts/rust" }
 dirs = "4.0"
 # may switch to `ethers = "0.6.2"` in the future; keeping this for compatibility for now
-ethers = { git = "https://github.com/gakonst/ethers-rs", branch = "master" }
-jf-aap = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "c9ded9359d82447ec5644c8df2921c16ba26c660" }
-jf-primitives = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "c9ded9359d82447ec5644c8df2921c16ba26c660" }
+ethers = { git = "https://github.com/gakonst/ethers-rs", rev = "e0ee03328332776f5f18a52b968ea3f62df982cb" }
+jf-aap = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "9e8f3a5ba77dcc523539689716cfe878d196469e" }
+jf-primitives = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "9e8f3a5ba77dcc523539689716cfe878d196469e" }
 lazy_static = "1.4.0"
 rand_chacha = { version = "0.3.1", features = ["serde1"] }
 serde = { version = "1.0.123", features = ["derive", "rc"] }
@@ -26,4 +26,4 @@ tide-websockets = "0.4.0"
 toml = "0.5"
 tracing = "0.1.26"
 tracing-subscriber = "0.3"
-zerok_lib = { git = "ssh://git@github.com/SpectrumXYZ/spectrum.git", rev = "b86e2e0ef24aa313a51a82875309f562fe0184d0" }
+zerok_lib = { git = "ssh://git@github.com/SpectrumXYZ/spectrum.git", rev = "42e0ec823e30d7b32fed56d12bf2abf0a392458a" }

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -16,10 +16,10 @@ bincode = "1.3.3"
 futures = "0.3.0"
 futures-util = "0.3.8"
 itertools = "0.10.1"
-jf-aap = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "c9ded9359d82447ec5644c8df2921c16ba26c660" }
-jf-plonk = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "c9ded9359d82447ec5644c8df2921c16ba26c660" }
-jf-primitives = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "c9ded9359d82447ec5644c8df2921c16ba26c660"}
-jf-utils = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "c9ded9359d82447ec5644c8df2921c16ba26c660"}
+jf-aap = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "9e8f3a5ba77dcc523539689716cfe878d196469e" }
+jf-plonk = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "9e8f3a5ba77dcc523539689716cfe878d196469e" }
+jf-primitives = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "9e8f3a5ba77dcc523539689716cfe878d196469e"}
+jf-utils = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "9e8f3a5ba77dcc523539689716cfe878d196469e"}
 lazy_static = "1.4.0"
 markdown = "0.3"
 rand_chacha = "0.3.1"
@@ -40,7 +40,7 @@ tracing = "0.1.26"
 tracing-distributed = "0.3.1"
 tracing-futures = "0.2"
 tracing-subscriber = "0.2.19"
-zerok_lib = { git = "ssh://git@github.com/SpectrumXYZ/spectrum.git", rev = "80d568119b72c7ea33728fa48ad45215869fe345", features = ["mocks"] }
+zerok_lib = { git = "ssh://git@github.com/SpectrumXYZ/spectrum.git", rev = "42e0ec823e30d7b32fed56d12bf2abf0a392458a", features = ["mocks"] }
 
 [dev-dependencies]
 surf = "2.3.2"


### PR DESCRIPTION
`ethers-rs` commit `1908c6d8ad51b56ee1402811d61152f7212662ee` updates `elliptic-curve`, breaking jellyfish via `crypto_box`. This commit updates jellyfish to a newer version of `crypto_box`, updates spectrum dependencies to point to those updated versions, and pins the most recent commit of `ethers` that isn't broken for us.

This does not fully address https://github.com/SpectrumXYZ/cape/issues/269 but makes progress on it.