### PR TITLE
WIP: use reef

### DIFF
--- a/contracts/rust/Cargo.toml
+++ b/contracts/rust/Cargo.toml
@@ -7,12 +7,13 @@ edition = "2018"
 doctest = false
 
 [dependencies]
-jf-plonk = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "c9ded9359d82447ec5644c8df2921c16ba26c660"}
-jf-primitives = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "c9ded9359d82447ec5644c8df2921c16ba26c660"}
-jf-aap = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "c9ded9359d82447ec5644c8df2921c16ba26c660"}
-jf-rescue = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "c9ded9359d82447ec5644c8df2921c16ba26c660"}
-jf-utils = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "c9ded9359d82447ec5644c8df2921c16ba26c660"}
-zerok_lib = { git = "ssh://git@github.com/SpectrumXYZ/spectrum.git", rev = "b86e2e0ef24aa313a51a82875309f562fe0184d0" }
+jf-plonk = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "54f112e41f2264abdfb92c433564fea5cc7cdc97"}
+jf-primitives = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "54f112e41f2264abdfb92c433564fea5cc7cdc97"}
+jf-aap = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "54f112e41f2264abdfb92c433564fea5cc7cdc97"}
+jf-rescue = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "54f112e41f2264abdfb92c433564fea5cc7cdc97"}
+jf-utils = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "54f112e41f2264abdfb92c433564fea5cc7cdc97"}
+zerok_lib = { git = "ssh://git@github.com/SpectrumXYZ/spectrum.git", rev = "4f961d7a9cb8ff6168dcafab48ec155d59049316" }
+reef = { git = "ssh://git@github.com/SpectrumXYZ/reef.git", rev = "34725636bbde038176d39dbf6b948ab0a0a0793c" }
 ethers = { git = "https://github.com/gakonst/ethers-rs", branch = "master" }
 itertools = "0.10.1" # needed for jf-aap to compile
 ark-std = "0.3.0"

--- a/contracts/rust/src/ledger.rs
+++ b/contracts/rust/src/ledger.rs
@@ -2,11 +2,11 @@ use ark_serialize::*;
 use generic_array::GenericArray;
 use jf_aap::{structs::Nullifier, TransactionNote};
 use jf_utils::tagged_blob;
+use reef::traits::{Block, Ledger, NullifierSet, Transaction, Validator};
 use serde::{Deserialize, Serialize};
 use sha3::{Digest, Keccak256};
 use zerok_lib::{
     commit::{Commitment, Committable, RawCommitmentBuilder},
-    ledger::traits::*,
     state::ValidationError,
 };
 
@@ -53,7 +53,7 @@ pub enum CAPETransactionKind {
     Unknown,
 }
 
-impl zerok_lib::ledger::traits::TransactionKind for CAPETransactionKind {
+impl reef::traits::TransactionKind for CAPETransactionKind {
     fn send() -> Self {
         Self::Send
     }
@@ -108,7 +108,7 @@ impl Transaction for CAPETransaction {
             jf_aap::keys::AuditorPubKey,
             jf_aap::keys::AuditorKeyPair,
         >,
-    ) -> Result<zerok_lib::ledger::AuditMemoOpening, zerok_lib::ledger::AuditError> {
+    ) -> Result<reef::types::AuditMemoOpening, reef::types::AuditError> {
         unimplemented!();
     }
 
@@ -140,6 +140,7 @@ impl Committable for CAPEBlock {
 
 impl Block for CAPEBlock {
     type Transaction = CAPETransaction;
+    type Error = ValidationError;
 
     fn add_transaction(&mut self, _txn: Self::Transaction) -> Result<(), ValidationError> {
         unimplemented!()
@@ -232,4 +233,8 @@ pub struct CAPELedger;
 
 impl Ledger for CAPELedger {
     type Validator = CAPEValidator;
+
+    fn name() -> String {
+        unimplemented!()
+    }
 }

--- a/doc/workflow/Cargo.toml
+++ b/doc/workflow/Cargo.toml
@@ -4,9 +4,9 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-jf-aap = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "c9ded9359d82447ec5644c8df2921c16ba26c660" }
-jf-utils = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "c9ded9359d82447ec5644c8df2921c16ba26c660" }
-jf-rescue = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "c9ded9359d82447ec5644c8df2921c16ba26c660" }
+jf-aap = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "54f112e41f2264abdfb92c433564fea5cc7cdc97" }
+jf-utils = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "54f112e41f2264abdfb92c433564fea5cc7cdc97" }
+jf-rescue = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "54f112e41f2264abdfb92c433564fea5cc7cdc97" }
 ethers = { git = "https://github.com/gakonst/ethers-rs", features = ["abigen"] }
 
 serde_json = "1.0.67"

--- a/relayer/Cargo.toml
+++ b/relayer/Cargo.toml
@@ -13,8 +13,8 @@ cap-rust-sandbox = { path = "../contracts/rust" }
 dirs = "4.0"
 # may switch to `ethers = "0.6.2"` in the future; keeping this for compatibility for now
 ethers = { git = "https://github.com/gakonst/ethers-rs", branch = "master" }
-jf-aap = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "c9ded9359d82447ec5644c8df2921c16ba26c660" }
-jf-primitives = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "c9ded9359d82447ec5644c8df2921c16ba26c660" }
+jf-aap = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "54f112e41f2264abdfb92c433564fea5cc7cdc97" }
+jf-primitives = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "54f112e41f2264abdfb92c433564fea5cc7cdc97" }
 lazy_static = "1.4.0"
 rand_chacha = { version = "0.3.1", features = ["serde1"] }
 serde = { version = "1.0.123", features = ["derive", "rc"] }
@@ -26,4 +26,4 @@ tide-websockets = "0.4.0"
 toml = "0.5"
 tracing = "0.1.26"
 tracing-subscriber = "0.3"
-zerok_lib = { git = "ssh://git@github.com/SpectrumXYZ/spectrum.git", rev = "b86e2e0ef24aa313a51a82875309f562fe0184d0" }
+zerok_lib = { git = "ssh://git@github.com/SpectrumXYZ/spectrum.git", rev = "4f961d7a9cb8ff6168dcafab48ec155d59049316" }

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -16,13 +16,14 @@ bincode = "1.3.3"
 futures = "0.3.0"
 futures-util = "0.3.8"
 itertools = "0.10.1"
-jf-aap = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "c9ded9359d82447ec5644c8df2921c16ba26c660" }
-jf-plonk = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "c9ded9359d82447ec5644c8df2921c16ba26c660" }
-jf-primitives = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "c9ded9359d82447ec5644c8df2921c16ba26c660"}
-jf-utils = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "c9ded9359d82447ec5644c8df2921c16ba26c660"}
+jf-aap = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "54f112e41f2264abdfb92c433564fea5cc7cdc97" }
+jf-plonk = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "54f112e41f2264abdfb92c433564fea5cc7cdc97" }
+jf-primitives = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "54f112e41f2264abdfb92c433564fea5cc7cdc97"}
+jf-utils = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "54f112e41f2264abdfb92c433564fea5cc7cdc97"}
 lazy_static = "1.4.0"
 markdown = "0.3"
 rand_chacha = "0.3.1"
+reef = { git = "ssh://git@github.com/SpectrumXYZ/reef.git", rev = "34725636bbde038176d39dbf6b948ab0a0a0793c" }
 serde = { version = "1.0.123", features = ["derive", "rc"] }
 serde_derive = "1.0.118"
 serde_json = "1.0.61"
@@ -40,7 +41,7 @@ tracing = "0.1.26"
 tracing-distributed = "0.3.1"
 tracing-futures = "0.2"
 tracing-subscriber = "0.2.19"
-zerok_lib = { git = "ssh://git@github.com/SpectrumXYZ/spectrum.git", rev = "80d568119b72c7ea33728fa48ad45215869fe345", features = ["mocks"] }
+zerok_lib = { git = "ssh://git@github.com/SpectrumXYZ/spectrum.git", rev = "4f961d7a9cb8ff6168dcafab48ec155d59049316", features = ["mocks"] }
 
 [dev-dependencies]
 surf = "2.3.2"

--- a/wallet/src/routes.rs
+++ b/wallet/src/routes.rs
@@ -8,6 +8,7 @@ use jf_aap::{
     structs::{AssetCode, AssetDefinition},
     MerkleTree, TransactionVerifyingKey,
 };
+use reef::traits::Ledger;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt::Debug;
@@ -220,7 +221,7 @@ pub fn dummy_url_eval(
         .build())
 }
 
-fn wallet_error(source: WalletError) -> tide::Error {
+fn wallet_error<L: Ledger>(source: WalletError<L>) -> tide::Error {
     tide::Error::from_str(StatusCode::InternalServerError, source.to_string())
 }
 


### PR DESCRIPTION
Depends on 
- https://github.com/SpectrumXYZ/commit/pull/4 to

resolve dependencies.

There are still at least 2 errors when compiling.

```
warning: Patch `commit v0.1.0 (/Users/lulu/r/spectrumxyz/commit)` was not used in the crate graph.
Check that the patched package version and available features are compatible
with the dependency requirements. If the patch has a different version from
what is locked in the Cargo.lock file, run `cargo update` to use the new
version. This may also occur with an optional dependency that is not enabled.
    Blocking waiting for file lock on build directory
   Compiling cape_wallet v0.1.0 (/Users/lulu/r/spectrumxyz/cape/wallet)
error[E0283]: type annotations needed
   --> wallet/src/main.rs:397:37
    |
397 |                 client: client.with(client::parse_error_body),
    |                                     ^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for type parameter `E` declared on the function `parse_error_body`
    |
    = note: cannot satisfy `_: zerok_lib::api::Error`
note: required by a bound in `parse_error_body`
   --> /Users/lulu/.cargo/git/checkouts/spectrum-1cd82e42efcea3f2/4f961d7/zerok/zerok_lib/src/api.rs:451:32
    |
451 |     pub fn parse_error_body<E: Error>(
    |                                ^^^^^ required by this bound in `parse_error_body`
help: consider specifying the type argument in the function call
    |
397 |                 client: client.with(client::parse_error_body::<E>),
    |                                                             +++++

error[E0283]: type annotations needed
   --> wallet/src/main.rs:252:41
    |
252 |     web_server.with(server::trace).with(server::add_error_body);
    |                                         ^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for type parameter `E` declared on the function `add_error_body`
    |
    = note: cannot satisfy `_: zerok_lib::api::Error`
note: required by a bound in `add_error_body`
   --> /Users/lulu/.cargo/git/checkouts/spectrum-1cd82e42efcea3f2/4f961d7/zerok/zerok_lib/src/api.rs:349:68
    |
349 |     pub fn add_error_body<'a, T: Clone + Send + Sync + 'static, E: Error>(
    |                                                                    ^^^^^ required by this bound in `add_error_body`
help: consider specifying the type arguments in the function call
    |
252 |     web_server.with(server::trace).with(server::add_error_body::<T, E>);
    |                                                               ++++++++

For more information about this error, try `rustc --explain E0283`.
error: could not compile `cape_wallet` due to 2 previous errors
```