### PR TITLE
Remove timeout in wallet API tests.

### DIFF
--- a/wallet/src/main.rs
+++ b/wallet/src/main.rs
@@ -398,6 +398,7 @@ mod tests {
 
             let client: surf::Client = surf::Config::new()
                 .set_base_url(Url::parse(&format!("http://localhost:{}", port)).unwrap())
+                .set_timeout(None)
                 .try_into()
                 .unwrap();
             Self {


### PR DESCRIPTION
With many test threads running in parallel, it can sometimes take
longer than the default timeout (1 minute) to complete a request-
response cycle, particularly for the openwallet/newwallet endpoints,
which have to load or generate proving keys.