### PR TITLE
Relaying an invalid transaction is expected to fail.

### DIFF
--- a/relayer/src/bin/minimal_relayer.rs
+++ b/relayer/src/bin/minimal_relayer.rs
@@ -323,9 +323,10 @@ mod test {
 
         // Submit an invalid transaction (e.g.the same one again) and check that the contract's
         // records Merkle tree is not modified.
-        relay(&Contract::Test(contract.clone()), transaction)
-            .await
-            .unwrap();
+        match relay(&Contract::Test(contract.clone()), transaction).await {
+            Err(RelayerError::Submission { .. }) => {}
+            res => panic!("expected submission error, got {:?}", res),
+        }
         assert_eq!(contract.get_num_leaves().call().await.unwrap(), 3.into());
     }
 


### PR DESCRIPTION
Before recent changes to the contract, relaying an invalid transaction
would succeed, but not affect the contract state, because the invalid
transaction would simply be filtered out of the block.

Now, the contract no longer filters invalid transactions. Instead,
it fails the whole block if any transaction is invalid.