### PR TITLE
Remove left-overs from excluding notes from blocks

### DIFF
--- a/contracts/contracts/mocks/TestCAPE.sol
+++ b/contracts/contracts/mocks/TestCAPE.sol
@@ -22,8 +22,8 @@ contract TestCAPE is CAPE {
         }
     }
 
-    function insertNullifier(uint256 nullifier) public {
-        return _insertNullifier(nullifier);
+    function publish(uint256 nullifier) public {
+        return _publish(nullifier);
     }
 
     function checkTransfer(TransferNote memory note) public pure {

--- a/contracts/test/cape.spec.ts
+++ b/contracts/test/cape.spec.ts
@@ -38,19 +38,19 @@ describe("CAPE", function () {
       let elem = ethers.utils.randomBytes(32);
       expect(await cape.nullifiers(elem)).to.be.false;
 
-      let tx = await cape.insertNullifier(elem);
+      let tx = await cape.publish(elem);
       await tx.wait();
       expect(await cape.nullifiers(elem)).to.be.true;
     });
 
-    it("is possible to insert several elements", async function () {
+    it("is possible to publish several nullifiers", async function () {
       let elem1 = ethers.utils.randomBytes(32);
       let elem2 = ethers.utils.randomBytes(32);
       expect(elem1).not.equal(elem2);
 
-      let tx = await cape.insertNullifier(elem1);
+      let tx = await cape.publish(elem1);
       await tx.wait();
-      expect(await cape.insertNullifier(elem2)).not.to.throw;
+      expect(await cape.publish(elem2)).not.to.throw;
     });
   });
 });


### PR DESCRIPTION
- Remove functions necessary for nullifier handling for excluding notes
  from blocks.
- Merge the two loops over all notes into one. The plonk proof
  extraction is now just one extra line for each note type.
- Minor code re-organization to perform processing steps for each note
  type in the same order.

Close #411