### PR TITLE
Refactor/deploy test cape faucet

### DIFF
--- a/contracts/rust/src/asset_registry.rs
+++ b/contracts/rust/src/asset_registry.rs
@@ -1,116 +1,17 @@
 #![cfg(test)]
 use anyhow::Result;
-use ethers::prelude::*;
-use jf_aap::structs::{AssetCode, AssetCodeSeed, AssetDefinition, AssetPolicy, RecordOpening};
+use ethers::prelude::Address;
+use jf_aap::structs::{AssetCode, AssetDefinition, AssetPolicy};
 
 use crate::assertion::Matcher;
-use crate::deploy::deploy_cape_test;
+use crate::deploy::deploy_test_asset_registry_contract;
 use crate::ethereum::get_funded_client;
 use crate::state::{erc20_asset_description, Erc20Code, EthereumAddr};
-use crate::types::{AssetCodeSol, GenericInto, TestCAPE};
-
-#[tokio::test]
-async fn test_erc20_description() -> Result<()> {
-    let contract = deploy_cape_test().await;
-    let sponsor = Address::random();
-    let asset_address = Address::random();
-    let asset_code = Erc20Code(EthereumAddr(asset_address.to_fixed_bytes()));
-    let description = erc20_asset_description(&asset_code, &EthereumAddr(sponsor.to_fixed_bytes()));
-    let ret = contract
-        .compute_asset_description(asset_address, sponsor)
-        .call()
-        .await?;
-    assert_eq!(ret.to_vec(), description);
-    Ok(())
-}
-
-#[tokio::test]
-async fn test_check_foreign_asset_code() -> Result<()> {
-    let contract = deploy_cape_test().await;
-    let erc20_address = Address::random();
-    let sponsor_address = Address::random();
-    let erc20_code = Erc20Code(EthereumAddr(erc20_address.to_fixed_bytes()));
-
-    // Fails for random record opening with random asset code.
-    let rng = &mut ark_std::test_rng();
-    let ro = RecordOpening::rand_for_test(rng);
-    contract
-        .check_foreign_asset_code(
-            ro.asset_def.code.generic_into::<AssetCodeSol>().0,
-            Address::random(),
-        )
-        .from(sponsor_address)
-        .call()
-        .await
-        .should_revert_with_message("Wrong foreign asset code");
-
-    // Fails for domestic asset code.
-    let domestic_asset_code =
-        AssetCode::new_domestic(AssetCodeSeed::generate(rng), erc20_address.as_bytes());
-    contract
-        .check_foreign_asset_code(
-            domestic_asset_code.generic_into::<AssetCodeSol>().0,
-            erc20_address,
-        )
-        .from(sponsor_address)
-        .call()
-        .await
-        .should_revert_with_message("Wrong foreign asset code");
-
-    // Fails if txn sender address does not match sponsor in asset code.
-    let description_wrong_sponsor = erc20_asset_description(
-        &erc20_code,
-        &EthereumAddr(Address::random().to_fixed_bytes()),
-    );
-    let asset_code_wrong_sponsor = AssetCode::new_foreign(&description_wrong_sponsor);
-    contract
-        .check_foreign_asset_code(
-            asset_code_wrong_sponsor.generic_into::<AssetCodeSol>().0,
-            erc20_address,
-        )
-        .from(sponsor_address)
-        .call()
-        .await
-        .should_revert_with_message("Wrong foreign asset code");
-
-    let description =
-        erc20_asset_description(&erc20_code, &EthereumAddr(sponsor_address.to_fixed_bytes()));
-    let asset_code = AssetCode::new_foreign(&description);
-
-    // Fails for random erc20 address.
-    contract
-        .check_foreign_asset_code(
-            asset_code.generic_into::<AssetCodeSol>().0,
-            Address::random(),
-        )
-        .from(sponsor_address)
-        .call()
-        .await
-        .should_revert_with_message("Wrong foreign asset code");
-
-    // Fails if not called by correct sponsor
-    contract
-        .check_foreign_asset_code(asset_code.generic_into::<AssetCodeSol>().0, erc20_address)
-        .from(Address::random())
-        .call()
-        .await
-        .should_revert_with_message("Wrong foreign asset code");
-
-    // Passes for correctly derived asset code
-    contract
-        .check_foreign_asset_code(asset_code.generic_into::<AssetCodeSol>().0, erc20_address)
-        .from(sponsor_address)
-        .call()
-        .await
-        .should_not_revert();
-
-    Ok(())
-}
+use crate::types::TestCAPE;
 
 #[tokio::test]
 async fn test_asset_registry() -> Result<()> {
-    let contract = deploy_cape_test().await;
-
+    let contract = deploy_test_asset_registry_contract().await;
     let erc20_address = Address::random();
 
     let sponsor = get_funded_client().await?;

--- a/contracts/rust/src/bn254.rs
+++ b/contracts/rust/src/bn254.rs
@@ -1,8 +1,8 @@
 #![cfg(test)]
 
+use crate::deploy::deploy_test_bn254_contract;
 use crate::{
     assertion::Matcher,
-    ethereum::{deploy, get_funded_client},
     types::{field_to_u256, u256_to_field, G1Point, G2Point, TestBN254},
 };
 use anyhow::Result;
@@ -19,25 +19,11 @@ use ark_std::Zero;
 use ethers::core::k256::ecdsa::SigningKey;
 use ethers::prelude::*;
 use rand::RngCore;
-use std::path::Path;
-
-async fn deploy_contract() -> Result<TestBN254<SignerMiddleware<Provider<Http>, Wallet<SigningKey>>>>
-{
-    let client = get_funded_client().await.unwrap();
-    let contract = deploy(
-        client.clone(),
-        Path::new("../abi/contracts/mocks/TestBN254.sol/TestBN254"),
-        (),
-    )
-    .await
-    .unwrap();
-    Ok(TestBN254::new(contract.address(), client))
-}
 
 #[tokio::test]
 async fn test_quadratic_residue() -> Result<()> {
     let rng = &mut ark_std::test_rng();
-    let contract = deploy_contract().await?;
+    let contract = deploy_test_bn254_contract().await;
 
     // test random group addition
     for _ in 0..100 {
@@ -55,7 +41,7 @@ async fn test_quadratic_residue() -> Result<()> {
 #[tokio::test]
 async fn test_add() -> Result<()> {
     let rng = &mut ark_std::test_rng();
-    let contract = deploy_contract().await?;
+    let contract = deploy_test_bn254_contract().await;
 
     // test random group addition
     for _ in 0..10 {
@@ -76,7 +62,7 @@ async fn test_add() -> Result<()> {
 
 #[tokio::test]
 async fn test_group_generators() -> Result<()> {
-    let contract = deploy_contract().await?;
+    let contract = deploy_test_bn254_contract().await;
 
     let g1_gen = G1Affine::prime_subgroup_generator();
     let g2_gen = G2Affine::prime_subgroup_generator();
@@ -92,7 +78,7 @@ async fn test_group_generators() -> Result<()> {
 #[tokio::test]
 async fn test_is_infinity() -> Result<()> {
     let rng = &mut ark_std::test_rng();
-    let contract = deploy_contract().await?;
+    let contract = deploy_test_bn254_contract().await;
 
     let zero = G1Affine::zero();
     assert!(contract.is_infinity(zero.into()).call().await?);
@@ -107,7 +93,7 @@ async fn test_is_infinity() -> Result<()> {
 #[tokio::test]
 async fn test_negate() -> Result<()> {
     let rng = &mut ark_std::test_rng();
-    let contract = deploy_contract().await?;
+    let contract = deploy_test_bn254_contract().await;
 
     for _ in 0..10 {
         let p: G1Affine = G1Projective::rand(rng).into();
@@ -121,7 +107,7 @@ async fn test_negate() -> Result<()> {
 #[tokio::test]
 async fn test_scalar_mul() -> Result<()> {
     let rng = &mut ark_std::test_rng();
-    let contract = deploy_contract().await?;
+    let contract = deploy_test_bn254_contract().await;
 
     for _ in 0..10 {
         let p = G1Projective::rand(rng);
@@ -141,7 +127,7 @@ async fn test_scalar_mul() -> Result<()> {
 #[tokio::test]
 async fn test_multi_scalar_mul() -> Result<()> {
     let rng = &mut ark_std::test_rng();
-    let contract = deploy_contract().await?;
+    let contract = deploy_test_bn254_contract().await;
 
     for length in 1..10 {
         let p_rust: Vec<G1Affine> = (0..length)
@@ -173,7 +159,7 @@ async fn test_multi_scalar_mul() -> Result<()> {
 #[tokio::test]
 async fn test_is_y_negative() -> Result<()> {
     let rng = &mut ark_std::test_rng();
-    let contract = deploy_contract().await?;
+    let contract = deploy_test_bn254_contract().await;
 
     for _ in 0..10 {
         let p: G1Affine = G1Projective::rand(rng).into();
@@ -191,7 +177,7 @@ async fn test_is_y_negative() -> Result<()> {
 #[tokio::test]
 async fn test_invert() -> Result<()> {
     let rng = &mut ark_std::test_rng();
-    let contract = deploy_contract().await?;
+    let contract = deploy_test_bn254_contract().await;
 
     for _ in 0..10 {
         let f = Fr::rand(rng);
@@ -206,7 +192,7 @@ async fn test_invert() -> Result<()> {
 #[tokio::test]
 async fn test_validate_g1_point() -> Result<()> {
     let rng = &mut ark_std::test_rng();
-    let contract = deploy_contract().await?;
+    let contract = deploy_test_bn254_contract().await;
     let p: G1Affine = G1Projective::rand(rng).into();
     contract.validate_g1_point(p.into()).call().await?;
 
@@ -250,7 +236,7 @@ async fn test_validate_g1_point() -> Result<()> {
 #[tokio::test]
 async fn test_validate_scalar_field() -> Result<()> {
     let rng = &mut ark_std::test_rng();
-    let contract = deploy_contract().await?;
+    let contract = deploy_test_bn254_contract().await;
     let f = Fr::rand(rng);
     contract
         .validate_scalar_field(field_to_u256(f))
@@ -274,7 +260,7 @@ async fn test_validate_scalar_field() -> Result<()> {
 #[tokio::test]
 async fn test_pairing_prod() -> Result<()> {
     let rng = &mut ark_std::test_rng();
-    let contract = deploy_contract().await?;
+    let contract = deploy_test_bn254_contract().await;
     let g1_base = G1Projective::prime_subgroup_generator();
     let g2_base = G2Projective::prime_subgroup_generator();
 
@@ -301,7 +287,7 @@ async fn test_pairing_prod() -> Result<()> {
 #[tokio::test]
 async fn test_from_le_bytes_mod_order() -> Result<()> {
     let rng = &mut ark_std::test_rng();
-    let contract = deploy_contract().await?;
+    let contract = deploy_test_bn254_contract().await;
 
     for _ in 0..10 {
         let mut bytes = [0u8; 32];
@@ -330,7 +316,7 @@ async fn test_from_le_bytes_mod_order() -> Result<()> {
 #[tokio::test]
 async fn test_pow_small() -> Result<()> {
     let rng = &mut ark_std::test_rng();
-    let contract = deploy_contract().await?;
+    let contract = deploy_test_bn254_contract().await;
     let modulus = <<Fr as PrimeField>::Params as FpParameters>::MODULUS;
 
     for _ in 0..10 {
@@ -355,7 +341,7 @@ async fn test_pow_small() -> Result<()> {
 #[tokio::test]
 async fn test_serialization() -> Result<()> {
     let rng = &mut ark_std::test_rng();
-    let contract = deploy_contract().await?;
+    let contract = deploy_test_bn254_contract().await;
     let mut rust_ser = Vec::new();
 
     // infinity
@@ -391,7 +377,7 @@ async fn test_serialization() -> Result<()> {
 #[tokio::test]
 async fn test_deserialization() -> Result<()> {
     let rng = &mut ark_std::test_rng();
-    let contract = deploy_contract().await?;
+    let contract = deploy_test_bn254_contract().await;
     let mut rust_buf = Vec::new();
     let mut sol_buf = [0u8; 32];
 

--- a/contracts/rust/src/deploy.rs
+++ b/contracts/rust/src/deploy.rs
@@ -1,17 +1,21 @@
 use crate::cape::CAPEConstructorArgs;
 use crate::ethereum::{deploy, get_funded_client};
 use crate::state::CAPE_MERKLE_HEIGHT;
-use crate::types::{GenericInto, Greeter, SimpleToken, TestCAPE, TestQueue};
+use crate::test_utils::contract_abi_path;
+use crate::types::{
+    AssetRegistry, GenericInto, Greeter, SimpleToken, TestBN254, TestCAPE, TestCapeTypes,
+    TestEdOnBN254, TestPlonkVerifier, TestPolynomialEval, TestQueue, TestRecordsMerkleTree,
+    TestRescue, TestRootStore, TestTranscript, TestVerifyingKeys,
+};
 use anyhow::Result;
 use ethers::prelude::{k256::ecdsa::SigningKey, Address, Http, Provider, SignerMiddleware, Wallet};
-use std::path::Path;
 
 pub async fn deploy_cape_test() -> TestCAPE<SignerMiddleware<Provider<Http>, Wallet<SigningKey>>> {
     let client = get_funded_client().await.unwrap();
     // deploy the PlonkVerifier
     let verifier = deploy(
         client.clone(),
-        Path::new("../abi/contracts/verifier/PlonkVerifier.sol/PlonkVerifier"),
+        &contract_abi_path("verifier/PlonkVerifier.sol/PlonkVerifier"),
         (),
     )
     .await
@@ -20,7 +24,7 @@ pub async fn deploy_cape_test() -> TestCAPE<SignerMiddleware<Provider<Http>, Wal
     // deploy TestCAPE.sol
     let contract = deploy(
         client.clone(),
-        Path::new("../abi/contracts/mocks/TestCAPE.sol/TestCAPE"),
+        &contract_abi_path("mocks/TestCAPE.sol/TestCAPE"),
         CAPEConstructorArgs::new(CAPE_MERKLE_HEIGHT, 10, verifier.address())
             .generic_into::<(u8, u64, Address)>(),
     )
@@ -29,41 +33,121 @@ pub async fn deploy_cape_test() -> TestCAPE<SignerMiddleware<Provider<Http>, Wal
     TestCAPE::new(contract.address(), client)
 }
 
-pub async fn deploy_queue_test() -> TestQueue<SignerMiddleware<Provider<Http>, Wallet<SigningKey>>>
-{
-    let client = get_funded_client().await.unwrap();
-    let call = deploy(
-        client.clone(),
-        Path::new("../abi/contracts/mocks/TestQueue.sol/TestQueue"),
-        (),
-    )
-    .await;
-    let contract = call.unwrap();
-    TestQueue::new(contract.address(), client)
+macro_rules! mk_deploy_fun {
+    ($func:ident, $output_type:ty, $path:expr) => {
+        pub async fn $func() -> $output_type {
+            let client = get_funded_client().await.unwrap();
+            let call = deploy(client.clone(), &contract_abi_path($path), ()).await;
+            let contract = call.unwrap();
+            <$output_type>::new(contract.address(), client)
+        }
+    };
 }
 
-pub async fn deploy_erc20_token(
-) -> SimpleToken<SignerMiddleware<Provider<Http>, Wallet<SigningKey>>> {
-    let client = get_funded_client().await.unwrap();
-    let call = deploy(
-        client.clone(),
-        Path::new("../abi/contracts/SimpleToken.sol/SimpleToken"),
-        (),
-    )
-    .await;
-    let contract = call.unwrap();
-    SimpleToken::new(contract.address(), client)
-}
+mk_deploy_fun!(
+    deploy_test_cape_types_contract,
+    TestCapeTypes<SignerMiddleware<Provider<Http>, Wallet<SigningKey>>>,
+    "mocks/TestCapeTypes.sol/TestCapeTypes"
+);
 
+mk_deploy_fun!(
+    deploy_queue_test,
+    TestQueue<SignerMiddleware<Provider<Http>, Wallet<SigningKey>>>,
+    "mocks/TestQueue.sol/TestQueue"
+);
+mk_deploy_fun!(
+    deploy_erc20_token,
+    SimpleToken<SignerMiddleware<Provider<Http>, Wallet<SigningKey>>>,
+    "SimpleToken.sol/SimpleToken"
+);
+mk_deploy_fun!(
+    deploy_test_plonk_verifier_contract,
+    TestPlonkVerifier<SignerMiddleware<Provider<Http>, Wallet<SigningKey>>>,
+    "mocks/TestPlonkVerifier.sol/TestPlonkVerifier"
+);
+mk_deploy_fun!(
+    deploy_test_polynomial_eval_contract,
+    TestPolynomialEval<SignerMiddleware<Provider<Http>, Wallet<SigningKey>>>,
+    "mocks/TestPolynomialEval.sol/TestPolynomialEval"
+);
+mk_deploy_fun!(
+    deploy_test_verifying_keys_contract,
+    TestVerifyingKeys<SignerMiddleware<Provider<Http>, Wallet<SigningKey>>>,
+    "mocks/TestVerifyingKeys.sol/TestVerifyingKeys"
+);
+mk_deploy_fun!(
+    deploy_test_asset_registry_contract,
+    AssetRegistry<SignerMiddleware<Provider<Http>, Wallet<SigningKey>>>,
+    "AssetRegistry.sol/AssetRegistry"
+);
+mk_deploy_fun!(
+    deploy_test_rescue,
+    TestRescue<SignerMiddleware<Provider<Http>, Wallet<SigningKey>>>,
+    "mocks/TestRescue.sol/TestRescue"
+);
+mk_deploy_fun!(
+    deploy_test_bn254_contract,
+    TestBN254<SignerMiddleware<Provider<Http>, Wallet<SigningKey>>>,
+    "mocks/TestBN254.sol/TestBN254"
+);
+mk_deploy_fun!(
+    deploy_test_ed_on_bn_254_contract,
+    TestEdOnBN254<SignerMiddleware<Provider<Http>, Wallet<SigningKey>>>,
+    "mocks/TestEdOnBN254.sol/TestEdOnBN254"
+);
+
+// We do not call the macro for the contracts below because they take some argument
 pub async fn deploy_greeter_contract(
 ) -> Result<Greeter<SignerMiddleware<Provider<Http>, Wallet<SigningKey>>>> {
     let client = get_funded_client().await.unwrap();
     let contract = deploy(
         client.clone(),
-        Path::new("../abi/contracts/Greeter.sol/Greeter"),
+        &contract_abi_path("Greeter.sol/Greeter"),
         ("Initial Greeting".to_string(),),
     )
     .await
     .unwrap();
     Ok(Greeter::new(contract.address(), client))
+}
+
+pub async fn deploy_test_root_store_contract(
+) -> TestRootStore<SignerMiddleware<Provider<Http>, Wallet<SigningKey>>> {
+    let client = get_funded_client().await.unwrap();
+    let contract = deploy(
+        client.clone(),
+        &contract_abi_path("mocks/TestRootStore.sol/TestRootStore"),
+        (3u64,), /* num_roots */
+    )
+    .await
+    .unwrap();
+    TestRootStore::new(contract.address(), client)
+}
+
+pub async fn deploy_test_transcript_contract(
+) -> TestTranscript<SignerMiddleware<Provider<Http>, Wallet<SigningKey>>> {
+    let client = get_funded_client().await.unwrap();
+    let contract = deploy(
+        client.clone(),
+        &contract_abi_path("mocks/TestTranscript.sol/TestTranscript"),
+        (),
+    )
+    .await
+    .unwrap();
+    TestTranscript::new(contract.address(), client)
+}
+
+pub async fn deploy_test_records_merkle_tree_contract(
+    height: u8,
+) -> TestRecordsMerkleTree<
+    SignerMiddleware<Provider<Http>, Wallet<ethers::core::k256::ecdsa::SigningKey>>,
+> {
+    let client = get_funded_client().await.unwrap();
+    let contract = deploy(
+        client.clone(),
+        &contract_abi_path("mocks/TestRecordsMerkleTree.sol/TestRecordsMerkleTree"),
+        height,
+    )
+    .await
+    .unwrap();
+    TestRecordsMerkleTree::new(contract.address(), client)
 }

--- a/contracts/rust/src/ed_on_bn254.rs
+++ b/contracts/rust/src/ed_on_bn254.rs
@@ -1,39 +1,20 @@
 #![cfg(test)]
 
-use crate::{
-    ethereum::{deploy, get_funded_client},
-    types::{EdOnBN254Point, TestEdOnBN254},
-};
+use crate::deploy::deploy_test_ed_on_bn_254_contract;
+use crate::types::EdOnBN254Point;
 use anyhow::Result;
 use ark_ec::AffineCurve;
 use ark_ed_on_bn254::EdwardsAffine;
 use ark_serialize::CanonicalSerialize;
 use ark_std::UniformRand;
 use ark_std::Zero;
-use ethers::core::k256::ecdsa::SigningKey;
-use ethers::prelude::*;
-use std::path::Path;
-
-async fn deploy_contract(
-) -> Result<TestEdOnBN254<SignerMiddleware<Provider<Http>, Wallet<SigningKey>>>> {
-    let client = get_funded_client().await?;
-
-    let contract = deploy(
-        client.clone(),
-        Path::new("../abi/contracts/mocks/TestEdOnBN254.sol/TestEdOnBN254"),
-        (),
-    )
-    .await?;
-
-    Ok(TestEdOnBN254::new(contract.address(), client))
-}
 
 #[tokio::test]
 async fn test_serialization() -> Result<()> {
     let rng = &mut ark_std::test_rng();
 
     // somehow deploying this contract returns an error
-    let contract = deploy_contract().await?;
+    let contract = deploy_test_ed_on_bn_254_contract().await;
     let mut rust_ser = Vec::new();
 
     // infinity

--- a/contracts/rust/src/lib.rs
+++ b/contracts/rust/src/lib.rs
@@ -17,6 +17,7 @@ mod queue;
 mod records_merkle_tree;
 mod root_store;
 pub mod state;
+pub mod test_utils;
 mod transcript;
 pub mod types;
 pub mod universal_param;

--- a/contracts/rust/src/plonk_verifier/poly_eval.rs
+++ b/contracts/rust/src/plonk_verifier/poly_eval.rs
@@ -1,10 +1,6 @@
 #![cfg(test)]
-use std::path::Path;
-
-use crate::{
-    ethereum::{deploy, get_funded_client},
-    types::{field_to_u256, u256_to_field, EvalDomain, TestPolynomialEval},
-};
+use crate::deploy::deploy_test_polynomial_eval_contract;
+use crate::types::{field_to_u256, u256_to_field, EvalDomain};
 use anyhow::Result;
 use ark_bn254::Fr;
 use ark_ff::Field;
@@ -12,25 +8,12 @@ use ark_poly::{EvaluationDomain, Radix2EvaluationDomain};
 use ark_std::One;
 use ark_std::Zero;
 use ark_std::{test_rng, UniformRand};
-use ethers::prelude::{Http, Provider, SignerMiddleware, Wallet};
-use ethers::{core::k256::ecdsa::SigningKey, prelude::U256};
-
-async fn deploy_contract(
-) -> Result<TestPolynomialEval<SignerMiddleware<Provider<Http>, Wallet<SigningKey>>>> {
-    let client = get_funded_client().await?;
-    let contract = deploy(
-        client.clone(),
-        Path::new("../abi/contracts/mocks/TestPolynomialEval.sol/TestPolynomialEval"),
-        (),
-    )
-    .await?;
-    Ok(TestPolynomialEval::new(contract.address(), client))
-}
+use ethers::prelude::U256;
 
 #[tokio::test]
 async fn test_vanishing_poly() -> Result<()> {
     let mut rng = test_rng();
-    let contract = deploy_contract().await?;
+    let contract = deploy_test_polynomial_eval_contract().await;
 
     for log_domain_size in 15..=17 {
         // test case: 1 edge case of evaluate at zero, and 1 random case
@@ -58,7 +41,7 @@ async fn test_vanishing_poly() -> Result<()> {
 #[tokio::test]
 async fn test_evaluate_lagrange_one() -> Result<()> {
     let mut rng = test_rng();
-    let contract = deploy_contract().await?;
+    let contract = deploy_test_polynomial_eval_contract().await;
 
     for log_domain_size in 15..=17 {
         let test_zeta = vec![Fr::zero(), Fr::rand(&mut rng)];
@@ -95,7 +78,7 @@ async fn test_evaluate_lagrange_one() -> Result<()> {
 #[tokio::test]
 async fn test_evaluate_pi_poly() -> Result<()> {
     let mut rng = test_rng();
-    let contract = deploy_contract().await?;
+    let contract = deploy_test_polynomial_eval_contract().await;
 
     for pi_length in 0..5 {
         let rust_pub_input: Vec<Fr> = (0..pi_length).map(|_| Fr::rand(&mut rng)).collect();

--- a/contracts/rust/src/plonk_verifier/vk.rs
+++ b/contracts/rust/src/plonk_verifier/vk.rs
@@ -1,16 +1,12 @@
-use crate::{
-    ethereum::{deploy, get_funded_client},
-    types as sol,
-    types::TestVerifyingKeys,
-};
+use crate::deploy::deploy_test_verifying_keys_contract;
+use crate::ethereum::get_funded_client;
+use crate::{types as sol, types::TestVerifyingKeys};
 use anyhow::Result;
 use ark_std::{rand::Rng, test_rng};
-use ethers::core::k256::ecdsa::SigningKey;
 use ethers::prelude::*;
 use jf_aap::proof::{freeze, mint, transfer};
 use jf_aap::structs::NoteType;
 use jf_aap::testing_apis::universal_setup_for_test;
-use std::path::Path;
 
 const TREE_DEPTH: u8 = 24;
 const SUPPORTED_VKS: [(NoteType, u8, u8, u8); 3] = [
@@ -19,21 +15,9 @@ const SUPPORTED_VKS: [(NoteType, u8, u8, u8); 3] = [
     (NoteType::Freeze, 3, 3, TREE_DEPTH),
 ];
 
-async fn deploy_contract(
-) -> Result<TestVerifyingKeys<SignerMiddleware<Provider<Http>, Wallet<SigningKey>>>> {
-    let client = get_funded_client().await?;
-    let contract = deploy(
-        client.clone(),
-        Path::new("../abi/contracts/mocks/TestVerifyingKeys.sol/TestVerifyingKeys"),
-        (),
-    )
-    .await?;
-    Ok(TestVerifyingKeys::new(contract.address(), client))
-}
-
 #[tokio::test]
 async fn test_get_encoded_id() -> Result<()> {
-    let contract = deploy_contract().await?;
+    let contract = deploy_test_verifying_keys_contract().await;
     let rng = &mut test_rng();
 
     for _ in 0..5 {
@@ -59,7 +43,7 @@ async fn test_get_encoded_id() -> Result<()> {
 
 #[tokio::test]
 async fn test_get_vk_by_id() -> Result<()> {
-    let contract = deploy_contract().await?;
+    let contract = deploy_test_verifying_keys_contract().await;
     let rng = &mut test_rng();
 
     let max_degree = 2usize.pow(17);

--- a/contracts/rust/src/records_merkle_tree/mod.rs
+++ b/contracts/rust/src/records_merkle_tree/mod.rs
@@ -1,17 +1,11 @@
 mod rescue;
-
-use crate::ethereum;
-use crate::types::TestRecordsMerkleTree;
 use ark_ed_on_bn254::Fq as Fr254;
-use ethers::prelude::*;
 use jf_primitives::merkle_tree::{
     MerkleFrontier, MerkleLeaf, MerkleLeafProof, MerklePath, MerklePathNode, NodePos, NodeValue,
 };
 use jf_rescue::Permutation;
 use jf_rescue::RescueParameter;
-
 use std::convert::TryFrom;
-use std::path::Path;
 
 // TODO make this function public in Jellyfish?
 /// Hash function used to compute an internal node value
@@ -42,22 +36,6 @@ pub(crate) fn compute_hash_leaf(leaf_value: Fr254, uid: u64) -> Fr254 {
     .to_scalar()
 }
 
-#[allow(dead_code)]
-pub(crate) async fn get_contract_records_merkle_tree(
-    height: u8,
-) -> TestRecordsMerkleTree<
-    SignerMiddleware<Provider<Http>, Wallet<ethers::core::k256::ecdsa::SigningKey>>,
-> {
-    let client = ethereum::get_funded_client().await.unwrap();
-    let contract = ethereum::deploy(
-        client.clone(),
-        Path::new("../abi/contracts/mocks/TestRecordsMerkleTree.sol/TestRecordsMerkleTree"),
-        height,
-    )
-    .await
-    .unwrap();
-    TestRecordsMerkleTree::new(contract.address(), client)
-}
 /// Takes a frontier from a Merkle tree and returns
 /// [leaf,s_{0,first},s_{0,second},pos_0,
 /// s_{1,first},s_{1,second},pos_1,
@@ -133,9 +111,12 @@ fn parse_flattened_frontier(flattened_frontier: &[Fr254], uid: u64) -> MerkleFro
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::deploy::deploy_test_records_merkle_tree_contract;
     use crate::helpers::{compare_merkle_root_from_contract_and_jf_tree, convert_fr254_to_u256};
+    use crate::types::TestRecordsMerkleTree;
     use ark_ed_on_bn254::Fq as Fr254;
     use ark_std::UniformRand;
+    use ethers::prelude::{Http, Provider, SignerMiddleware, Wallet, U256};
     use jf_primitives::merkle_tree::{MerkleTree, NodeValue};
 
     async fn compare_roots(
@@ -260,7 +241,7 @@ mod tests {
     ) {
         // Check that we can insert values in the Merkle tree
 
-        let contract = get_contract_records_merkle_tree(height).await;
+        let contract = deploy_test_records_merkle_tree_contract(height).await;
         let mut mt = MerkleTree::<Fr254>::new(height).unwrap();
 
         // At beginning (no leaf inserted) both roots are the same.

--- a/contracts/rust/src/records_merkle_tree/rescue.rs
+++ b/contracts/rust/src/records_merkle_tree/rescue.rs
@@ -1,16 +1,12 @@
 #[cfg(test)]
 mod tests {
-
-    use crate::ethereum;
+    use crate::deploy::deploy_test_rescue;
     use crate::helpers::{convert_fr254_to_u256, convert_u256_to_bytes_le};
-    use crate::types::TestRescue;
     use ark_ed_on_bn254::Fq as Fr254;
     use ark_ff::{BigInteger, PrimeField, UniformRand, Zero};
-    use ethers::prelude::k256::ecdsa::SigningKey;
     use ethers::prelude::*;
     use jf_rescue::Permutation;
     use std::default::Default;
-    use std::path::Path;
 
     // From jellyfish rescue/src/lib.rs
     // hash output on vector [0, 0, 0, 0]
@@ -45,19 +41,6 @@ mod tests {
         ];
         let real_output = rescue.sponge_no_padding(&input, 3).unwrap();
         assert_eq!(real_output, expected);
-    }
-
-    async fn deploy_test_rescue() -> TestRescue<SignerMiddleware<Provider<Http>, Wallet<SigningKey>>>
-    {
-        let client = ethereum::get_funded_client().await.unwrap();
-        let contract = ethereum::deploy(
-            client.clone(),
-            Path::new("../abi/contracts/mocks/TestRescue.sol/TestRescue"),
-            (),
-        )
-        .await
-        .unwrap();
-        TestRescue::new(contract.address(), client)
     }
 
     #[tokio::test]

--- a/contracts/rust/src/root_store.rs
+++ b/contracts/rust/src/root_store.rs
@@ -1,21 +1,12 @@
 #![cfg(test)]
 use crate::assertion::Matcher;
-use crate::ethereum::{deploy, get_funded_client};
-use crate::types::TestRootStore;
+use crate::deploy::deploy_test_root_store_contract;
 use anyhow::Result;
 use ethers::prelude::U256;
-use std::path::Path;
 
 #[tokio::test]
 async fn test_root_store() -> Result<()> {
-    let client = get_funded_client().await?;
-    let contract = deploy(
-        client.clone(),
-        Path::new("../abi/contracts/mocks/TestRootStore.sol/TestRootStore"),
-        (3u64,), /* num_roots */
-    )
-    .await?;
-    let contract = TestRootStore::new(contract.address(), client);
+    let contract = deploy_test_root_store_contract().await;
 
     let roots: Vec<U256> = (5..10).map(U256::from).collect();
 

--- a/contracts/rust/src/test_utils.rs
+++ b/contracts/rust/src/test_utils.rs
@@ -1,0 +1,86 @@
+use crate::types::{field_to_u256, SimpleToken, TestCAPE};
+use ethers::prelude::{k256::ecdsa::SigningKey, Http, Provider, SignerMiddleware, Wallet, H160};
+use jf_aap::keys::UserKeyPair;
+use jf_aap::structs::{AssetDefinition, FreezeFlag, RecordCommitment, RecordOpening};
+use rand_chacha::{rand_core::SeedableRng, ChaChaRng};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+#[derive(Clone)]
+pub struct ContractsInfo {
+    pub cape_contract: TestCAPE<SignerMiddleware<Provider<Http>, Wallet<SigningKey>>>,
+    pub erc20_token_contract: SimpleToken<SignerMiddleware<Provider<Http>, Wallet<SigningKey>>>,
+    pub cape_contract_for_erc20_owner:
+        TestCAPE<SignerMiddleware<Provider<Http>, Wallet<SigningKey>>>,
+    pub erc20_token_address: H160,
+    pub owner_of_erc20_tokens_client: SignerMiddleware<Provider<Http>, Wallet<SigningKey>>,
+    pub owner_of_erc20_tokens_client_address: H160,
+}
+
+// TODO try to parametrize the struct with the trait M:Middleware
+impl ContractsInfo {
+    pub async fn new(
+        cape_contract_ref: &TestCAPE<SignerMiddleware<Provider<Http>, Wallet<SigningKey>>>,
+        erc20_token_contract_ref: &SimpleToken<
+            SignerMiddleware<Provider<Http>, Wallet<SigningKey>>,
+        >,
+    ) -> Self {
+        let cape_contract = cape_contract_ref.clone();
+        let erc20_token_contract = erc20_token_contract_ref.clone();
+
+        let erc20_token_address = erc20_token_contract.address();
+        let owner_of_erc20_tokens_client = erc20_token_contract.client().clone();
+        let owner_of_erc20_tokens_client_address = owner_of_erc20_tokens_client.address();
+
+        let cape_contract_for_erc20_owner = TestCAPE::new(
+            cape_contract_ref.address(),
+            Arc::from(owner_of_erc20_tokens_client.clone()),
+        );
+
+        Self {
+            cape_contract,
+            erc20_token_contract,
+            cape_contract_for_erc20_owner,
+            erc20_token_address,
+            owner_of_erc20_tokens_client,
+            owner_of_erc20_tokens_client_address,
+        }
+    }
+}
+
+/// Generates a user key pair that controls the faucet and call the contract for inserting a record commitment inside the merkle tree containing
+/// some native fee asset records.
+pub async fn create_faucet(
+    contract: &TestCAPE<SignerMiddleware<Provider<Http>, Wallet<SigningKey>>>,
+) -> (UserKeyPair, RecordOpening) {
+    let mut rng = ChaChaRng::from_seed([42; 32]);
+    let faucet_key_pair = UserKeyPair::generate(&mut rng);
+    let faucet_rec = RecordOpening::new(
+        &mut rng,
+        u64::MAX / 2,
+        AssetDefinition::native(),
+        faucet_key_pair.pub_key(),
+        FreezeFlag::Unfrozen,
+    );
+    let faucet_comm = RecordCommitment::from(&faucet_rec);
+    contract
+        .set_initial_record_commitments(vec![field_to_u256(faucet_comm.to_field_element())])
+        .send()
+        .await
+        .unwrap()
+        .await
+        .unwrap();
+    assert_eq!(contract.get_num_leaves().call().await.unwrap(), 1.into());
+
+    (faucet_key_pair, faucet_rec)
+}
+
+pub fn contract_abi_path(contract_name: &str) -> PathBuf {
+    [
+        &PathBuf::from(env!("CONTRACTS_DIR")),
+        Path::new("abi/contracts"),
+        Path::new(&contract_name),
+    ]
+    .iter()
+    .collect::<PathBuf>()
+}

--- a/doc/workflow/src/lib.rs
+++ b/doc/workflow/src/lib.rs
@@ -290,7 +290,7 @@ impl CapeContract {
 
                 // to validate the burn transaction, we need to check if the second output
                 // of the transfer (while the first being fee change) is sent to dedicated
-                // "burn address/pubkey". Since the contract only have record commitments,
+                // "burn address/pubkey". Since the transaction only contains record commitments,
                 // we require the user to provide the record opening and check against it.
                 assert_eq!(
                     RecordCommitment::from(burned_ro),


### PR DESCRIPTION
* Centralize the code for deploying contracts.
* Extract some useful function to fund some user with some fee asset records from the minimal relayer code.