### PR TITLE
Enable alternative nightly dev shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,9 +146,6 @@ These scripts will
 2. Run the tests.
 3. Shut down the node (if it was started in 1.)
 
-Note that running `js` tests against the `hardhat node` may take several
-minutes.
-
 The port of the node can be changed with `RPC_PORT`. For example,
 
     env RPC_PORT=8877 cape-test-geth
@@ -293,6 +290,18 @@ To watch the rust files and compile on changes
     cargo watch
 
 The command (`check` by default) can be changed with `-x` (for example `cargo watch -x test`).
+
+### Using nightly rust
+
+Certain features require a nightly compiler, to get a dev shell with nightly compiler use
+
+    nix develop .#nightly
+
+This requires nix version >= 2.4.
+
+#### Checking for unused dependencies
+
+    nix develop .#nightly --command cargo udeps
 
 ## Linting & Formatting
 

--- a/flake.nix
+++ b/flake.nix
@@ -24,133 +24,57 @@
     , pre-commit-hooks
     , ...
     }:
-    flake-utils.lib.eachDefaultSystem (system:
-    let
-      overlays = [ (import rust-overlay) ];
-      pkgs = import nixpkgs {
-        inherit system overlays;
-      };
-    in
-    {
-      checks = {
-        pre-commit-check = pre-commit-hooks.lib.${system}.run {
-          src = ./.;
-          hooks = {
-            lint-solidity = {
-              enable = true;
-              files = "^contracts/contracts/";
-              entry = "lint-solidity";
-              types = [ "solidity" ];
-            };
-            check-format = {
-              enable = true;
-              entry = "treefmt --fail-on-change";
-            };
-            # The hook "clippy" that ships with nix-precommit-hooks is outdated.
-            cargo-clippy = {
-              enable = true;
-              description = "Lint Rust code.";
-              entry = "cargo-clippy --workspace -- -D warnings";
-              files = "\\.rs$";
-              pass_filenames = false;
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        overlays = [ (import rust-overlay) ];
+        pkgs = import nixpkgs {
+          inherit system overlays;
+        };
+        checks = {
+          pre-commit-check = pre-commit-hooks.lib.${system}.run {
+            src = ./.;
+            hooks = {
+              lint-solidity = {
+                enable = true;
+                files = "^contracts/contracts/";
+                entry = "lint-solidity";
+                types = [ "solidity" ];
+              };
+              check-format = {
+                enable = true;
+                entry = "treefmt --fail-on-change";
+              };
+              # The hook "clippy" that ships with nix-precommit-hooks is outdated.
+              cargo-clippy = {
+                enable = true;
+                description = "Lint Rust code.";
+                entry = "cargo-clippy --workspace -- -D warnings";
+                files = "\\.rs$";
+                pass_filenames = false;
+              };
             };
           };
         };
-      };
-      devShell =
-        let
-          mySolc = pkgs.callPackage ./nix/solc-bin { version = "0.8.10"; };
-          pythonEnv = pkgs.poetry2nix.mkPoetryEnv {
-            projectDir = ./.;
-          };
-          myPython = with pkgs; [
-            poetry
-            pythonEnv
-          ];
-
-          stableToolchain = pkgs.rust-bin.stable."1.56.1".minimal.override {
+        mkCapeShell = import ./nix/cape_shell.nix;
+      in
+      {
+        devShell = mkCapeShell {
+          inherit pkgs checks;
+          rustToolchain = pkgs.rust-bin.stable."1.56.1".minimal.override {
             extensions = [ "rustfmt" "clippy" "llvm-tools-preview" "rust-src" ];
           };
-          rustDeps = with pkgs; [
-            pkgconfig
-            openssl
+        };
 
-            curl
-            plantuml
-            stableToolchain
-
-            cargo-edit
-          ] ++ lib.optionals stdenv.isDarwin [
-            # required to compile ethers-rs
-            darwin.apple_sdk.frameworks.Security
-            darwin.apple_sdk.frameworks.CoreFoundation
-
-            # https://github.com/NixOS/nixpkgs/issues/126182
-            libiconv
-          ] ++ lib.optionals (stdenv.system != "aarch64-darwin") [
-            cargo-watch # broken: https://github.com/NixOS/nixpkgs/issues/146349
-          ];
-          # nixWithFlakes allows pre v2.4 nix installations to use flake commands (like `nix flake update`)
-          nixWithFlakes = pkgs.writeShellScriptBin "nix" ''
-            exec ${pkgs.nixFlakes}/bin/nix --experimental-features "nix-command flakes" "$@"
-          '';
-        in
-        pkgs.mkShell
-          {
-            buildInputs = with pkgs; [
-              nixWithFlakes
-              go-ethereum
-              nodePackages.pnpm
-              mySolc
-              hivemind # process runner
-              nodejs-16_x # nodejs
-              jq
-              entr # watch files for changes, for example: ls contracts/*.sol | entr -c hardhat compile
-              treefmt # multi language formatter
-              nixpkgs-fmt
-              git # required for pre-commit hook installation
-              netcat-gnu # only used to check for open ports
-              cacert
-              mdbook # make-doc, documentation generation
-              moreutils # includes `ts`, used to add timestamps on CI
-            ]
-            ++ myPython
-            ++ rustDeps;
-
-            RUST_SRC_PATH = "${stableToolchain}/lib/rustlib/src/rust/library";
-            RUST_BACKTRACE = 1;
-            RUST_LOG = "info";
-
-            SOLCX_BINARY_PATH = "${mySolc}/bin";
-            SOLC_VERSION = mySolc.version;
-            SOLC_PATH = "${mySolc}/bin/solc";
-            # TODO: increase this when contract size limit is not a problem
-            SOLC_OPTIMIZER_RUNS = "20";
-
-            shellHook = ''
-              echo "Ensuring node dependencies are installed"
-              pnpm --recursive install
-
-              if [ ! -f .env ]; then
-                echo "Copying .env.sample to .env"
-                cp .env.sample .env
-              fi
-
-              echo "Exporting all vars in .env file"
-              set -a; source .env; set +a;
-
-              export CONTRACTS_DIR=$(pwd)/contracts
-              export HARDHAT_CONFIG=$CONTRACTS_DIR/hardhat.config.ts
-              export PATH=$(pwd)/node_modules/.bin:$PATH
-              export PATH=$CONTRACTS_DIR/node_modules/.bin:$PATH
-              export PATH=$(pwd)/bin:$PATH
-
-              git config --local blame.ignoreRevsFile .git-blame-ignore-revs
-            ''
-            # install pre-commit hooks
-            + self.checks.${system}.pre-commit-check.shellHook;
-          };
-
-    }
+        devShells.nightly = mkCapeShell {
+          inherit pkgs checks;
+          rustToolchain = pkgs.rust-bin.selectLatestNightlyWith (toolchain:
+            toolchain.default.override {
+              extensions = [ "rustfmt" "clippy" "llvm-tools-preview" "rust-src" ];
+            }
+          );
+          extraPkgs = with pkgs; [ cargo-udeps ];
+        };
+      }
     );
 }

--- a/nix/cape_shell.nix
+++ b/nix/cape_shell.nix
@@ -1,0 +1,92 @@
+{ pkgs, checks, rustToolchain, extraPkgs ? [ ] }:
+let
+  mySolc = pkgs.callPackage ./solc-bin { version = "0.8.10"; };
+  pythonEnv = pkgs.poetry2nix.mkPoetryEnv {
+    projectDir = ../.;
+  };
+  myPython = with pkgs; [
+    poetry
+    pythonEnv
+  ];
+
+  rustDeps = with pkgs; [
+    pkgconfig
+    openssl
+
+    curl
+    plantuml
+    rustToolchain
+
+    cargo-edit
+  ]
+  ++ lib.optionals stdenv.isDarwin [
+    # required to compile ethers-rs
+    darwin.apple_sdk.frameworks.Security
+    darwin.apple_sdk.frameworks.CoreFoundation
+
+    # https://github.com/NixOS/nixpkgs/issues/126182
+    libiconv
+  ] ++ lib.optionals (stdenv.system != "aarch64-darwin") [
+    cargo-watch # broken: https://github.com/NixOS/nixpkgs/issues/146349
+  ];
+  # nixWithFlakes allows pre v2.4 nix installations to use flake commands (like `nix flake update`)
+  nixWithFlakes = pkgs.writeShellScriptBin "nix" ''
+    exec ${pkgs.nixFlakes}/bin/nix --experimental-features "nix-command flakes" "$@"
+  '';
+in
+pkgs.mkShell
+{
+  buildInputs = with pkgs; [
+    nixWithFlakes
+    go-ethereum
+    nodePackages.pnpm
+    mySolc
+    hivemind # process runner
+    nodejs-16_x # nodejs
+    jq
+    entr # watch files for changes, for example: ls contracts/*.sol | entr -c hardhat compile
+    treefmt # multi language formatter
+    nixpkgs-fmt
+    git # required for pre-commit hook installation
+    netcat-gnu # only used to check for open ports
+    cacert
+    mdbook # make-doc, documentation generation
+    moreutils # includes `ts`, used to add timestamps on CI
+  ]
+  ++ myPython
+  ++ rustDeps
+  ++ extraPkgs;
+
+  RUST_SRC_PATH = "${rustToolchain}/lib/rustlib/src/rust/library";
+  RUST_BACKTRACE = 1;
+  RUST_LOG = "info";
+
+  SOLCX_BINARY_PATH = "${mySolc}/bin";
+  SOLC_VERSION = mySolc.version;
+  SOLC_PATH = "${mySolc}/bin/solc";
+  # TODO: increase this when contract size limit is not a problem
+  SOLC_OPTIMIZER_RUNS = "20";
+
+  shellHook = ''
+    echo "Ensuring node dependencies are installed"
+    pnpm --recursive install
+
+    if [ ! -f .env ]; then
+      echo "Copying .env.sample to .env"
+      cp .env.sample .env
+    fi
+
+    echo "Exporting all vars in .env file"
+    set -a; source .env; set +a;
+
+    export CONTRACTS_DIR=$(pwd)/contracts
+    export HARDHAT_CONFIG=$CONTRACTS_DIR/hardhat.config.ts
+    export PATH=$(pwd)/node_modules/.bin:$PATH
+    export PATH=$CONTRACTS_DIR/node_modules/.bin:$PATH
+    export PATH=$(pwd)/bin:$PATH
+
+    git config --local blame.ignoreRevsFile .git-blame-ignore-revs
+  ''
+  # install pre-commit hooks
+  + checks.pre-commit-check.shellHook;
+}


### PR DESCRIPTION
### Motivation
- ~~Timing tests for #417~~
- Being able to use `cargo-udeps` for finding unused dependencies

### Notes
- Move dev shell to its own file
- Add instructions about how to use nightly dev shell
- Tested on `nixos` and `aarch64-darwin`

I'm not sure the way I "organized" the flake is very idiomatic but it does seem to get the job done.