### PR TITLE
Feat/t182 unwrapping

### DIFF
--- a/contracts/rust/src/assertion.rs
+++ b/contracts/rust/src/assertion.rs
@@ -2,7 +2,7 @@
 use ethers::{abi::Detokenize, prelude::*};
 use std::fmt::Debug;
 
-pub(crate) trait Matcher {
+pub trait Matcher {
     fn should_not_revert(self);
     fn should_revert(self);
     fn should_revert_with_message(self, message: &str);

--- a/contracts/rust/src/cape/mod.rs
+++ b/contracts/rust/src/cape/mod.rs
@@ -352,7 +352,7 @@ mod tests {
         // submit the block during which validity proofs would be verified in batch
         let cape_block = CapeBlock::generate(params.txns, vec![], miner.address())?;
         contract
-            .submit_cape_block(cape_block.into(), vec![])
+            .submit_cape_block(cape_block.into())
             .send()
             .await?
             .await?;
@@ -371,7 +371,7 @@ mod tests {
         // Submitting an empty block does not yield a reject from the contract
         let contract = deploy_cape_test().await;
         contract
-            .submit_cape_block(cape_block.into(), vec![])
+            .submit_cape_block(cape_block.into())
             .send()
             .await?
             .await?;
@@ -423,7 +423,7 @@ mod tests {
 
         // Submit to the contract
         contract
-            .submit_cape_block(cape_block.into(), vec![])
+            .submit_cape_block(cape_block.into())
             .send()
             .await?
             .await?;
@@ -458,7 +458,7 @@ mod tests {
             .await?;
 
         contract
-            .submit_cape_block(cape_block.into(), vec![])
+            .submit_cape_block(cape_block.into())
             .send()
             .await?
             .await?;
@@ -484,7 +484,7 @@ mod tests {
             .await?;
 
         contract
-            .submit_cape_block(cape_block.into(), vec![])
+            .submit_cape_block(cape_block.into())
             .send()
             .await?
             .await?;

--- a/contracts/rust/src/cape/note_types.rs
+++ b/contracts/rust/src/cape/note_types.rs
@@ -131,12 +131,11 @@ async fn test_check_transfer_expired_note_triggers_an_error() -> Result<()> {
         .await?
         .await?;
 
-    let call = contract
-        .submit_cape_block(cape_block.into(), vec![])
+    contract
+        .submit_cape_block(cape_block.into())
         .call()
-        .await;
-
-    call.should_revert_with_message("Expired note");
+        .await
+        .should_revert_with_message("Expired note");
 
     Ok(())
 }

--- a/contracts/rust/src/cape/submit_block.rs
+++ b/contracts/rust/src/cape/submit_block.rs
@@ -91,7 +91,7 @@ async fn test_submit_empty_block_to_cape_contract() -> Result<()> {
 
     // Submitting an empty block does not yield a reject from the contract
     contract
-        .submit_cape_block(cape_block.into(), vec![])
+        .submit_cape_block(cape_block.into())
         .send()
         .await?
         .await?;
@@ -143,7 +143,7 @@ async fn test_submit_block_to_cape_contract() -> Result<()> {
 
     // Submit to the contract
     contract
-        .submit_cape_block(cape_block.into(), vec![])
+        .submit_cape_block(cape_block.into())
         .send()
         .await?
         .await?;
@@ -178,7 +178,7 @@ async fn test_block_height() -> Result<()> {
         .await?;
 
     contract
-        .submit_cape_block(cape_block.into(), vec![])
+        .submit_cape_block(cape_block.into())
         .send()
         .await?
         .await?;
@@ -206,7 +206,7 @@ async fn test_event_block_committed() -> Result<()> {
         .await?;
 
     contract
-        .submit_cape_block(cape_block.into(), vec![])
+        .submit_cape_block(cape_block.into())
         .send()
         .await?
         .await?;
@@ -240,7 +240,7 @@ async fn test_check_domestic_asset_code_in_submit_cape_block() -> Result<()> {
         InternalAssetCode::new(AssetCodeSeed::generate(rng), b"description");
 
     contract
-        .submit_cape_block(block.into(), vec![])
+        .submit_cape_block(block.into())
         .call()
         .await
         .should_revert_with_message("Wrong domestic asset code");

--- a/contracts/rust/src/cape_e2e_tests.rs
+++ b/contracts/rust/src/cape_e2e_tests.rs
@@ -218,7 +218,7 @@ async fn test_2user_maybe_submit(should_submit: bool) -> Result<()> {
             CapeBlock::from_cape_transactions(vec![txn1_cape.clone()], miner.address())?;
         // Submit to the contract
         contract
-            .submit_cape_block(cape_block.into(), vec![])
+            .submit_cape_block(cape_block.into())
             .send()
             .await?
             .await?;

--- a/contracts/rust/src/eqs_test.rs
+++ b/contracts/rust/src/eqs_test.rs
@@ -82,7 +82,7 @@ mod tests {
                 contract
                     .lock()
                     .await
-                    .submit_cape_block(cape_block.into(), vec![])
+                    .submit_cape_block(cape_block.into())
                     .send()
                     .await
                     .unwrap()

--- a/contracts/rust/src/lib.rs
+++ b/contracts/rust/src/lib.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 extern crate num_derive;
 
-mod assertion;
+pub mod assertion;
 mod asset_registry;
 mod bn254;
 pub mod cape;

--- a/contracts/rust/src/records_merkle_tree/mod.rs
+++ b/contracts/rust/src/records_merkle_tree/mod.rs
@@ -112,28 +112,12 @@ fn parse_flattened_frontier(flattened_frontier: &[Fr254], uid: u64) -> MerkleFro
 mod tests {
     use super::*;
     use crate::deploy::deploy_test_records_merkle_tree_contract;
-    use crate::helpers::{compare_merkle_root_from_contract_and_jf_tree, convert_fr254_to_u256};
-    use crate::types::TestRecordsMerkleTree;
+    use crate::helpers::convert_fr254_to_u256;
+    use crate::test_utils::compare_roots_records_merkle_tree_contract;
     use ark_ed_on_bn254::Fq as Fr254;
     use ark_std::UniformRand;
-    use ethers::prelude::{Http, Provider, SignerMiddleware, Wallet, U256};
+    use ethers::prelude::U256;
     use jf_primitives::merkle_tree::{MerkleTree, NodeValue};
-
-    async fn compare_roots(
-        mt: &MerkleTree<Fr254>,
-        contract: &TestRecordsMerkleTree<
-            SignerMiddleware<Provider<Http>, Wallet<ethers::core::k256::ecdsa::SigningKey>>,
-        >,
-        should_be_equal: bool,
-    ) {
-        let root_fr254 = mt.commitment().root_value;
-        let root_value_u256 = contract.get_root_value().call().await.unwrap();
-
-        assert_eq!(
-            should_be_equal,
-            compare_merkle_root_from_contract_and_jf_tree(root_value_u256, root_fr254)
-        );
-    }
 
     #[test]
     fn test_jellyfish_records_merkle_tree() {
@@ -245,7 +229,7 @@ mod tests {
         let mut mt = MerkleTree::<Fr254>::new(height).unwrap();
 
         // At beginning (no leaf inserted) both roots are the same.
-        compare_roots(&mt, &contract, true).await;
+        compare_roots_records_merkle_tree_contract(&mt, &contract, true).await;
 
         // We insert the first set of leaves
         let elems_u256 = insert_elements_into_jellyfish_mt(&mut mt, n_leaves_before);
@@ -258,7 +242,7 @@ mod tests {
             .await
             .unwrap();
 
-        compare_roots(&mt, &contract, true).await;
+        compare_roots_records_merkle_tree_contract(&mt, &contract, true).await;
 
         // We insert the second set of leaves
         let elems_u256 = insert_elements_into_jellyfish_mt(&mut mt, n_leaves_after);
@@ -271,7 +255,7 @@ mod tests {
             .await
             .unwrap();
 
-        compare_roots(&mt, &contract, true).await;
+        compare_roots_records_merkle_tree_contract(&mt, &contract, true).await;
     }
 
     #[tokio::test]

--- a/contracts/rust/src/test_utils.rs
+++ b/contracts/rust/src/test_utils.rs
@@ -1,8 +1,20 @@
+use crate::cape::{BurnNote, DOM_SEP_CAPE_BURN};
+use crate::helpers::compare_merkle_root_from_contract_and_jf_tree;
+use crate::ledger::CapeLedger;
+use crate::types::TestRecordsMerkleTree;
 use crate::types::{field_to_u256, SimpleToken, TestCAPE};
-use ethers::prelude::{k256::ecdsa::SigningKey, Http, Provider, SignerMiddleware, Wallet, H160};
-use jf_aap::keys::UserKeyPair;
-use jf_aap::structs::{AssetDefinition, FreezeFlag, RecordCommitment, RecordOpening};
+use ethers::prelude::{
+    k256::ecdsa::SigningKey, Address, Http, Provider, SignerMiddleware, Wallet, H160, U256,
+};
+use jf_aap::keys::{UserKeyPair, UserPubKey};
+use jf_aap::structs::{
+    AssetDefinition, FeeInput, FreezeFlag, RecordCommitment, RecordOpening, TxnFeeInfo,
+};
+use jf_aap::testing_apis::universal_setup_for_test;
+use jf_aap::transfer::{TransferNote, TransferNoteInput};
+use jf_aap::{AccMemberWitness, MerkleTree};
 use rand_chacha::{rand_core::SeedableRng, ChaChaRng};
+use reef::Ledger;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -83,4 +95,130 @@ pub fn contract_abi_path(contract_name: &str) -> PathBuf {
     ]
     .iter()
     .collect::<PathBuf>()
+}
+
+pub async fn check_erc20_token_balance(
+    erc20_token_contract: &SimpleToken<SignerMiddleware<Provider<Http>, Wallet<SigningKey>>>,
+    user_eth_address: Address,
+    expected_amount: U256,
+) {
+    let balance = erc20_token_contract
+        .balance_of(user_eth_address)
+        .call()
+        .await
+        .unwrap();
+    assert_eq!(balance, expected_amount);
+}
+
+pub fn compute_extra_proof_bound_data_for_burn_tx(recipient_address: Address) -> Vec<u8> {
+    [
+        DOM_SEP_CAPE_BURN.to_vec(),
+        recipient_address.to_fixed_bytes().to_vec(),
+    ]
+    .concat()
+}
+
+pub fn generate_burn_tx(
+    faucet_key_pair: &UserKeyPair,
+    faucet_ro: RecordOpening,
+    wrapped_ro: RecordOpening,
+    mt: &MerkleTree,
+    pos_fee_comm: u64,
+    pos_wrapped_asset_comm: u64,
+    ethereum_recipient_address: Address,
+) -> BurnNote {
+    let mut rng = ChaChaRng::from_seed([42; 32]);
+
+    let srs = universal_setup_for_test(2usize.pow(16), &mut rng).unwrap();
+
+    // 2 inputs: fee input record and wrapped asset record
+    // 2 outputs: changed fee asset record, burn output record
+    let xfr_prove_key =
+        jf_aap::proof::transfer::preprocess(&srs, 2, 2, CapeLedger::merkle_height())
+            .unwrap()
+            .0;
+    let valid_until = 2u64.pow(jf_aap::constants::MAX_TIMESTAMP_LEN as u32) - 1;
+
+    let fee_input = FeeInput {
+        ro: faucet_ro,
+        acc_member_witness: AccMemberWitness::lookup_from_tree(mt, pos_fee_comm)
+            .expect_ok()
+            .unwrap()
+            .1,
+        owner_keypair: faucet_key_pair,
+    };
+
+    let txn_fee_info = TxnFeeInfo::new(&mut rng, fee_input, 10).unwrap().0;
+
+    let inputs = vec![TransferNoteInput {
+        ro: wrapped_ro.clone(),
+        acc_member_witness: AccMemberWitness::lookup_from_tree(mt, pos_wrapped_asset_comm)
+            .expect_ok()
+            .unwrap()
+            .1,
+        owner_keypair: faucet_key_pair,
+        cred: None,
+    }];
+
+    let burn_pk = UserPubKey::default();
+    let burn_ro = RecordOpening::new(
+        &mut rng,
+        wrapped_ro.amount,
+        wrapped_ro.asset_def,
+        burn_pk,
+        FreezeFlag::Unfrozen,
+    );
+
+    let outputs = vec![burn_ro.clone()];
+
+    // Set the correct extra_proof_bound_data
+    // The wrapped asset is sent back to the depositor address
+    let extra_proof_bound_data =
+        compute_extra_proof_bound_data_for_burn_tx(ethereum_recipient_address);
+
+    let note = TransferNote::generate_non_native(
+        &mut rng,
+        inputs,
+        &outputs,
+        txn_fee_info,
+        valid_until,
+        &xfr_prove_key,
+        extra_proof_bound_data,
+    )
+    .unwrap()
+    .0;
+
+    BurnNote::generate(note, burn_ro).unwrap()
+}
+
+pub async fn compare_roots_records_merkle_tree_contract(
+    mt: &MerkleTree,
+    contract: &TestRecordsMerkleTree<
+        SignerMiddleware<Provider<Http>, Wallet<ethers::core::k256::ecdsa::SigningKey>>,
+    >,
+    should_be_equal: bool,
+) {
+    let root_fr254 = mt.commitment().root_value;
+    let root_value_u256 = contract.get_root_value().call().await.unwrap();
+
+    assert_eq!(
+        should_be_equal,
+        compare_merkle_root_from_contract_and_jf_tree(root_value_u256, root_fr254)
+    );
+}
+
+pub async fn compare_roots_records_test_cape_contract(
+    mt: &MerkleTree,
+    contract: &TestCAPE<
+        SignerMiddleware<Provider<Http>, Wallet<ethers::core::k256::ecdsa::SigningKey>>,
+    >,
+    should_be_equal: bool,
+) {
+    let root_fr254 = mt.commitment().root_value;
+    let root_value_u256 = contract.get_root_value().call().await.unwrap();
+
+    assert_eq!(
+        should_be_equal,
+        compare_merkle_root_from_contract_and_jf_tree(root_value_u256, root_fr254)
+    );
 }

--- a/contracts/rust/tests/ethereum_test.rs
+++ b/contracts/rust/tests/ethereum_test.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use cap_rust_sandbox::deploy::deploy_greeter_contract;
 
 #[tokio::test]
@@ -8,18 +9,15 @@ async fn test_basic_contract_deployment() {
 }
 
 #[tokio::test]
-async fn test_basic_contract_transaction() {
+async fn test_basic_contract_transaction() -> Result<()> {
     let contract = deploy_greeter_contract().await.unwrap();
     let _receipt = contract
         .set_greeting("Hi!".to_string())
-        .legacy()
         .send()
-        .await
-        .unwrap()
-        .await
-        .unwrap()
-        .expect("Failed to get TX receipt");
+        .await?
+        .await?;
 
     let res: String = contract.greet().call().await.unwrap();
     assert_eq!(res, "Hi!");
+    Ok(())
 }

--- a/contracts/rust/tests/unwrapping.rs
+++ b/contracts/rust/tests/unwrapping.rs
@@ -1,0 +1,182 @@
+use anyhow::Result;
+use cap_rust_sandbox::assertion::Matcher;
+use cap_rust_sandbox::cape::CapeBlock;
+use cap_rust_sandbox::deploy::{deploy_cape_test, deploy_erc20_token};
+use cap_rust_sandbox::ethereum::get_funded_client;
+use cap_rust_sandbox::helpers::eth_transaction_has_been_mined;
+use cap_rust_sandbox::ledger::CapeLedger;
+use cap_rust_sandbox::state::{erc20_asset_description, Erc20Code, EthereumAddr};
+use cap_rust_sandbox::test_utils::{
+    check_erc20_token_balance, compare_roots_records_test_cape_contract, create_faucet,
+    generate_burn_tx, ContractsInfo,
+};
+use cap_rust_sandbox::types as sol;
+use cap_rust_sandbox::types::GenericInto;
+use ethers::prelude::U256;
+use jf_aap::keys::{CredIssuerPubKey, UserPubKey};
+use jf_aap::structs::{
+    AssetCode, AssetDefinition, AssetPolicy, FreezeFlag, RecordCommitment, RecordOpening,
+};
+use jf_aap::{MerkleTree, TransactionNote};
+use reef::Ledger;
+
+#[tokio::test]
+async fn integration_test_unwrapping() -> Result<()> {
+    // Deploy the contracts
+    let cape_contract = deploy_cape_test().await;
+
+    // Deploy ERC20 token contract. The client deploying the erc20 token contract receives 1000 * 10**18 tokens
+    let erc20_token_contract = deploy_erc20_token().await;
+    let contracts_info = ContractsInfo::new(&cape_contract, &erc20_token_contract).await;
+
+    // Generate a new client that will receive the unwrapped assets
+    let final_recipient_of_unwrapped_assets = get_funded_client().await?;
+
+    let mut mt = MerkleTree::new(CapeLedger::merkle_height()).unwrap();
+
+    // Create some fee asset record
+    let (faucet_key_pair, faucet_record_opening) = create_faucet(&cape_contract).await;
+    let faucet_record_comm = RecordCommitment::from(&faucet_record_opening).to_field_element();
+    mt.push(faucet_record_comm);
+
+    // Sponsor CAPE asset
+    let rng = &mut ark_std::test_rng();
+    let erc20_code = Erc20Code(EthereumAddr(
+        contracts_info.erc20_token_address.to_fixed_bytes(),
+    ));
+
+    let sponsor = contracts_info.owner_of_erc20_tokens_client_address;
+    let description = erc20_asset_description(&erc20_code, &EthereumAddr(sponsor.to_fixed_bytes()));
+    let asset_code = AssetCode::new_foreign(&description);
+
+    // We use an asset policy that does not track the user's credential.
+    let asset_policy =
+        AssetPolicy::rand_for_test(rng).set_cred_issuer_pub_key(CredIssuerPubKey::default());
+
+    let asset_def = AssetDefinition::new(asset_code, asset_policy).unwrap();
+    let asset_def_sol = asset_def.clone().generic_into::<sol::AssetDefinition>();
+
+    contracts_info
+        .cape_contract_for_erc20_owner
+        .sponsor_cape_asset(contracts_info.erc20_token_address, asset_def_sol)
+        .send()
+        .await?
+        .await?;
+
+    let deposited_amount = 1000u64;
+
+    let cape_contract_address = contracts_info.cape_contract.address();
+
+    // Deposit ERC20 tokens
+    let amount_u256 = U256::from(deposited_amount);
+    contracts_info
+        .erc20_token_contract
+        .approve(cape_contract_address, amount_u256)
+        .send()
+        .await?
+        .await?;
+
+    let wrapped_ro = RecordOpening::new(
+        rng,
+        deposited_amount,
+        asset_def,
+        faucet_key_pair.pub_key(),
+        FreezeFlag::Unfrozen,
+    );
+
+    let wrapped_record_comm = RecordCommitment::from(&wrapped_ro).to_field_element();
+    mt.push(wrapped_record_comm);
+
+    // We call the CAPE contract from the address that owns the ERC20 tokens
+    contracts_info
+        .cape_contract_for_erc20_owner
+        .deposit_erc_20(
+            wrapped_ro.clone().generic_into::<sol::RecordOpening>(),
+            contracts_info.erc20_token_address,
+        )
+        .send()
+        .await?
+        .await?;
+
+    // Submit empty block to trigger the inclusion of the pending deposit record commitment into the merkle tree
+    let miner = UserPubKey::default();
+    let empty_block = CapeBlock::generate(vec![], vec![], miner.address())?;
+
+    let receipt = cape_contract
+        .submit_cape_block(empty_block.clone().into())
+        .send()
+        .await?
+        .await;
+
+    assert!(eth_transaction_has_been_mined(&receipt.unwrap().unwrap()));
+
+    // Create burn transaction and record opening based on the content of the records merkle tree
+    let unwrapped_assets_recipient_eth_address = final_recipient_of_unwrapped_assets.address();
+
+    const POS_FEE_COMM: u64 = 0;
+    const POS_WRAPPED_ASSET_COMM: u64 = 1;
+
+    let cape_burn_tx = generate_burn_tx(
+        &faucet_key_pair,
+        faucet_record_opening,
+        wrapped_ro,
+        &mt,
+        POS_FEE_COMM,
+        POS_WRAPPED_ASSET_COMM,
+        unwrapped_assets_recipient_eth_address,
+    );
+
+    // Create and submit new block with the burn transaction
+    let burn_transaction_note =
+        TransactionNote::Transfer(Box::new(cape_burn_tx.clone().transfer_note));
+    let mut cape_block = CapeBlock::generate(
+        vec![burn_transaction_note],
+        vec![cape_burn_tx.clone().burned_ro],
+        miner.address(),
+    )
+    .unwrap();
+
+    // Alter the burn record opening to trigger an error in the CAPE contract
+    // when checking that the record opening and its commitment inside the burn transaction match.
+    cape_block.burn_notes[0].burned_ro.amount = 2222;
+
+    cape_contract
+        .submit_cape_block(cape_block.clone().into())
+        .call()
+        .await
+        .should_revert_with_message("Bad record commitment");
+
+    // Use the right burned amount and check the transaction goes through
+    cape_block.burn_notes[0].burned_ro.amount = deposited_amount;
+
+    cape_contract
+        .submit_cape_block(cape_block.clone().into())
+        .send()
+        .await?
+        .await?;
+
+    // The recipient has received the ERC20 tokens
+    check_erc20_token_balance(
+        &contracts_info.erc20_token_contract,
+        unwrapped_assets_recipient_eth_address,
+        U256::from(deposited_amount),
+    )
+    .await;
+
+    // The ERC20 tokens have left the CAPE contract
+    check_erc20_token_balance(
+        &contracts_info.erc20_token_contract,
+        cape_contract_address,
+        U256::from(0),
+    )
+    .await;
+
+    // Check that the records merkle tree is updated correctly, in particular that the burned record commitment is NOT inserted
+    let burned_tx_fee_rc =
+        cape_block.burn_notes[0].transfer_note.output_commitments[0].to_field_element();
+    mt.push(burned_tx_fee_rc);
+
+    compare_roots_records_test_cape_contract(&mt, &cape_contract, true).await;
+
+    Ok(())
+}

--- a/relayer/src/lib.rs
+++ b/relayer/src/lib.rs
@@ -68,16 +68,13 @@ async fn relay(
     transaction: CapeTransaction,
 ) -> Result<TransactionReceipt, Error> {
     let miner = UserPubKey::default();
-    let burned_ros = match &transaction {
-        CapeTransaction::Burn { ro, .. } => vec![(**ro).clone().into()],
-        _ => vec![],
-    };
+
     let cape_block = CapeBlock::from_cape_transactions(vec![transaction], miner.address())
         .map_err(|err| Error::BadBlock {
             msg: err.to_string(),
         })?;
     contract
-        .submit_cape_block(cape_block.into(), burned_ros)
+        .submit_cape_block(cape_block.into())
         .send()
         .await
         .map_err(|err| Error::Submission { msg: err.to_string() })?


### PR DESCRIPTION
Closes #182.

* Check that the output commitment corresponding to the burned record opening is computed correctly
* Insert all output commitments except the burned one
 * Rust workflow specification updated.  
* Send the erc20 tokens to the ethereum address specified in extra_proof_bound_data
