### PR TITLE
Separate slow tests into a different workflow.

### DIFF
--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -1,0 +1,58 @@
+name: Slow Tests
+
+on:
+  push:
+  workflow_dispatch:
+
+env:
+  RUST_TEST_THREADS: 4
+  # TODO: remove this or increase this when contract size limit is not a problem
+  SOLC_OPTIMIZER_RUNS: 20
+
+jobs:
+  build:
+    runs-on: self-hosted
+    container:
+      image: ghcr.io/spectrumxyz/nix:main
+      credentials:
+        username: ancient123
+        password: ${{ secrets.ORG_GITHUB_PAT }}
+      volumes:
+        - github_nix_251:/nix
+    steps:
+      - uses: styfle/cancel-workflow-action@0.9.1
+        name: Cancel Outdated Builds
+        with:
+          access_token: ${{ github.token }}
+
+      - name: Install Tools
+        # git not installed by default
+        # alpine default tar is not compatible: https://stackoverflow.com/a/64187955
+        run: |
+          apk add --no-cache tar git
+
+      - uses: actions/checkout@v2
+        name: Checkout Repository
+
+      - name: Initialize Nix Shell
+        run: nix-shell --run "echo Init"
+
+      - name: Configure Git
+        run: |
+          git config --global url."https://ancient123:${{ secrets.ORG_GITHUB_PAT }}@github.com".insteadOf git://github.com
+          git config --global url."https://ancient123:${{ secrets.ORG_GITHUB_PAT }}@github.com".insteadOf ssh://git@github.com
+          git config --global url."https://dl.cloudsmith.io/${{ secrets.CLOUDSMITH_ENTITLEMENT }}/".insteadOf https://dl.cloudsmith.io/basic/
+
+      - name: Cache cargo
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git
+            target
+          # todo: add nix key, for example:  nix-instantiate shell.nix | sha256sum  | head -c 10
+          key: cape-v3-${{ hashFiles('Cargo.lock') }}
+
+      - name: Run Tests
+        run: nix-shell --run "prepend-timestamps cape-test-geth-slow"

--- a/bin/cape-test-geth-slow
+++ b/bin/cape-test-geth-slow
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RPC_PORT=${RPC_PORT:-8545}
+node_pid=""
+
+# kill background processes on exit, from https://stackoverflow.com/a/2173421
+trap "exit" INT TERM
+trap cleanup EXIT
+function cleanup(){
+   if [[ $node_pid ]]; then
+     echo "Sending HUP signal to run-geth: $node_pid"
+     kill -HUP $node_pid
+   fi
+}
+
+echo "Compile contracts and generate ABI artifacts"
+build-abi
+
+if is-listening $RPC_PORT; then
+   echo "Using node running at $RPC_PORT"
+else
+   echo "Starting geth node"
+   run-geth --verbosity 0 --http.port $RPC_PORT &
+   node_pid=$!
+   wait-port $RPC_PORT
+fi
+
+echo "Running rust tests against geth backend"
+env RPC_URL=http://localhost:$RPC_PORT cargo test --release --features=slow-tests -- -Zunstable-options --report-time
+
+echo "All tests passed!"

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -57,3 +57,6 @@ universal-param = { git = "ssh://git@github.com/SpectrumXYZ/universal-param.git"
 [dev-dependencies]
 tempdir = "0.3.7"
 tracing-test = "0.2.1"
+
+[features]
+slow-tests = []

--- a/wallet/src/bin/web_server.rs
+++ b/wallet/src/bin/web_server.rs
@@ -124,6 +124,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "slow-tests")]
     #[async_std::test]
     #[traced_test]
     async fn test_newwallet() {
@@ -157,6 +158,7 @@ mod tests {
             .expect_err("newwallet succeeded when a wallet already existed");
     }
 
+    #[cfg(feature = "slow-tests")]
     #[async_std::test]
     #[traced_test]
     async fn test_openwallet() {
@@ -204,6 +206,7 @@ mod tests {
             .expect_err("openwallet succeeded with an invalid path");
     }
 
+    #[cfg(feature = "slow-tests")]
     #[async_std::test]
     #[traced_test]
     async fn test_closewallet() {

--- a/wallet/src/mocks.rs
+++ b/wallet/src/mocks.rs
@@ -782,7 +782,9 @@ mod cape_wallet_tests {
     use seahorse::txn_builder::TransactionError;
     use std::time::Instant;
 
+    #[cfg(feature = "slow-tests")]
     use testing::generic_wallet_tests;
+    #[cfg(feature = "slow-tests")]
     seahorse::instantiate_generic_wallet_tests!(CapeTest);
 
     #[async_std::test]


### PR DESCRIPTION
* Add a Rust feature "slow tests"
* Annotate tests that shouldn't block merges with #[cfg(feature="slow-tests")]
* Add a separate GitHub workflow to run all the tests (including slow ones)

The "Slow Tests" workflow repeats all the fast tests from the Build workflow. Is there a good way to _only_ run the slow tests to avoid redundancy?

So far I have only annotated wallet tests as "slow". This already makes a big difference in the time it takes to run the default tests, but anyone familiar with the other components should feel free to mark appropriate tests as slow.