### PR TITLE
Problem: there is no check in `CAPE.depositErc20` about the queue size

### DIFF
--- a/contracts/contracts/CAPE.sol
+++ b/contracts/contracts/CAPE.sol
@@ -29,12 +29,6 @@ contract CAPE is RecordsMerkleTree, RootStore, AssetRegistry, Queue {
     uint64 public blockHeight;
     IPlonkVerifier private _verifier;
 
-    // In order to avoid the contract running out of gas if the queue is too large
-    // we set the maximum number of pending deposits record commitments to process
-    // when a new block is submitted. This is a temporary solution.
-    // See https://github.com/SpectrumXYZ/cape/issues/400
-    uint64 public constant MAX_QUEUE_SIZE = 10;
-
     using AccumulatingArray for AccumulatingArray.Data;
 
     bytes public constant CAPE_BURN_MAGIC_BYTES = "TRICAPE burn";
@@ -308,7 +302,7 @@ contract CAPE is RecordsMerkleTree, RootStore, AssetRegistry, Queue {
         uint256[] memory depositComms = new uint256[](numPendingDeposits);
 
         // See https://github.com/SpectrumXYZ/cape/issues/400 for why we check that the queue has at most MAX_QUEUE_SIZE elements
-        if ((numPendingDeposits > 0) && (numPendingDeposits < MAX_QUEUE_SIZE)) {
+        if (numPendingDeposits > 0) {
             for (uint256 i = 0; i < numPendingDeposits; i++) {
                 uint256 rc = _getQueueElem(i);
                 depositComms[i] = rc;

--- a/contracts/contracts/Queue.sol
+++ b/contracts/contracts/Queue.sol
@@ -5,12 +5,19 @@ contract Queue {
     mapping(uint256 => uint256) internal _queue;
     uint256 internal _queueSize;
 
+    // In order to avoid the contract running out of gas if the queue is too large
+    // we set the maximum number of pending deposits record commitments to process
+    // when a new block is submitted. This is a temporary solution.
+    // See https://github.com/SpectrumXYZ/cape/issues/400
+    uint64 public constant MAX_QUEUE_SIZE = 10;
+
     constructor() {
         _queueSize = 0;
     }
 
     // These functions must be internal
     function _pushToQueue(uint256 recordCommitment) internal {
+        require(_getQueueSize() < MAX_QUEUE_SIZE, "Pending deposits queue is full");
         _queue[_queueSize] = recordCommitment;
         _queueSize += 1;
     }

--- a/contracts/contracts/mocks/TestCAPE.sol
+++ b/contracts/contracts/mocks/TestCAPE.sol
@@ -89,4 +89,12 @@ contract TestCAPE is CAPE {
     function isPendingDepositsQueueEmpty() public returns (bool) {
         return _isQueueEmpty();
     }
+
+    function fillUpPendingDepositsQueue() public {
+        bool isQueueFull = (_getQueueSize() == MAX_QUEUE_SIZE);
+        while (!isQueueFull) {
+            _pushToQueue(0);
+            isQueueFull = (_getQueueSize() == MAX_QUEUE_SIZE);
+        }
+    }
 }


### PR DESCRIPTION
We need to ensure the queue is not full before inserting new pending deposits.
Solution: raise an error if the queue is already full.

Closes #442.