### PR TITLE
Simplify accumulating array library

### DIFF
--- a/contracts/contracts/libraries/AccumulatingArray.sol
+++ b/contracts/contracts/libraries/AccumulatingArray.sol
@@ -2,8 +2,8 @@
 pragma solidity ^0.8.0;
 
 /// @title AccumulatingArray library
-/// @dev There are no dynamic in memory arrays in solidity.
-/// This library can be used as a replacement.
+/// @dev This library simplifies inserting elements into an array by keeping track
+///      of the insertion index.
 
 library AccumulatingArray {
     struct Data {
@@ -12,13 +12,13 @@ library AccumulatingArray {
     }
 
     /// @dev Create a new AccumulatingArray
-    /// @param maxLength the maximum number of items that can be added
-    function create(uint256 maxLength) internal pure returns (Data memory) {
-        return Data(new uint256[](maxLength), 0);
+    /// @param length the number of items that will be inserted
+    function create(uint256 length) internal pure returns (Data memory) {
+        return Data(new uint256[](length), 0);
     }
 
     /// @param items the items to accumulate
-    /// @dev Will revert if items past maxLength are added.
+    /// @dev Will revert if items past length are added.
     function add(Data memory self, uint256[] memory items) internal pure {
         for (uint256 i = 0; i < items.length; i++) {
             self.items[i + self.index] = items[i];
@@ -27,19 +27,10 @@ library AccumulatingArray {
     }
 
     /// @param item the item to accumulate.
-    /// @dev Will revert if items past maxLength are added.
+    /// @dev Will revert if items past length are added.
     function add(Data memory self, uint256 item) internal pure {
         self.items[self.index] = item;
         self.index += 1;
-    }
-
-    /// @return array with all the accumulated items
-    function toArray(Data memory self) internal pure returns (uint256[] memory) {
-        uint256[] memory out = new uint256[](self.index);
-        for (uint256 i = 0; i < self.index; i++) {
-            out[i] = self.items[i];
-        }
-        return out;
     }
 
     function isEmpty(Data memory self) internal pure returns (bool) {

--- a/contracts/contracts/mocks/TestAccumulatingArray.sol
+++ b/contracts/contracts/mocks/TestAccumulatingArray.sol
@@ -6,25 +6,25 @@ import {AccumulatingArray} from "../libraries/AccumulatingArray.sol";
 contract TestAccumulatingArray {
     using AccumulatingArray for AccumulatingArray.Data;
 
-    function accumulate(uint256[][] memory arrays, uint256 maxLength)
+    function accumulate(uint256[][] memory arrays, uint256 length)
         public
         pure
         returns (uint256[] memory)
     {
-        AccumulatingArray.Data memory accumulated = AccumulatingArray.create(maxLength);
+        AccumulatingArray.Data memory accumulated = AccumulatingArray.create(length);
         for (uint256 i = 0; i < arrays.length; i++) {
             accumulated.add(arrays[i]);
         }
-        return accumulated.toArray();
+        return accumulated.items;
     }
 
     // Adds single element arrays as individual items
-    function accumulateWithIndividuals(uint256[][] memory arrays, uint256 maxLength)
+    function accumulateWithIndividuals(uint256[][] memory arrays, uint256 length)
         public
         pure
         returns (uint256[] memory)
     {
-        AccumulatingArray.Data memory accumulated = AccumulatingArray.create(maxLength);
+        AccumulatingArray.Data memory accumulated = AccumulatingArray.create(length);
         for (uint256 i = 0; i < arrays.length; i++) {
             if (arrays[i].length == 1) {
                 accumulated.add(arrays[i][0]);
@@ -32,6 +32,6 @@ contract TestAccumulatingArray {
                 accumulated.add(arrays[i]);
             }
         }
-        return accumulated.toArray();
+        return accumulated.items;
     }
 }

--- a/contracts/contracts/mocks/TestCAPE.sol
+++ b/contracts/contracts/mocks/TestCAPE.sol
@@ -58,8 +58,8 @@ contract TestCAPE is CAPE {
         blockHeight = newHeight;
     }
 
-    function computeMaxCommitments(CapeBlock memory newBlock) public pure returns (uint256) {
-        return _computeMaxCommitments(newBlock);
+    function computeNumCommitments(CapeBlock memory newBlock) public pure returns (uint256) {
+        return _computeNumCommitments(newBlock);
     }
 
     function checkForeignAssetCode(uint256 assetDefinitionCode, address erc20Address) public view {

--- a/contracts/rust/src/cape/submit_block.rs
+++ b/contracts/rust/src/cape/submit_block.rs
@@ -15,7 +15,7 @@ use rand::Rng;
 use reef::Ledger;
 
 #[tokio::test]
-async fn test_compute_max_commitments() {
+async fn test_compute_num_commitments() {
     let contract = deploy_cape_test().await;
     let rng = &mut ark_std::test_rng();
 
@@ -25,9 +25,10 @@ async fn test_compute_max_commitments() {
         let burn_notes = (0..rng.gen_range(0..2))
             .map(|_| {
                 let mut note = sol::BurnNote::default();
-                let n = rng.gen_range(0..10);
+                let n = rng.gen_range(2..10); // burn notes must have a least 2 record commitments
                 note.transfer_note.output_commitments = [U256::from(0)].repeat(n);
-                num_comms += n;
+                // subtract one because the burn record commitment is not inserted
+                num_comms += n - 1;
                 note
             })
             .collect();
@@ -68,13 +69,13 @@ async fn test_compute_max_commitments() {
             miner_addr: UserPubKey::default().address().into(),
         };
 
-        let max_comms_sol = contract
-            .compute_max_commitments(cape_block)
+        let num_comms_sol = contract
+            .compute_num_commitments(cape_block)
             .call()
             .await
             .unwrap();
 
-        assert_eq!(max_comms_sol, U256::from(num_comms));
+        assert_eq!(num_comms_sol, U256::from(num_comms));
     }
 }
 


### PR DESCRIPTION
- Remove the functionality of AccumulatingArray to output arrays of sizes
  not known at initialization time. We don't need this functionality
  anymore.
- Account for not inserting the burn commitment into the merkle tree. (cc @tri-joe)
- Rename comms -> commitments in main loop because it's a variable that
  is used in a lot of places.

Close #441 