### PR TITLE
Use seahorse::cli for generic CLI functionality.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,26 +149,12 @@ dependencies = [
 [[package]]
 name = "arbitrary-wrappers"
 version = "0.1.0"
-source = "git+ssh://git@github.com/SpectrumXYZ/arbitrary-wrappers.git?rev=bd84e90d131bdc4418a6c96543cb1003db1dd73b#bd84e90d131bdc4418a6c96543cb1003db1dd73b"
+source = "git+ssh://git@github.com/SpectrumXYZ/arbitrary-wrappers.git#e0bf09f31c057b2788eee30dcb6f7f698095e8ed"
 dependencies = [
  "arbitrary",
  "ark-std",
  "itertools 0.10.3",
- "jf-aap 0.0.1 (git+ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git?rev=8c32d8df3faf511e54ad89fa51627837ebcd8f20)",
- "rand_chacha 0.3.1",
- "serde",
- "zerok-macros",
-]
-
-[[package]]
-name = "arbitrary-wrappers"
-version = "0.1.0"
-source = "git+ssh://git@github.com/SpectrumXYZ/arbitrary-wrappers.git#bd84e90d131bdc4418a6c96543cb1003db1dd73b"
-dependencies = [
- "arbitrary",
- "ark-std",
- "itertools 0.10.3",
- "jf-aap 0.0.1 (git+ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git?rev=8c32d8df3faf511e54ad89fa51627837ebcd8f20)",
+ "jf-aap",
  "rand_chacha 0.3.1",
  "serde",
  "zerok-macros",
@@ -1028,7 +1014,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "arbitrary",
- "arbitrary-wrappers 0.1.0 (git+ssh://git@github.com/SpectrumXYZ/arbitrary-wrappers.git?rev=bd84e90d131bdc4418a6c96543cb1003db1dd73b)",
+ "arbitrary-wrappers",
  "ark-bn254",
  "ark-ec",
  "ark-ed-on-bn254",
@@ -1049,7 +1035,7 @@ dependencies = [
  "generic-array 0.14.5",
  "hex",
  "itertools 0.10.3",
- "jf-aap 0.0.1 (git+ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git?rev=8c32d8df3faf511e54ad89fa51627837ebcd8f20)",
+ "jf-aap",
  "jf-plonk",
  "jf-primitives",
  "jf-rescue",
@@ -1079,7 +1065,7 @@ dependencies = [
  "cap-rust-sandbox",
  "ethers 0.6.0 (git+https://github.com/gakonst/ethers-rs)",
  "itertools 0.10.3",
- "jf-aap 0.0.1 (git+ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git?rev=8c32d8df3faf511e54ad89fa51627837ebcd8f20)",
+ "jf-aap",
  "jf-rescue",
  "jf-utils",
  "rand 0.8.4",
@@ -1100,7 +1086,7 @@ dependencies = [
  "futures",
  "futures-util",
  "itertools 0.10.3",
- "jf-aap 0.0.1 (git+ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git?rev=8c32d8df3faf511e54ad89fa51627837ebcd8f20)",
+ "jf-aap",
  "jf-plonk",
  "jf-primitives",
  "jf-utils",
@@ -3163,7 +3149,7 @@ checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 [[package]]
 name = "jf-aap"
 version = "0.0.1"
-source = "git+ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git?rev=8c32d8df3faf511e54ad89fa51627837ebcd8f20#8c32d8df3faf511e54ad89fa51627837ebcd8f20"
+source = "git+ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git?rev=c789791d61b46e69367f07bb375c1ae2cf66e0d9#c789791d61b46e69367f07bb375c1ae2cf66e0d9"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -3194,47 +3180,6 @@ dependencies = [
  "sha2 0.9.9",
  "sha3 0.10.0",
  "structopt",
-]
-
-[[package]]
-name = "jf-aap"
-version = "0.0.1"
-source = "git+ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git?rev=fd1de050c214584a296a11f366846a53a316c4d4#fd1de050c214584a296a11f366846a53a316c4d4"
-dependencies = [
- "anyhow",
- "ark-bls12-377",
- "ark-bls12-381",
- "ark-bn254",
- "ark-ec",
- "ark-ed-on-bls12-377",
- "ark-ed-on-bls12-381",
- "ark-ed-on-bn254",
- "ark-ff",
- "ark-serialize",
- "ark-std",
- "bincode",
- "commit",
- "csv",
- "derivative",
- "displaydoc",
- "hex-literal",
- "itertools 0.10.3",
- "jf-plonk",
- "jf-primitives",
- "jf-rescue",
- "jf-utils",
- "num_cpus",
- "percentage",
- "rand 0.8.4",
- "rand_chacha 0.3.1",
- "rayon",
- "serde",
- "serde_derive",
- "serde_json",
- "sha2 0.9.9",
- "sha3 0.10.0",
- "structopt",
- "thiserror",
 ]
 
 [[package]]
@@ -3372,13 +3317,13 @@ checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 [[package]]
 name = "key-set"
 version = "0.1.0"
-source = "git+ssh://git@github.com/SpectrumXYZ/key-set.git#1cc35513c0f24c1d58d55ef699038fd647590555"
+source = "git+ssh://git@github.com/SpectrumXYZ/key-set.git#ce16c51eb10ebfd8a19b5200720c81c9dd086904"
 dependencies = [
  "ark-serialize",
  "bincode",
  "commit",
  "itertools 0.10.3",
- "jf-aap 0.0.1 (git+ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git?rev=8c32d8df3faf511e54ad89fa51627837ebcd8f20)",
+ "jf-aap",
  "serde",
  "serde_with",
  "snafu 0.6.10",
@@ -3616,7 +3561,7 @@ dependencies = [
 [[package]]
 name = "net"
 version = "0.1.0"
-source = "git+ssh://git@github.com/SpectrumXYZ/net.git#7f46bc8df52f99e61a723122107e6f45f082928a"
+source = "git+ssh://git@github.com/SpectrumXYZ/net.git#bdf20c7e87dec3fbcf0ba12ca4f235e2099d0a9e"
 dependencies = [
  "ark-serialize",
  "ark-std",
@@ -3625,7 +3570,7 @@ dependencies = [
  "futures",
  "generic-array 0.14.5",
  "itertools 0.10.3",
- "jf-aap 0.0.1 (git+ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git?rev=fd1de050c214584a296a11f366846a53a316c4d4)",
+ "jf-aap",
  "jf-utils",
  "serde",
  "serde_json",
@@ -4096,6 +4041,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pipe"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c7b8f27da217eb966df4c58d4159ea939431950ca03cf782c22bd7c5c1d8d75"
+dependencies = [
+ "crossbeam-channel",
+]
+
+[[package]]
 name = "pipeline"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4496,15 +4450,15 @@ dependencies = [
 [[package]]
 name = "reef"
 version = "0.1.0"
-source = "git+ssh://git@github.com/SpectrumXYZ/reef.git#859f50ef6181dc81adb20d041e98ec75700cac94"
+source = "git+ssh://git@github.com/SpectrumXYZ/reef.git#bd921b17c422e14fdaa12cae2e2a034eebf2a500"
 dependencies = [
  "arbitrary",
- "arbitrary-wrappers 0.1.0 (git+ssh://git@github.com/SpectrumXYZ/arbitrary-wrappers.git?rev=bd84e90d131bdc4418a6c96543cb1003db1dd73b)",
+ "arbitrary-wrappers",
  "ark-serialize",
  "commit",
  "funty",
  "itertools 0.10.3",
- "jf-aap 0.0.1 (git+ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git?rev=8c32d8df3faf511e54ad89fa51627837ebcd8f20)",
+ "jf-aap",
  "serde",
  "snafu 0.6.10",
  "strum_macros",
@@ -4546,7 +4500,7 @@ dependencies = [
  "cap-rust-sandbox",
  "dirs",
  "ethers 0.6.0 (git+https://github.com/gakonst/ethers-rs?branch=master)",
- "jf-aap 0.0.1 (git+ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git?rev=8c32d8df3faf511e54ad89fa51627837ebcd8f20)",
+ "jf-aap",
  "jf-primitives",
  "key-set",
  "lazy_static",
@@ -4904,10 +4858,10 @@ dependencies = [
 [[package]]
 name = "seahorse"
 version = "0.1.0"
-source = "git+ssh://git@github.com/SpectrumXYZ/seahorse.git?rev=88e058d714eedaadd8638f047dc91fb7d98dc91d#88e058d714eedaadd8638f047dc91fb7d98dc91d"
+source = "git+ssh://git@github.com/SpectrumXYZ/seahorse.git?rev=0420e2047cb498df029de253e5eb541ed1cbdeb5#0420e2047cb498df029de253e5eb541ed1cbdeb5"
 dependencies = [
  "arbitrary",
- "arbitrary-wrappers 0.1.0 (git+ssh://git@github.com/SpectrumXYZ/arbitrary-wrappers.git)",
+ "arbitrary-wrappers",
  "ark-serialize",
  "ark-std",
  "async-scoped",
@@ -4922,12 +4876,13 @@ dependencies = [
  "generic-array 0.14.5",
  "hmac 0.11.0",
  "itertools 0.10.3",
- "jf-aap 0.0.1 (git+ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git?rev=8c32d8df3faf511e54ad89fa51627837ebcd8f20)",
+ "jf-aap",
  "jf-utils",
  "key-set",
  "lazy_static",
  "mnemonic",
  "net",
+ "pipe",
  "proptest 0.8.7",
  "rand_chacha 0.3.1",
  "reef",
@@ -6075,12 +6030,12 @@ dependencies = [
 [[package]]
 name = "universal-param"
 version = "0.1.0"
-source = "git+ssh://git@github.com/SpectrumXYZ/universal-param.git#988da65b09eca7547ecdb878409455c4f95d4687"
+source = "git+ssh://git@github.com/SpectrumXYZ/universal-param.git#81e4eab45efdf761a44cf6d64d488b8135bbfbce"
 dependencies = [
  "ark-serialize",
  "ark-std",
  "itertools 0.10.3",
- "jf-aap 0.0.1 (git+ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git?rev=fd1de050c214584a296a11f366846a53a316c4d4)",
+ "jf-aap",
  "rand_chacha 0.3.1",
 ]
 

--- a/contracts/rust/Cargo.toml
+++ b/contracts/rust/Cargo.toml
@@ -10,7 +10,7 @@ doctest = false
 commit = { git = "ssh://git@github.com/SpectrumXYZ/commit.git", rev = "f48cd52c59755eade0605111826eef3df6abdcf8" }
 jf-plonk = { features=["std", "test_apis"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish.git" }
 jf-primitives = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish.git" }
-jf-aap = { features = ["test_apis"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "8c32d8df3faf511e54ad89fa51627837ebcd8f20" }
+jf-aap = { features = ["test_apis"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "c789791d61b46e69367f07bb375c1ae2cf66e0d9" }
 jf-rescue = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish.git" }
 jf-utils = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish.git" }
 key-set = { git = "ssh://git@github.com/SpectrumXYZ/key-set.git" }
@@ -18,7 +18,7 @@ reef = { git = "ssh://git@github.com/SpectrumXYZ/reef.git" }
 universal-param = { git = "ssh://git@github.com/SpectrumXYZ/universal-param.git" }
 zerok-macros = { git = "ssh://git@github.com/SpectrumXYZ/zerok-macros.git" }
 arbitrary = { version="1.0", features=["derive"] }
-arbitrary-wrappers = { git = "ssh://git@github.com/SpectrumXYZ/arbitrary-wrappers.git", rev = "bd84e90d131bdc4418a6c96543cb1003db1dd73b" }
+arbitrary-wrappers = { git = "ssh://git@github.com/SpectrumXYZ/arbitrary-wrappers.git" }
 
 # We need the legacy feature in order to avoid gas estimation issues. See https://github.com/gakonst/ethers-rs/issues/825
 ethers = { features=["legacy"], git = "https://github.com/gakonst/ethers-rs", branch = "master" }

--- a/doc/workflow/Cargo.toml
+++ b/doc/workflow/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 cap-rust-sandbox = { path = "../../contracts/rust" }
 jf-utils = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish.git" }
 jf-rescue = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish.git" }
-jf-aap = { features = ["test_apis"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "8c32d8df3faf511e54ad89fa51627837ebcd8f20" }
+jf-aap = { features = ["test_apis"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "c789791d61b46e69367f07bb375c1ae2cf66e0d9" }
 
 ethers = { git = "https://github.com/gakonst/ethers-rs", features = ["abigen"] }
 

--- a/relayer/Cargo.toml
+++ b/relayer/Cargo.toml
@@ -14,7 +14,7 @@ dirs = "4.0"
 # may switch to `ethers = "0.6.2"` in the future; keeping this for compatibility for now
 ethers = { git = "https://github.com/gakonst/ethers-rs", branch = "master" }
 
-jf-aap = { features = ["test_apis"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "8c32d8df3faf511e54ad89fa51627837ebcd8f20" }
+jf-aap = { features = ["test_apis"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "c789791d61b46e69367f07bb375c1ae2cf66e0d9" }
 jf-primitives = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish.git" }
 key-set = { git = "ssh://git@github.com/SpectrumXYZ/key-set.git" }
 

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -19,7 +19,7 @@ ethers = { git = "https://github.com/gakonst/ethers-rs", branch = "master" }
 futures = "0.3.0"
 futures-util = "0.3.8"
 itertools = "0.10.1"
-jf-aap = { features = ["test_apis"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "8c32d8df3faf511e54ad89fa51627837ebcd8f20" }
+jf-aap = { features = ["test_apis"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish-apps.git", rev = "c789791d61b46e69367f07bb375c1ae2cf66e0d9" }
 key-set = { git = "ssh://git@github.com/SpectrumXYZ/key-set.git" }
 lazy_static = "1.4.0"
 jf-plonk = { features=["std"], git = "ssh://git@github.com/SpectrumXYZ/jellyfish.git" }
@@ -32,7 +32,7 @@ rand_chacha = "0.3.1"
 regex = "1.5.4"
 reef = { git = "ssh://git@github.com/SpectrumXYZ/reef.git" }
 relayer = { path = "../relayer", features = ["testing"] }
-seahorse = { git = "ssh://git@github.com/SpectrumXYZ/seahorse.git", rev = "88e058d714eedaadd8638f047dc91fb7d98dc91d", features = ["testing"] }
+seahorse = { git = "ssh://git@github.com/SpectrumXYZ/seahorse.git", rev = "0420e2047cb498df029de253e5eb541ed1cbdeb5", features = ["testing"] }
 serde = { version = "1.0.123", features = ["derive", "rc"] }
 serde_derive = "1.0.118"
 serde_json = "1.0.61"

--- a/wallet/src/bin/cli.rs
+++ b/wallet/src/bin/cli.rs
@@ -16,36 +16,31 @@ use cap_rust_sandbox::{
 };
 use cape_wallet::{
     mocks::{MockCapeBackend, MockCapeNetwork},
-    wallet::{CapeWallet, CapeWalletExt},
+    wallet::CapeWalletExt,
 };
 use jf_aap::{
-    keys::{AuditorKeyPair, AuditorPubKey, FreezerKeyPair, FreezerPubKey, UserKeyPair},
+    keys::{AuditorPubKey, FreezerPubKey},
     proof::UniversalParam,
-    structs::{AssetCode, AssetPolicy, ReceiverMemo, RecordCommitment},
+    structs::{AssetCode, AssetPolicy},
     MerkleTree, TransactionVerifyingKey,
 };
 use key_set::{KeySet, VerifierKeySet};
-use net::{MerklePath, UserAddress};
+use net::UserAddress;
 use reef::Ledger;
 use seahorse::{
     cli::*,
-    events::EventIndex,
-    loader::{LoadMethod, Loader, LoaderMetadata, WalletLoader},
-    reader::Reader,
+    io::SharedIO,
+    loader::{LoadMethod, LoaderMetadata, WalletLoader},
     testing::MockLedger,
-    txn_builder::TransactionStatus,
     WalletError,
 };
 use std::any::type_name;
-use std::collections::HashMap;
-use std::fs::File;
-use std::io::Read;
+use std::io::Write;
 use std::path::PathBuf;
 use std::process::exit;
 use std::str::FromStr;
 use std::sync::Arc;
 use structopt::StructOpt;
-use tempdir::TempDir;
 
 pub struct CapeCli;
 
@@ -56,7 +51,7 @@ impl<'a> CLI<'a> for CapeCli {
 
     fn init_backend(
         univ_param: &'a UniversalParam,
-        _args: &'a Self::Args,
+        _args: Self::Args,
         loader: &mut impl WalletLoader<CapeLedger, Meta = LoaderMetadata>,
     ) -> Result<Self::Backend, WalletError<CapeLedger>> {
         let verif_crs = VerifierKeySet {
@@ -96,264 +91,32 @@ impl<'a> CLI<'a> for CapeCli {
         ))));
         MockCapeBackend::new(ledger, loader)
     }
-}
 
-type Wallet<'a> = CapeWallet<'a, MockCapeBackend<'a, LoaderMetadata>>;
-
-trait CapeCliInput<
-    'a,
-    C: CLI<'a, Ledger = CapeLedger, Backend = MockCapeBackend<'a, LoaderMetadata>>,
->: Sized
-{
-    fn parse_for_wallet(wallet: &mut Wallet<'a>, s: &str) -> Option<Self>;
-}
-
-macro_rules! cli_input_from_str {
-    ($($t:ty),*) => {
-        $(
-            impl<'a, C: CLI<'a, Ledger = CapeLedger, Backend= MockCapeBackend<'a, LoaderMetadata>>> CapeCliInput<'a, C> for $t {
-                fn parse_for_wallet(_wallet: &mut Wallet<'a>, s: &str) -> Option<Self> {
-                    Self::from_str(s).ok()
-                }
-            }
-        )*
+    fn extra_commands() -> Vec<Command<'a, Self>> {
+        cape_specific_cli_commands()
     }
 }
 
-cli_input_from_str! {
-    bool, u64, AssetCode, AuditorPubKey, Erc20Code, EthereumAddr, EventIndex, FreezerPubKey, MerklePath, PathBuf, ReceiverMemo, RecordCommitment, String, UserAddress
-}
-
-impl<
-        'a,
-        C: CLI<'a, Ledger = CapeLedger, Backend = MockCapeBackend<'a, LoaderMetadata>>,
-        T: Listable<'a, C> + CapeCliInput<'a, C>,
-    > CapeCliInput<'a, C> for ListItem<T>
-{
-    fn parse_for_wallet(wallet: &mut Wallet<'a>, s: &str) -> Option<Self> {
-        if let Ok(index) = usize::from_str(s) {
-            // If the input looks like a list index, build the list for type T and get an element of
-            // type T by indexing.
-            let mut items = T::list_sync(wallet);
-            if index < items.len() {
-                Some(items.remove(index))
-            } else {
-                None
-            }
-        } else {
-            // Otherwise, just parse a T directly.
-            T::parse_for_wallet(wallet, s).map(|item| ListItem {
-                item,
-                index: 0,
-                annotation: None,
-            })
-        }
+impl<'a> CLIInput<'a, CapeCli> for EthereumAddr {
+    fn parse_for_wallet(_wallet: &mut Wallet<'a, CapeCli>, s: &str) -> Option<Self> {
+        Self::from_str(s).ok()
     }
 }
 
-impl<'a, C: CLI<'a, Ledger = CapeLedger, Backend = MockCapeBackend<'a, LoaderMetadata>>>
-    CapeCliInput<'a, C> for KeyType
-{
-    fn parse_for_wallet(_wallet: &mut Wallet<'a>, s: &str) -> Option<Self> {
-        match s {
-            "audit" => Some(Self::Audit),
-            "freeze" => Some(Self::Freeze),
-            "spend" => Some(Self::Spend),
-            _ => None,
-        }
+impl<'a> CLIInput<'a, CapeCli> for Erc20Code {
+    fn parse_for_wallet(_wallet: &mut Wallet<'a, CapeCli>, s: &str) -> Option<Self> {
+        Self::from_str(s).ok()
     }
 }
 
-macro_rules! command {
-    ($name:ident,
-     $help:expr,
-     $cli:ident,
-     |$wallet:pat, $($arg:ident : $argty:ty),*
-      $(; $($kwarg:ident : Option<$kwargty:ty>),*)?| $run:expr) => {
-        Command {
-            name: String::from(stringify!($name)),
-            params: vec![$((
-                String::from(stringify!($arg)),
-                String::from(type_name::<$argty>()),
-            )),*],
-            kwargs: vec![$($((
-                String::from(stringify!($kwarg)),
-                String::from(type_name::<$kwargty>()),
-            )),*)?],
-            help: String::from($help),
-            run: Box::new(|wallet, args, kwargs| Box::pin(async move {
-                if args.len() != count!($($arg)*) {
-                    println!("incorrect number of arguments (expected {})", count!($($arg)*));
-                    return;
-                }
-
-                // For each (arg, ty) pair in the signature of the handler function, create a local
-                // variable `arg: ty` by converting from the corresponding string in the `args`
-                // vector. `args` will be unused if $($arg)* is empty, hence the following allows.
-                #[allow(unused_mut)]
-                #[allow(unused_variables)]
-                let mut args = args.into_iter();
-                $(
-                    let $arg = match <$argty as CapeCliInput<$cli>>::parse_for_wallet(wallet, args.next().unwrap().as_str()) {
-                        Some(arg) => arg,
-                        None => {
-                            println!(
-                                "invalid value for argument {} (expected {})",
-                                stringify!($arg),
-                                type_name::<$argty>());
-                            return;
-                        }
-                    };
-                )*
-
-                // For each (kwarg, ty) pair in the signature of the handler function, create a
-                // local variable `kwarg: Option<ty>` by converting the value associated with
-                // `kwarg` in `kwargs` to tye type `ty`.
-                $($(
-                    let $kwarg = match kwargs.get(stringify!($kwarg)) {
-                        Some(val) => match <$kwargty as CapeCliInput<$cli>>::parse_for_wallet(wallet, val) {
-                            Some(arg) => Some(arg),
-                            None => {
-                                println!(
-                                    "invalid value for argument {} (expected {})",
-                                    stringify!($kwarg),
-                                    type_name::<$kwargty>());
-                                return;
-                            }
-                        }
-                        None => None,
-                    };
-                )*)?
-                // `kwargs` will be unused if there are no keyword params.
-                let _ = kwargs;
-
-                let $wallet = wallet;
-                $run
-            }))
-        }
-    };
-
-    // Don't require a comma after $wallet if there are no additional args.
-    ($name:ident, $help:expr, $cli:ident, |$wallet:pat| $run:expr) => {
-        command!($name, $help, $cli, |$wallet,| $run)
-    };
-
-    // Don't require wallet at all.
-    ($name:ident, $help:expr, $cli:ident, || $run:expr) => {
-        command!($name, $help, $cli, |_| $run)
-    };
-}
-
-macro_rules! count {
-    () => (0);
-    ($x:tt $($xs:tt)*) => (1 + count!($($xs)*));
-}
-
-fn init_commands<
-    'a,
-    C: CLI<'a, Ledger = CapeLedger, Backend = MockCapeBackend<'a, LoaderMetadata>>,
->() -> Vec<Command<'a, C>> {
+fn cape_specific_cli_commands<'a>() -> Vec<Command<'a, CapeCli>> {
     vec![
-        command!(
-            balance,
-            "print owned balances of asset",
-            C,
-            |wallet, asset: ListItem<AssetCode>| {
-                println!("Address Balance");
-                for pub_key in wallet.pub_keys().await {
-                    println!(
-                        "{} {}",
-                        UserAddress(pub_key.address()),
-                        wallet.balance(&pub_key.address(), &asset.item).await
-                    );
-                }
-            }
-        ),
-        command!(
-            gen_key,
-            "generate new keys",
-            C,
-            |wallet, key_type: KeyType; scan_from: Option<EventIndex>| {
-                match key_type {
-                    KeyType::Audit => match wallet.generate_audit_key().await {
-                        Ok(pub_key) => println!("{}", pub_key),
-                        Err(err) => println!("Error generating audit key: {}", err),
-                    },
-                    KeyType::Freeze => match wallet.generate_freeze_key().await {
-                        Ok(pub_key) => println!("{}", pub_key),
-                        Err(err) => println!("Error generating freeze key: {}", err),
-                    },
-                    KeyType::Spend => match wallet.generate_user_key(scan_from).await {
-                        Ok(pub_key) => println!("{}", UserAddress(pub_key.address())),
-                        Err(err) => println!("Error generating spending key: {}", err),
-                    },
-                }
-            }
-        ),
-        command!(
-            load_key,
-            "load a key from a file",
-            C,
-            |wallet, key_type: KeyType, path: PathBuf; scan_from: Option<EventIndex>| {
-                let mut file = match File::open(path.clone()) {
-                    Ok(file) => file,
-                    Err(err) => {
-                        println!("Error opening file {:?}: {}", path, err);
-                        return;
-                    }
-                };
-                let mut bytes = Vec::new();
-                if let Err(err) = file.read_to_end(&mut bytes) {
-                    println!("Error reading file: {}", err);
-                    return;
-                }
-
-                match key_type {
-                    KeyType::Audit => match bincode::deserialize::<AuditorKeyPair>(&bytes) {
-                        Ok(key) => match wallet.add_audit_key(key.clone()).await {
-                            Ok(()) => println!("{}", key.pub_key()),
-                            Err(err) => println!("Error saving audit key: {}", err),
-                        },
-                        Err(err) => {
-                            println!("Error loading audit key: {}", err);
-                        }
-                    },
-                    KeyType::Freeze => match bincode::deserialize::<FreezerKeyPair>(&bytes) {
-                        Ok(key) => match wallet.add_freeze_key(key.clone()).await {
-                            Ok(()) => println!("{}", key.pub_key()),
-                            Err(err) => println!("Error saving freeze key: {}", err),
-                        },
-                        Err(err) => {
-                            println!("Error loading freeze key: {}", err);
-                        }
-                    },
-                    KeyType::Spend => match bincode::deserialize::<UserKeyPair>(&bytes) {
-                        Ok(key) => match wallet.add_user_key(
-                            key.clone(),
-                            scan_from.unwrap_or_default(),
-                        ).await {
-                            Ok(()) => {
-                                println!(
-                                    "Note: assets belonging to this key will become available after\
-                                     a scan of the ledger. This may take a long time. If you have\
-                                     the owner memo for a record you want to use immediately, use\
-                                     import_memo.");
-                                println!("{}", UserAddress(key.address()));
-                            }
-                            Err(err) => println!("Error saving spending key: {}", err),
-                        },
-                        Err(err) => {
-                            println!("Error loading spending key: {}", err);
-                        }
-                    },
-                };
-            }
-        ),
         command!(
             sponsor,
             "sponsor an asset",
-            C,
-            |wallet,
+            CapeCli,
+            |io,
+             wallet,
              erc20_code: Erc20Code,
              sponsor_addr: EthereumAddr;
              auditor: Option<AuditorPubKey>,
@@ -373,7 +136,7 @@ fn init_commands<
                     policy = match policy.reveal_amount() {
                         Ok(policy) => policy,
                         Err(err) => {
-                            println!("Invalid policy: {}", err);
+                            cli_writeln!(io, "Invalid policy: {}", err);
                             return;
                         }
                     }
@@ -382,7 +145,7 @@ fn init_commands<
                     policy = match policy.reveal_user_address() {
                         Ok(policy) => policy,
                         Err(err) => {
-                            println!("Invalid policy: {}", err);
+                            cli_writeln!(io, "Invalid policy: {}", err);
                             return;
                         }
                     }
@@ -391,7 +154,7 @@ fn init_commands<
                     policy = match policy.reveal_blinding_factor() {
                         Ok(policy) => policy,
                         Err(err) => {
-                            println!("Invalid policy: {}", err);
+                            cli_writeln!(io, "Invalid policy: {}", err);
                             return;
                         }
                     }
@@ -401,10 +164,10 @@ fn init_commands<
                 }
                 match wallet.sponsor(erc20_code, sponsor_addr, policy).await {
                     Ok(def) => {
-                        println!("{}", def.code);
+                        cli_writeln!(io, "{}", def.code);
                     }
                     Err(err) => {
-                        println!("{}\nAsset was not sponsored.", err);
+                        cli_writeln!(io, "{}\nAsset was not sponsored.", err);
                     }
                 }
             }
@@ -412,31 +175,19 @@ fn init_commands<
         command!(
             burn,
             "burn an asset",
-            C,
-            |wallet, asset: ListItem<AssetCode>, from: UserAddress, to: EthereumAddr, amount: u64, fee: u64; wait: Option<bool>| {
-                match wallet
+            CapeCli,
+            |io,
+             wallet,
+             asset: ListItem<AssetCode>,
+             from: UserAddress,
+             to: EthereumAddr,
+             amount: u64,
+             fee: u64;
+             wait: Option<bool>| {
+                let res = wallet
                     .burn(&from.0, to, &asset.item, amount, fee)
-                    .await
-                {
-                    Ok(receipt) => {
-                        if wait == Some(true) {
-                            match wallet.await_transaction(&receipt).await {
-                                Err(err) => {
-                                    println!("Error waiting for transaction to complete: {}", err);
-                                }
-                                Ok(TransactionStatus::Retired) => {},
-                                _ => {
-                                    println!("Transaction failed");
-                                }
-                            }
-                        } else {
-                            println!("Transaction {}", receipt);
-                        }
-                    }
-                    Err(err) => {
-                        println!("{}\nAssets were not burned.", err);
-                    }
-                }
+                    .await;
+                finish_transaction::<CapeCli>(io, wallet, res, wait, "burned").await;
             }
         ),
     ]
@@ -496,8 +247,12 @@ impl CLIArgs for Args {
         self.storage.clone()
     }
 
-    fn interactive(&self) -> bool {
-        !self.non_interactive
+    fn io(&self) -> Option<SharedIO> {
+        if self.non_interactive {
+            Some(SharedIO::std())
+        } else {
+            None
+        }
     }
 
     fn encrypted(&self) -> bool {
@@ -517,107 +272,12 @@ impl CLIArgs for Args {
     }
 }
 
-async fn repl<
-    'a,
-    L: 'static + Ledger,
-    C: CLI<'a, Ledger = CapeLedger, Backend = MockCapeBackend<'a, LoaderMetadata>>,
->(
-    args: &'a C::Args,
-) -> Result<(), WalletError<CapeLedger>> {
-    let (storage, _tmp_dir) = match args.storage_path() {
-        Some(storage) => (storage, None),
-        None if !args.use_tmp_storage() => {
-            let home = std::env::var("HOME").map_err(|_| WalletError::<CapeLedger>::Failed {
-                msg: String::from(
-                    "HOME directory is not set. Please set your HOME directory, or specify \
-                        a different storage location using --storage.",
-                ),
-            })?;
-            let mut dir = PathBuf::from(home);
-            dir.push(".translucence/wallet");
-            (dir, None)
-        }
-        None => {
-            let tmp_dir = TempDir::new("wallet").unwrap();
-            (PathBuf::from(tmp_dir.path()), Some(tmp_dir))
-        }
-    };
-
-    println!(
-        "Welcome to the {} wallet, version {}",
-        C::Ledger::name(),
-        env!("CARGO_PKG_VERSION")
-    );
-    println!("(c) 2021 Translucence Research, Inc.");
-
-    let reader = Reader::new(args.interactive());
-    let mut loader = Loader::new(args.load_method(), args.encrypted(), storage, reader);
-    let universal_param = Box::leak(Box::new(universal_param::get(
-        &mut loader.rng,
-        L::merkle_height(),
-    )));
-    let backend = C::init_backend(universal_param, args, &mut loader)?;
-
-    // Loading the wallet takes a while. Let the user know that's expected.
-    //todo !jeb.bearer Make it faster
-    println!("connecting...");
-    let mut wallet = Wallet::new(backend).await?;
-    println!("Type 'help' for a list of commands.");
-    let commands = init_commands::<C>();
-
-    let mut input = Reader::new(args.interactive());
-    'repl: while let Some(line) = input.read_line() {
-        let tokens = line.split_whitespace().collect::<Vec<_>>();
-        if tokens.is_empty() {
-            continue;
-        }
-        if tokens[0] == "help" {
-            for command in commands.iter() {
-                println!("{}", command);
-            }
-            continue;
-        }
-        for Command { name, run, .. } in commands.iter() {
-            if name == tokens[0] {
-                let mut args = Vec::new();
-                let mut kwargs = HashMap::new();
-                for tok in tokens.into_iter().skip(1) {
-                    if let Some((key, value)) = tok.split_once("=") {
-                        kwargs.insert(String::from(key), String::from(value));
-                    } else {
-                        args.push(String::from(tok));
-                    }
-                }
-                run(&mut wallet, args, kwargs).await;
-                continue 'repl;
-            }
-        }
-        println!("Unknown command. Type 'help' for a list of valid commands.");
-    }
-
-    Ok(())
-}
-
-async fn cape_cli_main<
-    'a,
-    L: 'static + Ledger,
-    C: CLI<'a, Ledger = CapeLedger, Backend = MockCapeBackend<'a, LoaderMetadata>>,
->(
-    args: &'a C::Args,
-) -> Result<(), WalletError<CapeLedger>> {
-    if let Some(path) = args.key_gen_path() {
-        key_gen::<C>(path)
-    } else {
-        repl::<L, C>(args).await
-    }
-}
-
 #[async_std::main]
 async fn main() -> Result<(), std::io::Error> {
     tracing_subscriber::fmt().pretty().init();
 
     // Initialize the wallet CLI.
-    if let Err(err) = cape_cli_main::<CapeLedger, CapeCli>(&Args::from_args()).await {
+    if let Err(err) = cli_main::<CapeLedger, CapeCli>(Args::from_args()).await {
         println!("{}", err);
         exit(1);
     }


### PR DESCRIPTION
* Update dependencies
* Use seahorse::cli for all network-agnostic CLI functionality
* Implement CapeCli::extra_commands for cape-specific commands

This pulls in all of the generic CLI commands for use alongside the
CAPE-specific commands, and also deletes a lot of duplicate code.