### PR TITLE
Implement populatefortest endpoint.

### DIFF
--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -58,4 +58,6 @@ tempdir = "0.3.7"
 tracing-test = "0.2.1"
 
 [features]
+default = ["testing"]
+testing = []
 slow-tests = []

--- a/wallet/src/mocks.rs
+++ b/wallet/src/mocks.rs
@@ -268,7 +268,10 @@ impl MockCapeNetwork {
         }
     }
 
-    fn submit_operations(&mut self, ops: Vec<CapeOperation>) -> Result<(), CapeValidationError> {
+    pub fn submit_operations(
+        &mut self,
+        ops: Vec<CapeOperation>,
+    ) -> Result<(), CapeValidationError> {
         let (new_state, effects) = self.contract.submit_operations(ops)?;
         let mut events = vec![];
         for effect in effects {
@@ -479,7 +482,7 @@ pub type MockCapeLedger<'a> =
 
 pub struct MockCapeBackend<'a, Meta: Serialize + DeserializeOwned> {
     storage: Arc<Mutex<AtomicWalletStorage<'a, CapeLedger, Meta>>>,
-    ledger: Arc<Mutex<MockCapeLedger<'a>>>,
+    pub(crate) ledger: Arc<Mutex<MockCapeLedger<'a>>>,
     key_stream: KeyTree,
 }
 

--- a/wallet/src/routes.rs
+++ b/wallet/src/routes.rs
@@ -286,7 +286,7 @@ pub fn dummy_url_eval(
         .build())
 }
 
-fn wallet_error(source: CapeWalletError) -> tide::Error {
+pub fn wallet_error(source: CapeWalletError) -> tide::Error {
     server_error(CapeAPIError::Wallet {
         msg: source.to_string(),
     })
@@ -380,7 +380,7 @@ async fn known_assets(wallet: &Wallet) -> HashMap<AssetCode, AssetInfo> {
     assets
 }
 
-fn require_wallet(wallet: &mut Option<Wallet>) -> Result<&mut Wallet, tide::Error> {
+pub fn require_wallet(wallet: &mut Option<Wallet>) -> Result<&mut Wallet, tide::Error> {
     wallet
         .as_mut()
         .ok_or_else(|| server_error(CapeAPIError::MissingWallet))

--- a/wallet/src/web.rs
+++ b/wallet/src/web.rs
@@ -218,6 +218,56 @@ async fn entry_page(req: tide::Request<WebState>) -> Result<tide::Response, tide
     }
 }
 
+#[cfg(any(test, feature = "testing"))]
+async fn populatefortest(req: tide::Request<WebState>) -> Result<tide::Response, tide::Error> {
+    use crate::{
+        routes::{require_wallet, wallet_error},
+        wallet::CapeWalletExt,
+    };
+    use cap_rust_sandbox::state::{CapeOperation, Erc20Code, EthereumAddr};
+
+    let wallet = &mut *req.state().wallet.lock().await;
+    let wallet = require_wallet(wallet)?;
+
+    // Generate two of each kind of key, to simulate multiple accounts.
+    for _ in 0..2 {
+        wallet.generate_user_key(None).await.map_err(wallet_error)?;
+        wallet.generate_audit_key().await.map_err(wallet_error)?;
+        wallet.generate_freeze_key().await.map_err(wallet_error)?;
+    }
+
+    // Add a wrapped asset, and give it some nonzero balance.
+    let erc20_code = Erc20Code(EthereumAddr([1; 20]));
+    let sponsor_addr = EthereumAddr([2; 20]);
+    let asset_def = wallet
+        .sponsor(erc20_code, sponsor_addr.clone(), Default::default())
+        .await
+        .map_err(wallet_error)?;
+    wallet
+        .wrap(
+            sponsor_addr,
+            asset_def,
+            wallet.pub_keys().await[0].address(),
+            1000,
+        )
+        .await
+        .map_err(wallet_error)?;
+    // Submit an empty block to force the wrap to be finalized.
+    let t = {
+        let guard = wallet.lock().await;
+        let mut mock_ledger = guard.backend().ledger.lock().await;
+        mock_ledger
+            .network()
+            .submit_operations(vec![CapeOperation::SubmitBlock(vec![])])
+            .unwrap();
+        mock_ledger.now()
+    };
+    // Wait for the wallet to process events corresponding to the wrapped asset.
+    wallet.sync(t).await.unwrap();
+
+    server::response(&req, ())
+}
+
 async fn handle_web_socket(
     req: tide::Request<WebState>,
     wsc: WebSocketConnection,
@@ -294,6 +344,9 @@ pub fn init_server(
             }
         });
     }
+
+    #[cfg(any(test, feature = "testing"))]
+    web_server.at("populatefortest").get(populatefortest);
 
     let addr = format!("0.0.0.0:{}", port);
     Ok(spawn(web_server.listen(addr)))


### PR DESCRIPTION
Requested by Plaza devs: testing endpoint to quickly populate
wallet with addresses, assets, and balance.