### PR TITLE
Allow extra calldata for block submission

### DIFF
--- a/contracts/contracts/CAPE.sol
+++ b/contracts/contracts/CAPE.sol
@@ -207,7 +207,15 @@ contract CAPE is RecordsMerkleTree, RootStore, AssetRegistry, ReentrancyGuard {
         );
     }
 
-    /// @notice submit a new block to the CAPE contract. Transactions are validated and the blockchain state is updated. Moreover *BURN* transactions trigger the unwrapping of cape asset records into erc20 tokens.
+    /// @notice Submit a new block with extra data to the CAPE contract.
+    /// @param newBlock block to be processed by the CAPE contract.
+    /// @param extraData extra data to be stored in calldata, this data is ignored by the contract function.
+    // solhint-disable-next-line no-unused-vars
+    function submitCapeBlockWithMemos(CapeBlock memory newBlock, bytes calldata extraData) public {
+        submitCapeBlock(newBlock);
+    }
+
+    /// @notice Submit a new block to the CAPE contract. Transactions are validated and the blockchain state is updated. Moreover *BURN* transactions trigger the unwrapping of cape asset records into erc20 tokens.
     /// @param newBlock block to be processed by the CAPE contract.
     function submitCapeBlock(CapeBlock memory newBlock) public nonReentrant {
         AccumulatingArray.Data memory commitments = AccumulatingArray.create(

--- a/contracts/rust/src/cape/events.rs
+++ b/contracts/rust/src/cape/events.rs
@@ -1,5 +1,7 @@
 #[cfg(test)]
 mod tests {
+    use std::iter::repeat_with;
+
     use crate::{
         cape::CapeBlock,
         deploy::deploy_cape_test,
@@ -8,15 +10,25 @@ mod tests {
         types::{self as sol, GenericInto, MerkleRootSol},
     };
     use anyhow::Result;
-    use ethers::prelude::Middleware;
-    use jf_cap::{keys::UserPubKey, utils::TxnsParams};
+    use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
+    use ethers::prelude::{Bytes, Middleware};
+    use itertools::Itertools;
+    use jf_cap::{
+        keys::{UserKeyPair, UserPubKey},
+        sign_receiver_memos,
+        structs::{AssetDefinition, FreezeFlag, ReceiverMemo, RecordOpening},
+        utils::TxnsParams,
+        KeyPair, Signature,
+    };
+    use rand::{RngCore, SeedableRng};
+    use rand_chacha::ChaChaRng;
     use reef::Ledger;
 
     #[tokio::test]
     async fn test_fetch_cape_block_from_event() -> Result<()> {
         let contract = deploy_cape_test().await;
-        let rng = &mut ark_std::test_rng();
-        let params = TxnsParams::generate_txns(rng, 1, 0, 0, CapeLedger::merkle_height());
+        let mut rng = ChaChaRng::from_seed([0x42u8; 32]);
+        let params = TxnsParams::generate_txns(&mut rng, 1, 0, 0, CapeLedger::merkle_height());
         let miner = UserPubKey::default();
 
         let root = params.txns[0].merkle_root();
@@ -29,8 +41,36 @@ mod tests {
             .await?
             .await?;
 
+        // XXX Adapted from seahorse
+        // https://github.com/SpectrumXYZ/seahorse/blob/ace20bc5f1bcf5b88ca0562799b8e80e6c52e933/src/persistence.rs#L574
+        // Generate some memos with default UserKeyPair
+        let key_pair = UserKeyPair::default();
+        let memos_with_sigs = repeat_with(|| {
+            let memos = repeat_with(|| {
+                let amount = rng.next_u64();
+                let ro = RecordOpening::new(
+                    &mut rng,
+                    amount,
+                    AssetDefinition::native(),
+                    key_pair.pub_key(),
+                    FreezeFlag::Unfrozen,
+                );
+                ReceiverMemo::from_ro(&mut rng, &ro, &[]).unwrap()
+            })
+            .take(3)
+            .collect::<Vec<_>>();
+            let sig = sign_receiver_memos(&KeyPair::generate(&mut rng), &memos).unwrap();
+            (memos, sig)
+        })
+        .take(3)
+        .collect_vec();
+
+        let mut memos_bytes: Vec<u8> = vec![];
+        memos_with_sigs.serialize(&mut memos_bytes).unwrap();
+
+        // Submit the block with memos
         contract
-            .submit_cape_block(cape_block.clone().into())
+            .submit_cape_block_with_memos(cape_block.clone().into(), memos_bytes.into())
             .send()
             .await?
             .await?;
@@ -52,13 +92,17 @@ mod tests {
             .await?
             .unwrap();
 
-        let decoded_calldata_block = contract
-            .decode::<sol::CapeBlock, _>("submitCapeBlock", tx.input)
+        // Decode the calldata (tx.input) into the function input types
+        let (decoded_calldata_block, fetched_memos_bytes) = contract
+            .decode::<(sol::CapeBlock, Bytes), _>("submitCapeBlockWithMemos", tx.input)
             .unwrap();
 
         let decoded_cape_block = CapeBlock::from(decoded_calldata_block);
-
         assert_eq!(decoded_cape_block, cape_block);
+
+        let decoded_memos: Vec<(Vec<ReceiverMemo>, Signature)> =
+            CanonicalDeserialize::deserialize(&fetched_memos_bytes.to_vec()[..]).unwrap();
+        assert_eq!(decoded_memos, memos_with_sigs);
 
         Ok(())
     }


### PR DESCRIPTION
Adds a function that accepts an additional bytes argument which just
calls the block submitting functions.

The block submitting entity can use the extra data to store anything in
calldata. Our current use case is to store `ReceiverMemo`s and their
signature.

Includes an example test to show how to submit a block with receiver
memos and fetch and decode the memos after block submission.

When this feature is not/no-longer useful the existing function
`submitCapeBlock` can be used.

The current function name is `submitCapeBlockWithMemos` it could also
be `...WithData` since the contract does not care what data is submitted.

I also tried using function overloading instead but this causes issues where 
the `abigen` was not generating the overloaded function. I haven't had time
to look into this. I'm also not sure if overloading is the right approach here  
because it may be difficult to spot what's going on without looking at the code
or having the IDE show the signatures.

Close #360