### PR TITLE
Problem: Noisy output from tide during tests

### DIFF
--- a/address_book/src/lib.rs
+++ b/address_book/src/lib.rs
@@ -5,7 +5,7 @@ use async_std::{
 use jf_cap::keys::{UserAddress, UserPubKey};
 use jf_cap::Signature;
 use std::collections::HashMap;
-use tide::{prelude::*, StatusCode};
+use tide::{log::LevelFilter, prelude::*, StatusCode};
 
 pub const DEFAULT_PORT: u16 = 50078u16;
 
@@ -20,8 +20,10 @@ struct ServerState {
     map: Arc<RwLock<HashMap<UserAddress, UserPubKey>>>,
 }
 
-pub async fn init_web_server() -> std::io::Result<JoinHandle<std::io::Result<()>>> {
-    tide::log::start();
+pub async fn init_web_server(
+    log_level: LevelFilter,
+) -> std::io::Result<JoinHandle<std::io::Result<()>>> {
+    tide::log::with_level(log_level);
     let mut app = tide::with_state(ServerState::default());
     app.at("/insert_pubkey").post(insert_pubkey);
     app.at("/request_pubkey").post(request_pubkey);

--- a/address_book/src/main.rs
+++ b/address_book/src/main.rs
@@ -1,11 +1,14 @@
 use address_book::init_web_server;
+use tide::log::LevelFilter;
 
 /// Run a web server that provides a key/value store mapping user
 /// addresses to public keys.
 #[async_std::main]
 async fn main() -> Result<(), std::io::Error> {
-    init_web_server().await.unwrap_or_else(|err| {
-        panic!("Web server exited with an error: {}", err);
-    });
+    init_web_server(LevelFilter::Info)
+        .await
+        .unwrap_or_else(|err| {
+            panic!("Web server exited with an error: {}", err);
+        });
     Ok(())
 }

--- a/address_book/tests/tests.rs
+++ b/address_book/tests/tests.rs
@@ -2,6 +2,7 @@ use address_book::{init_web_server, InsertPubKey, DEFAULT_PORT};
 use jf_cap::keys::{UserKeyPair, UserPubKey};
 use rand_chacha::rand_core::SeedableRng;
 use std::time::Duration;
+use tide::log::LevelFilter;
 
 const ROUND_TRIP_COUNT: u64 = 100;
 const NOT_FOUND_COUNT: u64 = 100;
@@ -33,7 +34,9 @@ async fn wait_for_server(port: u16) {
 #[async_std::test]
 async fn round_trip() {
     // TODO !corbett find an unused port rather than assuming 50078 is free.
-    init_web_server().await.expect("Failed to run server.");
+    init_web_server(LevelFilter::Error)
+        .await
+        .expect("Failed to run server.");
     wait_for_server(DEFAULT_PORT).await;
 
     let mut rng = rand_chacha::ChaChaRng::from_seed([0u8; 32]);


### PR DESCRIPTION
Solution: Set the log level to error in tests.

I have some doubts this is the right way to do it but it does fix the problem of having lots of output during the test run.