### PR TITLE
use include_bytes to make `types.rs` depend on ABI

### DIFF
--- a/contracts/rust/build.rs
+++ b/contracts/rust/build.rs
@@ -7,11 +7,9 @@ fn find_abi_paths() -> glob::Paths {
 
 fn main() {
     // If no abi files exist, generate them. This enables "cargo build" in a fresh repo.
-    if find_abi_paths().peekable().peek().is_none() {
-        Command::new("build-abi")
-            .output()
-            .expect("failed to compile contracts");
-    }
+    Command::new("build-abi")
+        .output()
+        .expect("failed to compile contracts");
 
     // Rerun this script (and recompile crate) if any abi files change.
     for entry in find_abi_paths() {

--- a/contracts/rust/src/types.rs
+++ b/contracts/rust/src/types.rs
@@ -23,7 +23,20 @@ use std::convert::TryInto;
 // The number of input wires of TurboPlonk.
 const GATE_WIDTH: usize = 4;
 
-abigen!(
+macro_rules! mark_deps {
+    ($($tname:expr, $path:expr, $derives:expr;)*) => {
+        $(const _: &[u8] = include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"),"/",$path));)*
+    }
+}
+
+macro_rules! abigen_and_mark_dep {
+    ($($tts:tt)*) => {
+        mark_deps!($($tts)*);
+        abigen!($($tts)*);
+    }
+}
+
+abigen_and_mark_dep!(
     AssetRegistry,
     "../abi/contracts/AssetRegistry.sol/AssetRegistry/abi.json",
     event_derives(serde::Deserialize, serde::Serialize);


### PR DESCRIPTION
@sveitser I set this to merge into the other PR.

This adds an explicit dependency in `types.rs` on each abi file it parses (to make sure it gets rebuilt if any of the files change)

I've been poking around with `build.rs` (and @nmccarty checked for some cargo features), and the conclusion I came to is that in an ideal world, we could have `build.rs`:
- run `build-abi`
- watch all `.sol` files and `abi.json` files
- If `build-abi` runs and doesn't write new abi files, tell cargo not to rebuild the package or things that depend on it.

Unfortunately that third part isn't supported, so I think the best we can do is:
- run `build-abi`
- watch all the `abi.json` files

This means it will rerun `build-abi` if any of the following happen:
- the abi files don't exist
- the abi files get deleted
- the abi files get changed (this one is less desirable, but `build-abi` only takes a few seconds if none of the abi files actually get updated by compilation)

So I think these tweaks are a good tradeoff between "cargo build should rebuild all the things that need rebuilding" and "changing a .sol file that doesn't change the ABI shouldn't cause slow-to-compile modules to get rebuilt".

Unfortunately there's a case I'm not sure how to address. Suppose we `git pull` some changes in that _only modify solidity files_ and change the ABI. In that case, `build.rs` won't necessarily rerun, because `git pull` won't change the ABI files.