### PR TITLE
Improve tests for submitting cape blocks

### DIFF
--- a/contracts/contracts/mocks/TestCAPE.sol
+++ b/contracts/contracts/mocks/TestCAPE.sol
@@ -92,10 +92,4 @@ contract TestCAPE is CAPE {
             pendingDeposits.push(100 + i);
         }
     }
-
-    function removeNullifiers(uint256[] memory nullifiersInput) public {
-        for (uint256 i = 0; i < nullifiersInput.length; i++) {
-            nullifiers[nullifiersInput[i]] = false;
-        }
-    }
 }


### PR DESCRIPTION
* Check that bad CAPE transactions yield a rejected block.
* Check single transaction blocks (Transfer,Mint,Freeze).

Closes #443  and #444.