### PR TITLE
Use `EthMiddleware` type, fix warnings

### DIFF
--- a/contracts/rust/src/bn254.rs
+++ b/contracts/rust/src/bn254.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 
-use crate::deploy::deploy_test_bn254_contract;
+use crate::deploy::{deploy_test_bn254_contract, EthMiddleware};
 use crate::{
     assertion::Matcher,
     types::{field_to_u256, u256_to_field, G1Point, G2Point, TestBN254},
@@ -16,7 +16,6 @@ use ark_ff::{FpParameters, PrimeField};
 use ark_serialize::CanonicalSerialize;
 use ark_std::UniformRand;
 use ark_std::Zero;
-use ethers::core::k256::ecdsa::SigningKey;
 use ethers::prelude::*;
 use rand::RngCore;
 
@@ -210,10 +209,7 @@ async fn test_validate_g1_point() -> Result<()> {
     let p: G1Affine = G1Projective::rand(rng).into();
     contract.validate_g1_point(p.into()).call().await?;
 
-    async fn should_fail_validation(
-        contract: &TestBN254<SignerMiddleware<Provider<Http>, Wallet<SigningKey>>>,
-        bad_p: G1Point,
-    ) {
+    async fn should_fail_validation(contract: &TestBN254<EthMiddleware>, bad_p: G1Point) {
         contract
             .validate_g1_point(bad_p)
             .call()

--- a/contracts/rust/src/eqs_test.rs
+++ b/contracts/rust/src/eqs_test.rs
@@ -1,12 +1,11 @@
 #[cfg(test)]
 mod tests {
     use crate::{
-        assertion::EnsureMined,
         cape::{
             submit_block::{fetch_cape_block, submit_cape_block_with_memos},
             BlockWithMemos, CapeBlock,
         },
-        deploy::{deploy_cape_test, deploy_erc20_token},
+        deploy::deploy_erc20_token,
         ethereum::{get_provider, EthConnection},
         ledger::{CapeLedger, CapeTransition},
         model::{erc20_asset_description, Erc20Code, EthereumAddr},
@@ -21,7 +20,6 @@ mod tests {
         abi::AbiDecode,
         prelude::{Middleware, U256},
     };
-    use futures::FutureExt;
     use itertools::Itertools;
     use jf_cap::{
         keys::{UserKeyPair, UserPubKey},
@@ -37,25 +35,6 @@ mod tests {
     use rand_chacha::ChaChaRng;
     use reef::Ledger;
     use std::iter::repeat_with;
-
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-    pub(crate) struct CAPEConstructorArgs {
-        height: u8,
-        n_roots: u64,
-    }
-
-    #[allow(dead_code)]
-    impl CAPEConstructorArgs {
-        pub(crate) fn new(height: u8, n_roots: u64) -> Self {
-            Self { height, n_roots }
-        }
-    }
-
-    impl From<CAPEConstructorArgs> for (u8, u64) {
-        fn from(args: CAPEConstructorArgs) -> (u8, u64) {
-            (args.height, args.n_roots)
-        }
-    }
 
     #[tokio::test]
     async fn eqs_test() -> anyhow::Result<()> {
@@ -119,7 +98,7 @@ mod tests {
 
         drop(cape_contract);
 
-        let block_committed_event_listener = async {
+        let _block_committed_event_listener = async {
             let mut number_events = 0;
             while number_events < 5 {
                 let cape_contract = eth_connection.lock().await.test_contract();
@@ -139,12 +118,12 @@ mod tests {
                     let provider = get_provider();
 
                     // Fetch Ethereum transaction that emitted event
-                    let tx = provider
+                    let _tx = provider
                         .get_transaction(meta.transaction_hash)
                         .await
                         .unwrap();
 
-                    let wraps = filter
+                    let _wraps = filter
                         .deposit_commitments
                         .iter()
                         .map(|&rc| {
@@ -158,7 +137,7 @@ mod tests {
             }
         };
 
-        let erc_20_tokens_deposited_event_listener = async {
+        let _erc_20_tokens_deposited_event_listener = async {
             let mut number_events = 0;
             while number_events < 1 {
                 let cape_contract = eth_connection.lock().await.test_contract();
@@ -200,19 +179,19 @@ mod tests {
                             let provider = get_provider();
 
                             // Fetch Ethereum transaction that emitted event
-                            let txs = provider
+                            let _txs = provider
                                 .get_transaction(meta.transaction_hash)
                                 .await
                                 .unwrap();
 
                             let connection = eth_connection.lock().await;
-                            let fetched_block_with_memos =
+                            let _fetched_block_with_memos =
                                 fetch_cape_block(&connection, meta.transaction_hash)
                                     .await
                                     .unwrap()
                                     .unwrap();
 
-                            let wraps = filter_data
+                            let _wraps = filter_data
                                 .deposit_commitments
                                 .iter()
                                 .map(|&rc| {
@@ -231,7 +210,7 @@ mod tests {
                                 filter_data.erc_20_token_address.to_fixed_bytes(),
                             ));
 
-                            let new_transition_wrap = CapeTransition::Wrap {
+                            let _new_transition_wrap = CapeTransition::Wrap {
                                 ro: Box::new(expected_ro),
                                 erc20_code,
                                 src_addr: EthereumAddr(filter_data.from.to_fixed_bytes()),

--- a/contracts/rust/src/ethereum.rs
+++ b/contracts/rust/src/ethereum.rs
@@ -9,11 +9,10 @@ use async_recursion::async_recursion;
 use ethers::{
     abi::{Abi, Tokenize},
     contract::Contract,
-    core::k256::ecdsa::SigningKey,
     prelude::{
         artifacts::BytecodeObject, coins_bip39::English, Address, ContractFactory, Http,
         LocalWallet, Middleware, MnemonicBuilder, Provider, Signer, SignerMiddleware,
-        TransactionRequest, Wallet, U256,
+        TransactionRequest, U256,
     },
 };
 
@@ -65,8 +64,7 @@ pub fn get_provider() -> Provider<Http> {
     Provider::<Http>::try_from(rpc_url).expect("could not instantiate HTTP Provider")
 }
 
-pub async fn get_funded_client() -> Result<Arc<SignerMiddleware<Provider<Http>, Wallet<SigningKey>>>>
-{
+pub async fn get_funded_client() -> Result<Arc<EthMiddleware>> {
     let mut provider = get_provider();
     let chain_id = provider.get_chainid().await.unwrap().as_u64();
 

--- a/contracts/rust/src/plonk_verifier/mod.rs
+++ b/contracts/rust/src/plonk_verifier/mod.rs
@@ -5,7 +5,7 @@ mod vk;
 
 use self::helpers::gen_plonk_proof_for_test;
 use crate::assertion::Matcher;
-use crate::deploy::deploy_test_plonk_verifier_contract;
+use crate::deploy::{deploy_test_plonk_verifier_contract, EthMiddleware};
 use crate::types::GenericInto;
 use crate::{
     ethereum::get_funded_client,
@@ -20,7 +20,6 @@ use ark_ff::{Field, Zero};
 use ark_poly::{EvaluationDomain, Radix2EvaluationDomain};
 use ark_std::rand::Rng;
 use ark_std::{test_rng, One, UniformRand};
-use ethers::core::k256::ecdsa::SigningKey;
 use ethers::prelude::*;
 use itertools::multiunzip;
 use jf_plonk::testing_apis::PcsInfo;
@@ -545,7 +544,7 @@ async fn test_proof_and_pub_inputs_validation() -> Result<()> {
 
     // bad path
     async fn test_bad_point_in_proof(
-        contract: &TestPlonkVerifier<SignerMiddleware<Provider<Http>, Wallet<SigningKey>>>,
+        contract: &TestPlonkVerifier<EthMiddleware>,
         vk_sol: &sol::VerifyingKey,
         pi_sol: &[U256],
         bad_proof: sol::PlonkProof,
@@ -564,7 +563,7 @@ async fn test_proof_and_pub_inputs_validation() -> Result<()> {
     }
 
     async fn test_bad_field_in_proof(
-        contract: &TestPlonkVerifier<SignerMiddleware<Provider<Http>, Wallet<SigningKey>>>,
+        contract: &TestPlonkVerifier<EthMiddleware>,
         vk_sol: &sol::VerifyingKey,
         pi_sol: &[U256],
         bad_proof: sol::PlonkProof,


### PR DESCRIPTION
The warnings due to unused imports and variables and only show up when
compiling the tests.