### PR TITLE
Updated SpectrumXYZ to EspressoSystems

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@
 
 ## Obtaining the source code
 
-    git clone git@github.com:SpectrumXYZ/cape.git
+    git clone git@github.com:EspressoSystems/cape.git
 
 # Environment
 
@@ -52,18 +52,18 @@ via the [nix](https://nixos.org) package manager.
 
 You also need access to the following currently private git repos
 
-- https://github.com/SpectrumXYZ/arbitrary-wrappers
-- https://github.com/SpectrumXYZ/atomic-store
-- https://github.com/SpectrumXYZ/cap
-- https://github.com/SpectrumXYZ/commit
-- https://github.com/SpectrumXYZ/curves
-- https://github.com/SpectrumXYZ/jellyfish-cap
-- https://github.com/SpectrumXYZ/key-set
-- https://github.com/SpectrumXYZ/net
-- https://github.com/SpectrumXYZ/reef
-- https://github.com/SpectrumXYZ/seahorse
-- https://github.com/SpectrumXYZ/universal-params
-- https://github.com/SpectrumXYZ/zerok-macros
+- https://github.com/EspressoSystems/arbitrary-wrappers
+- https://github.com/EspressoSystems/atomic-store
+- https://github.com/EspressoSystems/cap
+- https://github.com/EspressoSystems/commit
+- https://github.com/EspressoSystems/curves
+- https://github.com/EspressoSystems/jellyfish-cap
+- https://github.com/EspressoSystems/key-set
+- https://github.com/EspressoSystems/net
+- https://github.com/EspressoSystems/reef
+- https://github.com/EspressoSystems/seahorse
+- https://github.com/EspressoSystems/universal-params
+- https://github.com/EspressoSystems/zerok-macros
 
 Ping Mat for access.
 


### PR DESCRIPTION
- [x] Verify that installation/build instructions work - done on a 'fresh' macbook that hadn't been previously used for development before the repo name change. The old names redirect, so I think this test is still valid.
- [x] Update references to EspressoSystems
