### PR TITLE
Open Sourcing: Remove Github Auth

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,12 +46,6 @@ jobs:
       - name: Initialize Nix Shell
         run: nix-shell --run "echo Init"
 
-      - name: Configure Git
-        run: |
-          git config --global url."https://ancient123:${{ secrets.ORG_GITHUB_PAT }}@github.com".insteadOf git://github.com
-          git config --global url."https://ancient123:${{ secrets.ORG_GITHUB_PAT }}@github.com".insteadOf ssh://git@github.com
-          git config --global url."https://dl.cloudsmith.io/${{ secrets.CLOUDSMITH_ENTITLEMENT }}/".insteadOf https://dl.cloudsmith.io/basic/
-
       - name: Cache cargo
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
Note: This is going to be broken until dependencies don't require auth.