### PR TITLE
Separate `await_transaction` from `transfer_token`.

### DIFF
--- a/wallet/src/backend.rs
+++ b/wallet/src/backend.rs
@@ -439,7 +439,7 @@ mod test {
         let receiver_key = receiver.generate_user_key(None).await.unwrap();
 
         // Transfer from sender to receiver.
-        transfer_token(
+        let txn = transfer_token(
             &mut sender,
             receiver_key.address(),
             2,
@@ -448,6 +448,7 @@ mod test {
         )
         .await
         .unwrap();
+        await_transaction(&txn, &sender, &[&receiver]).await;
         assert_eq!(
             sender
                 .balance(&sender_key.address(), &AssetCode::native())
@@ -463,7 +464,7 @@ mod test {
 
         // Transfer back, just to make sure the receiver is actually able to spend the records it
         // received.
-        transfer_token(
+        let txn = transfer_token(
             &mut receiver,
             sender_key.address(),
             1,
@@ -472,6 +473,7 @@ mod test {
         )
         .await
         .unwrap();
+        await_transaction(&txn, &receiver, &[&sender]).await;
         assert_eq!(
             sender
                 .balance(&sender_key.address(), &AssetCode::native())

--- a/wallet/src/bin/random_wallet_in_mem.rs
+++ b/wallet/src/bin/random_wallet_in_mem.rs
@@ -311,23 +311,28 @@ async fn main() {
                     recipient_pk,
                 );
                 match transfer_token(sender, recipient_pk.address(), amount, *asset, fee).await {
-                    Ok(status) => {
-                        if !status.succeeded() {
-                            // Transfers are allowed to fail. It can happen, for instance, if we get starved
-                            // out until our transfer becomes too old for the validators. Thus we make this
-                            // a warning, not an error.
-                            event!(Level::WARN, "transfer failed!");
+                    Ok(txn) => match sender.await_transaction(&txn).await {
+                        Ok(status) => {
+                            if !status.succeeded() {
+                                // Transfers are allowed to fail. It can happen, for instance, if we
+                                // get starved out until our transfer becomes too old for the
+                                // validators. Thus we make this a warning, not an error.
+                                event!(Level::WARN, "transfer failed!");
+                            }
+                            update_balances(
+                                &sender_address,
+                                &recipient_pk.address(),
+                                amount,
+                                asset,
+                                &mut balances,
+                            )
                         }
-                        update_balances(
-                            &sender_address,
-                            &recipient_pk.address(),
-                            amount,
-                            asset,
-                            &mut balances,
-                        )
-                    }
+                        Err(err) => {
+                            event!(Level::ERROR, "error while waiting for transaction: {}", err);
+                        }
+                    },
                     Err(err) => {
-                        event!(Level::ERROR, "error while waiting for transaction: {}", err);
+                        event!(Level::ERROR, "error while building transaction: {}", err);
                     }
                 }
             }

--- a/wallet/src/testing.rs
+++ b/wallet/src/testing.rs
@@ -31,7 +31,7 @@ use rand_chacha::ChaChaRng;
 use reef::Ledger;
 use relayer::testing::start_minimal_relayer_for_test;
 use seahorse::testing::await_transaction;
-use seahorse::txn_builder::TransactionStatus;
+use seahorse::txn_builder::{TransactionReceipt, TransactionStatus};
 use surf::Url;
 use tide::log::LevelFilter;
 
@@ -261,9 +261,9 @@ pub async fn transfer_token<'a>(
     amount: u64,
     asset_code: AssetCode,
     fee: u64,
-) -> Result<TransactionStatus, CapeWalletError> {
+) -> Result<TransactionReceipt<CapeLedger>, CapeWalletError> {
     let sender_address = sender.pub_keys().await[0].address();
-    let txn = sender
+    sender
         .transfer(
             &sender_address,
             &asset_code,
@@ -271,6 +271,4 @@ pub async fn transfer_token<'a>(
             fee,
         )
         .await
-        .unwrap();
-    sender.await_transaction(&txn).await
 }


### PR DESCRIPTION
This allows the caller to choose how they want to wait on the
TransactionReceipt. In the CapeBackend tests, we wait for _all_
wallets to process the transaction and require it to succeed. In
the random wallet tests, we just wait for the sender to process
the transaction, and we don't panic if it fails.