### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1071,6 +1071,7 @@ dependencies = [
  "async-trait",
  "bincode",
  "commit",
+ "espresso-macros",
  "ethers 0.6.0 (git+https://github.com/gakonst/ethers-rs?branch=master)",
  "ethers-contract 0.6.0 (git+https://github.com/gakonst/ethers-rs?branch=master)",
  "ethers-contract-abigen 0.6.0 (git+https://github.com/gakonst/ethers-rs)",
@@ -1099,7 +1100,6 @@ dependencies = [
  "snafu 0.7.0",
  "strum_macros",
  "tokio",
- "zerok-macros",
 ]
 
 [[package]]
@@ -2083,6 +2083,16 @@ dependencies = [
  "once_cell",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "espresso-macros"
+version = "0.1.0"
+source = "git+ssh://git@github.com/EspressoSystems/espresso-macros.git#9e0b0258c99757c567676c4dd92f1501db0cf580"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/contracts/rust/Cargo.toml
+++ b/contracts/rust/Cargo.toml
@@ -15,7 +15,7 @@ jf-rescue = { features=["std"], git = "ssh://git@github.com/EspressoSystems/jell
 jf-utils = { features=["std"], git = "ssh://git@github.com/EspressoSystems/jellyfish.git" }
 key-set = { git = "ssh://git@github.com/EspressoSystems/key-set.git" }
 reef = { git = "ssh://git@github.com/EspressoSystems/reef.git" }
-zerok-macros = { git = "ssh://git@github.com/EspressoSystems/zerok-macros.git" }
+espresso-macros = { git = "ssh://git@github.com/EspressoSystems/espresso-macros.git" }
 arbitrary = { version="1.0", features=["derive"] }
 arbitrary-wrappers = { git = "ssh://git@github.com/EspressoSystems/arbitrary-wrappers.git" }
 

--- a/contracts/rust/src/ledger.rs
+++ b/contracts/rust/src/ledger.rs
@@ -2,6 +2,7 @@ use crate::model::*;
 use arbitrary::{Arbitrary, Unstructured};
 use arbitrary_wrappers::*;
 use commit::{Commitment, Committable, RawCommitmentBuilder};
+use espresso_macros::ser_test;
 use jf_cap::{
     keys::{AuditorKeyPair, AuditorPubKey},
     structs::{AssetCode, AssetDefinition, Nullifier, RecordCommitment, RecordOpening},
@@ -12,7 +13,6 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt::Display;
 use std::iter::repeat;
-use zerok_macros::ser_test;
 
 // A representation of an unauthenticated sparse set of nullifiers (it is "authenticated" by
 // querying the ultimate source of truth, the CAPE smart contract). The HashMap maps any nullifier


### PR DESCRIPTION
Just wanted to pull the latest Seahorse and make sure I could still run the CLI and everything. Ended up doing the `zerok-macros` -> `espresso-macros` change as well