### PR TITLE
update faucet address

### DIFF
--- a/contracts/deploy/00_cape.ts
+++ b/contracts/deploy/00_cape.ts
@@ -27,11 +27,11 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const treeDepth = 24;
   const nRoots = 1000;
 
-  // Faucet manager wallet public key: USERPUBKEY~RQtOX72Af9P9nxNKyZZXjQEN1j3FC02tyg8cXgHinasgAAAAAAAAAHvbhTwmXsaZJ6pSsjJQeDNpoD1Dp65tt5njNUbJkxNugQ
+  // Faucet manager wallet public key: USERPUBKEY~muN7VKxj1GbJ4D6rU6gANdvwD05oPKy_XmhkBxSByq0gAAAAAAAAAIRN-Rik8czFiToI8Ft5fsIf9HAEtWHDsOHh-ZBJZl1KxQ
   // address generation code:
   // ```rust
   // use ark_std::str::FromStr;
-  // let result = "USERPUBKEY~RQtOX72Af9P9nxNKyZZXjQEN1j3FC02tyg8cXgHinasgAAAAAAAAAHvbhTwmXsaZJ6pSsjJQeDNpoD1Dp65tt5njNUbJkxNugQ";
+  // let result = "USERPUBKEY~muN7VKxj1GbJ4D6rU6gANdvwD05oPKy_XmhkBxSByq0gAAAAAAAAAIRN-Rik8czFiToI8Ft5fsIf9HAEtWHDsOHh-ZBJZl1KxQ";
   // let pk = UserPubKey::from_str(&result).unwrap_or_default();
   // ark_std::eprintln!(
   //     "x: {}, y: {}",
@@ -40,8 +40,8 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   // );
   // ```
   const faucetManager = {
-    x: BigNumber.from("0x2B9DE2015E1C0FCAAD4D0BC53DD60D018D5796C94A139FFDD37F80BD5F4E0B45"),
-    y: BigNumber.from("0x22E38BAE576E313A11DE2BE09569830F3F7BF414592BA32812D82857947400CC"),
+    x: BigNumber.from("0x2DCA81140764685EBFAC3C684E0FF0DB3500A853AB3EE0C966D463AC547BE39A"),
+    y: BigNumber.from("0x228CF79945E37CFBB3F43F150B977639A12C900C949E23ED1DCD250578314393"),
   };
 
   await deploy("CAPE", {


### PR DESCRIPTION
Hopefully the last time we update the wallet address for testnet faucet. This is due to https://github.com/EspressoSystems/seahorse/pull/64