### PR TITLE
Allow lookup of ERC20 address via asset definition

### DIFF
--- a/contracts/contracts/AssetRegistry.sol
+++ b/contracts/contracts/AssetRegistry.sol
@@ -45,7 +45,7 @@ contract AssetRegistry {
     /// given asset definition.
     /// @param assetDefinition an asset definition
     /// @return An ERC-20 address
-    function _lookup(AssetDefinition memory assetDefinition) internal view returns (address) {
+    function lookup(AssetDefinition memory assetDefinition) public view returns (address) {
         bytes32 key = keccak256(abi.encode(assetDefinition));
         return assets[key];
     }
@@ -58,7 +58,7 @@ contract AssetRegistry {
         view
         returns (bool)
     {
-        return _lookup(assetDefinition) != address(0);
+        return lookup(assetDefinition) != address(0);
     }
 
     /// @notice Create and register a new asset type associated with an

--- a/contracts/contracts/CAPE.sol
+++ b/contracts/contracts/CAPE.sol
@@ -354,7 +354,7 @@ contract CAPE is RecordsMerkleTree, RootStore, AssetRegistry, ReentrancyGuard {
     /// @dev send the ERC20 tokens equivalent to the asset records being burnt. Recall that the burned record opening is contained inside the note.
     /// @param note note of type *BURN*
     function _handleWithdrawal(BurnNote memory note) internal {
-        address ercTokenAddress = _lookup(note.recordOpening.assetDef);
+        address ercTokenAddress = lookup(note.recordOpening.assetDef);
 
         // Extract recipient address
         address recipientAddress = BytesLib.toAddress(

--- a/contracts/rust/src/asset_registry.rs
+++ b/contracts/rust/src/asset_registry.rs
@@ -83,6 +83,14 @@ async fn test_asset_registry() -> Result<()> {
 
     assert!(registered);
 
+    // Lookup the address given the asset definition
+    let address = contract
+        .lookup(asset_def.clone().into())
+        .call()
+        .await
+        .unwrap();
+    assert_eq!(address, erc20_address);
+
     // Asset cannot be registered again
     contract
         .sponsor_cape_asset(erc20_address, asset_def.clone().into())


### PR DESCRIPTION
Make `AssetRegistry._lookup` public.

Close #682 