### PR TITLE
Emit FaucetInitialized event with faucet grant ro

### DIFF
--- a/contracts/contracts/CAPE.sol
+++ b/contracts/contracts/CAPE.sol
@@ -48,6 +48,7 @@ contract CAPE is RecordsMerkleTree, RootStore, AssetRegistry, ReentrancyGuard {
     // See https://github.com/EspressoSystems/cape/issues/400
     uint256 public constant MAX_NUM_PENDING_DEPOSIT = 10;
 
+    event FaucetInitialized(bytes roBytes);
     event BlockCommitted(uint64 indexed height, uint256[] depositCommitments);
     event Erc20TokensDeposited(bytes roBytes, address erc20TokenAddress, address from);
 
@@ -178,6 +179,7 @@ contract CAPE is RecordsMerkleTree, RootStore, AssetRegistry, ReentrancyGuard {
         _updateRecordsMerkleTree(recordCommitments);
         _addRoot(_rootValue);
 
+        emit FaucetInitialized(abi.encode(ro));
         faucetInitialized = true;
     }
 

--- a/eqs/src/eth_polling.rs
+++ b/eqs/src/eth_polling.rs
@@ -239,6 +239,11 @@ impl EthPolling {
                     };
                     self.pending_commit_event.push(new_transition_wrap);
                 }
+                CAPEEvents::FaucetInitializedFilter(filter_data) => {
+                    let ro_bytes = filter_data.ro_bytes;
+                    let _ro_sol: RecordOpeningSol = AbiDecode::decode(ro_bytes).unwrap();
+                    todo!();
+                }
             }
         }
         Ok(0)


### PR DESCRIPTION
Still hitting an ethers bug if we put the `RecordOpening` type into the event directly :( so this is also emitting ABI encoded bytes like the deposit event.

Close #697