### PR TITLE
Use plain base64 for UI-constructed parameters.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1123,6 +1123,7 @@ dependencies = [
  "address_book",
  "async-std",
  "async-trait",
+ "base64 0.13.0",
  "bincode",
  "cap-rust-sandbox",
  "commit",

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -9,6 +9,7 @@ license = "GPL-3.0-or-later"
 async-std = { version = "1.9.0", features = ["unstable", "attributes"] }
 async-trait = "0.1.51"
 address_book = { path = "../address_book" }
+base64 = "0.13"
 bincode = "1.3.3"
 cap-rust-sandbox = { path = "../contracts/rust" }
 commit = { git = "https://github.com/EspressoSystems/commit.git", tag = "0.1.0" }

--- a/wallet/api/api.toml
+++ b/wallet/api/api.toml
@@ -40,7 +40,7 @@ DOC = "Generate a random mnemonic phrase."
 [route.newwallet]
 PATH = ["newwallet/:mnemonic/:password", "newwallet/:mnemonic/:password/path/:path"]
 ":password" = "Literal"
-":path" = "TaggedBase64"
+":path" = "Base64"
 ":mnemonic" = "Literal"
 DOC = """
 Creates and opens a new the wallet with the given mnemonic and password.
@@ -49,7 +49,7 @@ Creates and opens a new the wallet with the given mnemonic and password.
 [route.openwallet]
 PATH = ["openwallet/:password", "openwallet/:password/path/:path"]
 ":password" = "Literal"
-":path" = "TaggedBase64"
+":path" = "Base64"
 DOC = """
 Open the wallet from local storage with the given password and path.
 """
@@ -244,7 +244,7 @@ PATH = [
   "newasset",
 ]
 ":erc20" = "TaggedBase64"
-":description" = "TaggedBase64"
+":description" = "Base64"
 ":sponsor" = "TaggedBase64"
 ":freezing_key" = "TaggedBase64"
 ":viewing_key" = "TaggedBase64"

--- a/wallet/src/bin/web_server.rs
+++ b/wallet/src/bin/web_server.rs
@@ -149,9 +149,8 @@ mod tests {
     }
 
     fn fmt_path(path: &Path) -> String {
-        TaggedBase64::new("PATH", path.as_os_str().to_str().unwrap().as_bytes())
-            .unwrap()
-            .to_string()
+        let bytes = path.as_os_str().to_str().unwrap().as_bytes();
+        base64::encode_config(bytes, base64::URL_SAFE_NO_PAD)
     }
 
     struct TestServer {
@@ -698,7 +697,7 @@ mod tests {
         let viewing_threshold = 10;
         let view_amount = true;
         let view_address = false;
-        let description = TaggedBase64::new("DESC", &[3u8; 32]).unwrap();
+        let description = base64::encode_config(&[3u8; 32], base64::URL_SAFE_NO_PAD);
 
         // Should fail if a wallet is not already open.
         server


### PR DESCRIPTION
There is currently no JS/WASM library for constructing tagged base
64. This changes URL parameters which the UI is expected to construct
from scratch, that were using tagged base 64, to use plain base 64
instead, which is easier to construct in JS.

We should change these back to tagged base 64 if and when we have a
compatible JS library.