### PR TITLE
Make Path Storage Arg for Wallet Optional

### DIFF
--- a/wallet/src/web.rs
+++ b/wallet/src/web.rs
@@ -56,7 +56,8 @@ pub struct NodeOpt {
     /// Path to store location of most recent wallet
     #[structopt(
         long = "storage_path",
-        env = "PATH_STORAGE"    // Fallback to env_var or $HOME
+        env = "PATH_STORAGE",    // Fallback to env_var or $HOME
+        default_value = "",
     )]
     pub path_storage: String,
 }


### PR DESCRIPTION
Adding default value makes it so the arg is optional.  

Test this by running the web_server without the path_storage arg and logged that the path storage value was empty (set to default)