### PR TITLE
Increment the state_number (timestamp) on each commit

### DIFF
--- a/eqs/src/eth_polling.rs
+++ b/eqs/src/eth_polling.rs
@@ -225,6 +225,7 @@ impl EthPolling {
                         });
 
                         updated_state.events.append(&mut memo_events);
+                        updated_state.ledger_state.state_number += 1;
 
                         //update merkle tree
                         if let Some(merkle_tree) = merkle_tree {


### PR DESCRIPTION
Tiny additional bit of data updating, probably has no effect, but fixing for correctness.