### PR TITLE
Support named keystores with an endpoint to list them.

### DIFF
--- a/wallet/api/api.toml
+++ b/wallet/api/api.toml
@@ -38,26 +38,41 @@ PATH = ["getmnemonic"]
 DOC = "Generate a random mnemonic phrase."
 
 [route.newwallet]
-PATH = ["newwallet/:mnemonic/:password", "newwallet/:mnemonic/:password/path/:path"]
+PATH = ["newwallet/:mnemonic/:password", "newwallet/:mnemonic/:password/path/:path", "newwallet/:mnemonic/:password/name/:name"]
 ":password" = "Literal"
 ":path" = "Base64"
+":name" = "Literal"
 ":mnemonic" = "Literal"
 DOC = """
 Creates and opens a new the wallet with the given mnemonic and password.
+
+If `:path` is given, the wallet will be stored in the given location. If `:name` is given, the walllet will be stored in
+`~/.espresso/cape/wallet/keystores/:name`. If neither `:path` nor `:name` is given, the wallet will be stored in
+`~/.espresso/cape/wallet/keystores/default`.
 """
 
 [route.openwallet]
-PATH = ["openwallet/:password", "openwallet/:password/path/:path"]
+PATH = ["openwallet/:password", "openwallet/:password/path/:path", "openwallet/:password/name/:name"]
 ":password" = "Literal"
 ":path" = "Base64"
 DOC = """
 Open the wallet from local storage with the given password and path.
+
+`:path` and `:name` work as they do for `newwallet`.
 """
 
 [route.closewallet]
 PATH = ["closewallet"]
 DOC = """
 Close the current wallet.
+"""
+
+[route.listkeystores]
+PATH = ["listkeystores"]
+DOC = """
+Return a list of all named keystores.
+
+Named keystores are those created with `newwallet/:mnemonic/:password/name/:name`.
 """
 
 [route.getaddress]

--- a/wallet/src/routes.rs
+++ b/wallet/src/routes.rs
@@ -13,7 +13,7 @@ use crate::{
     wallet::{CapeWalletError, CapeWalletExt},
     web::WebState,
 };
-use async_std::fs::{create_dir_all, File};
+use async_std::fs::{read_dir, File};
 use async_std::sync::{Arc, Mutex};
 use cap_rust_sandbox::{
     ledger::CapeLedger,
@@ -247,6 +247,7 @@ pub enum ApiRouteKey {
     getinfo,
     getmnemonic,
     importkey,
+    listkeystores,
     mint,
     newasset,
     newkey,
@@ -311,45 +312,29 @@ pub fn wallet_error(source: CapeWalletError) -> tide::Error {
         msg: source.to_string(),
     })
 }
-
-pub fn get_home_path() -> Result<PathBuf, tide::Error> {
-    let home = std::env::var("HOME").map_err(|_| {
-        server_error(CapeAPIError::Internal {
-            msg: String::from("HOME directory is not set. Please set the server's HOME directory."),
-        })
-    })?;
-    Ok(PathBuf::from(home))
+pub fn last_used_path_storage(storage: &Path) -> PathBuf {
+    [storage, Path::new("last_wallet_path")].iter().collect()
 }
 
-pub async fn default_storage_path() -> Result<PathBuf, tide::Error> {
-    let mut storage_path = get_home_path().unwrap();
-    storage_path.push(".espresso/cape");
-    create_dir_all(&storage_path).await?;
-    Ok(storage_path)
+pub fn keystores_dir(storage: &Path) -> PathBuf {
+    [storage, Path::new("keystores")].iter().collect()
 }
 
-pub async fn get_storage_path(path_arg: &Option<PathBuf>) -> Result<PathBuf, tide::Error> {
-    let mut path = if path_arg.is_some() {
-        path_arg.as_ref().unwrap().clone()
-    } else {
-        default_storage_path().await?
-    };
-    path.push("last_wallet_path");
-    Ok(path)
+pub fn keystore_path(storage: &Path, name: &str) -> PathBuf {
+    [keystores_dir(storage).as_path(), Path::new(name)]
+        .iter()
+        .collect()
 }
 
-pub async fn write_path(
-    wallet_path: &Path,
-    storage_path: &Option<PathBuf>,
-) -> Result<(), tide::Error> {
-    let path = get_storage_path(storage_path).await?;
+pub async fn write_path(wallet_path: &Path, storage: &Path) -> Result<(), tide::Error> {
+    let path = last_used_path_storage(storage);
     let mut file = File::create(path).await?;
     Ok(file
         .write_all(&bincode::serialize(&wallet_path).unwrap())
         .await?)
 }
-pub async fn read_last_path(path_arg: &Option<PathBuf>) -> Result<Option<PathBuf>, tide::Error> {
-    let path = get_storage_path(path_arg).await?;
+pub async fn read_last_path(storage: &Path) -> Result<Option<PathBuf>, tide::Error> {
+    let path = last_used_path_storage(storage);
     let file_result = File::open(&path).await;
     if file_result.is_err()
         && file_result.as_ref().err().unwrap().kind() == std::io::ErrorKind::NotFound
@@ -367,21 +352,12 @@ pub async fn init_wallet(
     faucet_pub_key: UserPubKey,
     mnemonic: Option<String>,
     password: String,
-    path: Option<PathBuf>,
+    path: PathBuf,
     existing: bool,
-    storage_path: &Option<PathBuf>,
+    storage: &Path,
 ) -> Result<Wallet, tide::Error> {
-    let path = match path {
-        Some(path) => path,
-        None => {
-            let mut path = get_home_path().unwrap();
-            path.push(".espresso/cape/wallet");
-            path
-        }
-    };
-
     // Store the path so we can have a getlastkeystore endpoint
-    write_path(&path, storage_path).await?;
+    write_path(&path, storage).await?;
 
     let verif_crs = VerifierKeySet {
         mint: TransactionVerifyingKey::Mint(
@@ -493,11 +469,14 @@ pub async fn newwallet(
     rng: &mut ChaChaRng,
     faucet_key_pair: &UserKeyPair,
     wallet: &mut Option<Wallet>,
-    storage_path: &Option<PathBuf>,
+    storage: &Path,
 ) -> Result<(), tide::Error> {
     let path = match bindings.get(":path") {
-        Some(binding) => Some(binding.value.as_path()?),
-        None => None,
+        Some(binding) => binding.value.as_path()?,
+        None => match bindings.get(":name") {
+            Some(name) => keystore_path(storage, &name.value.as_string()?),
+            None => keystore_path(storage, "default"),
+        },
     };
     let mnemonic = bindings[":mnemonic"].value.as_string()?;
     let password = bindings[":password"].value.as_string()?;
@@ -514,7 +493,7 @@ pub async fn newwallet(
             password,
             path,
             false,
-            storage_path,
+            storage,
         )
         .await?,
     );
@@ -526,11 +505,14 @@ pub async fn openwallet(
     rng: &mut ChaChaRng,
     faucet_key_pair: &UserKeyPair,
     wallet: &mut Option<Wallet>,
-    storage_path: &Option<PathBuf>,
+    storage: &Path,
 ) -> Result<(), tide::Error> {
     let path = match bindings.get(":path") {
-        Some(binding) => Some(binding.value.as_path()?),
-        None => None,
+        Some(binding) => binding.value.as_path()?,
+        None => match bindings.get(":name") {
+            Some(name) => keystore_path(storage, &name.value.as_string()?),
+            None => keystore_path(storage, "default"),
+        },
     };
     let password = bindings[":password"].value.as_string()?;
 
@@ -546,7 +528,7 @@ pub async fn openwallet(
             password,
             path,
             true,
-            storage_path,
+            storage,
         )
         .await?,
     );
@@ -557,6 +539,16 @@ async fn closewallet(wallet: &mut Option<Wallet>) -> Result<(), tide::Error> {
     require_wallet(wallet)?;
     *wallet = None;
     Ok(())
+}
+
+async fn listkeystores(storage: &Path) -> Result<Vec<String>, tide::Error> {
+    let dir = keystores_dir(storage);
+    let mut entries = read_dir(dir).await?;
+    let mut keystores = vec![];
+    while let Some(entry) = entries.next().await {
+        keystores.push(entry?.file_name().to_str().unwrap().to_owned());
+    }
+    Ok(keystores)
 }
 
 async fn getinfo(wallet: &mut Option<Wallet>) -> Result<WalletSummary, tide::Error> {
@@ -861,8 +853,8 @@ pub async fn get_records(wallet: &mut Option<Wallet>) -> Result<Vec<RecordInfo>,
     Ok(wallet.records().await.collect::<Vec<_>>())
 }
 
-pub async fn get_last_keystore(path: &Option<PathBuf>) -> Result<Option<PathBuf>, tide::Error> {
-    Ok(read_last_path(path).await?)
+pub async fn get_last_keystore(storage: &Path) -> Result<Option<PathBuf>, tide::Error> {
+    Ok(read_last_path(storage).await?)
 }
 
 // Get the set of assets associated with the given codes.
@@ -973,7 +965,7 @@ pub async fn dispatch_url(
     let rng = &mut *state.rng.lock().await;
     let faucet_key_pair = &state.faucet_key_pair;
     let wallet = &mut *state.wallet.lock().await;
-    let path_storage = &state.path_storage;
+    let storage = &state.storage;
     let key = ApiRouteKey::from_str(segments.0).expect("Unknown route");
     match key {
         ApiRouteKey::closewallet => response(&req, closewallet(wallet).await?),
@@ -984,16 +976,17 @@ pub async fn dispatch_url(
         ApiRouteKey::getinfo => response(&req, getinfo(wallet).await?),
         ApiRouteKey::getmnemonic => response(&req, getmnemonic(rng).await?),
         ApiRouteKey::importkey => dummy_url_eval(route_pattern, bindings),
+        ApiRouteKey::listkeystores => response(&req, listkeystores(storage).await?),
         ApiRouteKey::mint => response(&req, mint(bindings, wallet).await?),
         ApiRouteKey::newasset => response(&req, newasset(bindings, wallet).await?),
         ApiRouteKey::newkey => response(&req, newkey(segments.1, wallet).await?),
         ApiRouteKey::newwallet => response(
             &req,
-            newwallet(bindings, rng, faucet_key_pair, wallet, path_storage).await?,
+            newwallet(bindings, rng, faucet_key_pair, wallet, storage).await?,
         ),
         ApiRouteKey::openwallet => response(
             &req,
-            openwallet(bindings, rng, faucet_key_pair, wallet, path_storage).await?,
+            openwallet(bindings, rng, faucet_key_pair, wallet, storage).await?,
         ),
         ApiRouteKey::recoverkey => response(&req, recoverkey(segments.1, bindings, wallet).await?),
         ApiRouteKey::send => response(&req, send(bindings, wallet).await?),
@@ -1003,6 +996,6 @@ pub async fn dispatch_url(
         ApiRouteKey::view => dummy_url_eval(route_pattern, bindings),
         ApiRouteKey::wrap => response(&req, wrap(bindings, wallet).await?),
         ApiRouteKey::getrecords => response(&req, get_records(wallet).await?),
-        ApiRouteKey::lastusedkeystore => response(&req, get_last_keystore(path_storage).await?),
+        ApiRouteKey::lastusedkeystore => response(&req, get_last_keystore(storage).await?),
     }
 }

--- a/wallet/src/web.rs
+++ b/wallet/src/web.rs
@@ -12,7 +12,8 @@
 //! of the actual routes is defined in [crate::routes].
 
 use crate::routes::{
-    dispatch_url, CapeAPIError, RouteBinding, UrlSegmentType, UrlSegmentValue, Wallet,
+    dispatch_url, keystores_dir, CapeAPIError, RouteBinding, UrlSegmentType, UrlSegmentValue,
+    Wallet,
 };
 use async_std::{
     sync::{Arc, Mutex},
@@ -23,6 +24,7 @@ use jf_cap::{keys::UserKeyPair, structs::AssetCode};
 use net::server;
 use rand_chacha::ChaChaRng;
 use std::collections::hash_map::HashMap;
+use std::fs::create_dir_all;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use structopt::StructOpt;
@@ -40,26 +42,19 @@ pub const DEFAULT_NATIVE_AMT_IN_WRAPPER_ADDR: u64 = 400;
 )]
 pub struct NodeOpt {
     /// Path to assets including web server files.
-    #[structopt(
-        long = "assets",
-        default_value = ""      // See fn default_web_path().
-    )]
-    pub web_path: String,
+    #[structopt(long = "assets")]
+    pub web_path: Option<PathBuf>,
 
     /// Path to API specification and messages.
-    #[structopt(
-        long = "api",
-        default_value = ""      // See fn default_api_path().
-    )]
-    pub api_path: String,
+    #[structopt(long = "api")]
+    pub api_path: Option<PathBuf>,
 
-    /// Path to store location of most recent wallet
+    /// Path to store keystores and location of most recent wallet
     #[structopt(
-        long = "storage_path",
-        env = "PATH_STORAGE",    // Fallback to env_var or $HOME
-        default_value = "",
+        long = "storage",
+        env = "CAPE_WALLET_STORAGE", // Fallback to env_var or $HOME
     )]
-    pub path_storage: String,
+    pub storage: Option<PathBuf>,
 }
 
 /// Returns the project directory.
@@ -89,6 +84,13 @@ pub fn default_api_path() -> PathBuf {
     [&dir, Path::new(API_FILE)].iter().collect()
 }
 
+/// Returns the default path to store generated files.
+pub fn default_storage_path() -> PathBuf {
+    let home = std::env::var("HOME")
+        .expect("HOME directory is not set. Please set the server's HOME directory.");
+    [&home, ".espresso/cape/wallet"].iter().collect()
+}
+
 /// State maintained by the server, used to handle requests.
 #[derive(Clone)]
 pub struct WebState {
@@ -96,7 +98,7 @@ pub struct WebState {
     pub(crate) wallet: Arc<Mutex<Option<Wallet>>>,
     pub(crate) rng: Arc<Mutex<ChaChaRng>>,
     pub(crate) faucet_key_pair: UserKeyPair,
-    pub(crate) path_storage: Option<PathBuf>,
+    pub(crate) storage: PathBuf,
 }
 
 // Get the route pattern that matches the URL of a request, and the bindings for parameters in the
@@ -314,8 +316,11 @@ pub fn init_server(
     api_path: PathBuf,
     web_path: PathBuf,
     port: u64,
-    path_storage: Option<PathBuf>,
+    storage: PathBuf,
 ) -> std::io::Result<JoinHandle<std::io::Result<()>>> {
+    // Make sure relevant sub-directories of `storage` exist.
+    create_dir_all(keystores_dir(&storage))?;
+
     let api = crate::disco::load_messages(&api_path);
     let faucet_key_pair = UserKeyPair::generate(&mut rng);
     let mut web_server = tide::with_state(WebState {
@@ -323,7 +328,7 @@ pub fn init_server(
         wallet: Arc::new(Mutex::new(None)),
         rng: Arc::new(Mutex::new(rng)),
         faucet_key_pair,
-        path_storage,
+        storage,
     });
     web_server
         .with(server::trace)


### PR DESCRIPTION
The bulk if this change is reworking the way storage is configured,
so that there is now one parameter for the root storage directory
for all wallets. This replaces `~/.espresso/cape/wallet` if given.
This directory is then used to store both the last used wallet path
(`$CAPE_WALLET_STORAGE/last_wallet_path`) and named keystores
(`$CAPE_WALLET_STORAGE/keystores/`).

We then extend the `newwallet` and `openwallet` endpoints to take a
:name instead of a :path, which automatically stores the created
wallet in `$CAPE_WALLET_STORAGE/keystores/$NAME`. We add an endpoint
`listkeystores` to list all of the keystore names in the keystores
directory.