### PR TITLE
Use nix based docker base image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,4 @@ target/release/build
 target/release/deps
 target/release/examples
 target/release/incremental
+target/doc

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,11 +98,10 @@ jobs:
           name: wallet-webserver
           path: wallet-checkout/target/release/
 
-      - name: Set linker/loader to not be nix
-        run: patchelf --set-interpreter /lib64/ld-linux-x86-64.so.2 wallet-checkout/target/release/web_server
-
       - uses: docker/setup-buildx-action@v1
         name: Setup Docker BuildKit (buildx)
+        with:
+          driver: docker
 
       - uses: docker/login-action@v1
         name: Login to Github Container Repo
@@ -117,6 +116,9 @@ jobs:
         id: meta
         with:
           images: ghcr.io/espressosystems/cape/wallet
+
+      - name: Generate base image
+        run: cd wallet-checkout && bin/build-docker-base
 
       - uses: docker/build-push-action@v2
         name: Build and Push Docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,4 @@
-FROM ubuntu:impish
-RUN apt-get update \
-  && apt-get install -y libcurl4 \
-  && rm -rf /var/lib/apt/lists/*
+FROM nix-base-docker
 COPY target/release/web_server /app/web_server
 COPY wallet/api /app/api
 COPY wallet/public /app/public

--- a/bin/build-docker-base
+++ b/bin/build-docker-base
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+nix --experimental-features "nix-command flakes" build .#docker
+docker load --input result

--- a/flake.nix
+++ b/flake.nix
@@ -57,6 +57,16 @@
           };
         };
       };
+      # A nix base image
+      packages.docker = pkgs.dockerTools.buildImage {
+        name = "nix-base-docker";
+        tag = "latest";
+        contents = with pkgs; [
+          curl
+          coreutils
+          bashInteractive
+        ];
+      };
       devShell =
         let
           mySolc = pkgs.callPackage ./nix/solc-bin { version = "0.8.10"; };


### PR DESCRIPTION
### Motivation

1. No need for patchelf. Base image inputs are tracked with nix.
2. Make it possible to build the image locally. Should make it easier to put together the remaining images we need.