### PR TITLE
Check wallet API parameter types.

### DIFF
--- a/wallet/api/api.toml
+++ b/wallet/api/api.toml
@@ -55,6 +55,7 @@ If `:path` is given, the wallet will be stored in the given location. If `:name`
 PATH = ["openwallet/:password", "openwallet/:password/path/:path", "openwallet/:password/name/:name"]
 ":password" = "Literal"
 ":path" = "Base64"
+":name" = "Literal"
 DOC = """
 Open the wallet from local storage with the given password and path.
 
@@ -116,6 +117,7 @@ Get all records related to the current wallet.
 
 [route.getinfo]
 PATH = ["getinfo", "getinfo/address", "getinfo/key", "getinfo/asset", "getinfo/asset/:asset", "getinfo/freezing_key", "getinfo/sending_key", "getinfo/viewing_key"]
+":asset" = "TaggedBase64"
 DOC = """
 Get the addresses, public keys, and asset types for the current wallet.
 """
@@ -328,9 +330,9 @@ View the given asset or view the asset associated with the given viewing key.
 """
 
 [route.transaction]
-PATH = ["transaction/list", "transaction/list/:from/:count", "transaction/status/:receipt", "transaction/await/:reciept"]
+PATH = ["transaction/list", "transaction/list/:from/:count", "transaction/status/:receipt", "transaction/await/:receipt"]
 ":from" = "TaggedBase64"
-":reciept" = "TaggedBase64"
+":receipt" = "TaggedBase64"
 ":count" = "Integer"
 DOC = """
 List transactions, poll the status of a given transaction, or await events for a given transaction.

--- a/wallet/src/disco.rs
+++ b/wallet/src/disco.rs
@@ -16,7 +16,9 @@ pub fn load_messages(path: &Path) -> toml::Value {
     let messages = read_to_string(&path).unwrap_or_else(|_| panic!("Unable to read {:?}.", &path));
     let api: toml::Value =
         toml::from_str(&messages).unwrap_or_else(|_| panic!("Unable to parse {:?}.", &path));
-    check_api(api.clone());
+    if let Err(err) = check_api(api.clone()) {
+        panic!("{}", err);
+    }
     api
 }
 


### PR DESCRIPTION
Added a check when the API is loaded that every URL parameter has
a valid type. Fixed a few errors that this new check caught.