### PR TITLE
Fix deadlock in wallet caused by double locking mutex

### DIFF
--- a/wallet/src/wallet.rs
+++ b/wallet/src/wallet.rs
@@ -238,11 +238,11 @@ impl<'a, Backend: CapeWalletBackend<'a> + Sync + 'a> CapeWalletExt<'a, Backend>
 
     /// Determine if an asset is a wrapped asset (as opposed to a domestic CAPE asset).
     async fn is_wrapped_asset(&self, asset: AssetCode) -> bool {
-        let state = self.lock().await;
         let definition = match self.asset(asset).await {
             Some(asset) => asset.definition,
             None => return false,
         };
+        let state = self.lock().await;
         state
             .backend()
             .get_wrapped_erc20_code(&definition)


### PR DESCRIPTION
When I was debugging why the wallet integration test, I noticed the program would hang whenever it chose to burn.  The issue was caused by the call to `is_wrapped_asset()`.  The problem is  `is_wrapped_asset` calls `self.assets()` which locks the state mutex while it already holds the lock.  Locking the same mutex twice causes deadlock.  

Fix is just to swap the order (lock after calling self.assets()).  I confirmed this fix works while working on integration testing and seeing the deadlock disappear with this change.  