### PR TITLE
Add Docker build for the full CAPE demo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,6 +93,16 @@ jobs:
             target/release/faucet
             target/release/minimal-relayer
 
+      - uses: actions/upload-artifact@v2
+        with:
+          name: demo-executables
+          path: |
+            target/release/address-book
+            target/release/eqs
+            target/release/faucet
+            target/release/minimal-relayer
+            target/release/wallet-api
+
   docker-wallet:
     runs-on: self-hosted
     needs: build
@@ -180,6 +190,52 @@ jobs:
         with:
           context: ./services-checkout/
           file: ./services.Dockerfile
+          platforms: linux/amd64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  docker-demo:
+    runs-on: self-hosted
+    needs: build
+    steps:
+      - uses: actions/checkout@v2
+        name: Checkout Repository
+        with:
+          path: demo-checkout
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: demo-executables
+          path: demo-checkout/target/release/
+
+      - uses: docker/setup-buildx-action@v1
+        name: Setup Docker BuildKit (buildx)
+        with:
+          driver: docker
+
+      - uses: docker/login-action@v1
+        name: Login to Github Container Repo
+        if: github.event_name != 'pull_request'
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v3
+        name: Generate Docker Metadata
+        id: meta
+        with:
+          images: ghcr.io/espressosystems/cape/demo
+
+      - name: Generate base image
+        run: cd demo-checkout && bin/build-docker-base
+
+      - uses: docker/build-push-action@v2
+        name: Build and Push Docker
+        with:
+          context: ./demo-checkout/
+          file: ./demo.Dockerfile
           platforms: linux/amd64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/bin/build-docker-demo
+++ b/bin/build-docker-demo
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+build-docker-base
+docker build -t cape/demo -f ./demo.Dockerfile .

--- a/demo.Dockerfile
+++ b/demo.Dockerfile
@@ -1,0 +1,35 @@
+FROM nix-base-docker
+
+COPY target/release/eqs /app/target/release/eqs
+RUN chmod +x /app/target/release/eqs
+COPY eqs/api /app/eqs/api
+
+COPY target/release/minimal-relayer /app/target/release/minimal-relayer
+RUN chmod +x /app/target/release/minimal-relayer
+
+COPY target/release/faucet /app/target/release/faucet
+RUN chmod +x /app/target/release/faucet
+
+COPY target/release/address-book /app/target/release/address-book
+RUN chmod +x /app/target/release/address-book
+
+COPY target/release/wallet-api /app/target/release/wallet-api
+RUN chmod +x /app/target/release/wallet-api
+COPY wallet/api /app/wallet/api
+COPY wallet/public /app/wallet/public
+
+COPY bin/cape-demo /app/cape-demo
+
+WORKDIR /app/
+CMD ./cape-demo
+
+# Address book
+EXPOSE 50000
+# EQS
+EXPOSE 50010
+# Relayer
+EXPOSE 50020 
+# Faucet
+EXPOSE 50030 
+# Wallet
+EXPOSE 50040 


### PR DESCRIPTION
Need this for Plaza.

Note sure if I'm doing this right and can't test because `docker build` doesn't seem to work on Mac:
```
> [ 3/16] RUN chmod +x /app/target/release/eqs:
#7 0.196 standard_init_linux.go:228: exec user process caused: exec format error
```