### PR TITLE
Add status information for the wallet ledger scanner

### DIFF
--- a/wallet/src/backend.rs
+++ b/wallet/src/backend.rs
@@ -518,6 +518,14 @@ impl<'a, Meta: Serialize + DeserializeOwned + Send> CapeWalletBackend<'a>
             .parse()
             .unwrap()
     }
+
+    async fn eqs_time(&self) -> Result<EventIndex, CapeWalletError> {
+        let state: CapState = self.get_eqs("get_cap_state").await?;
+        Ok(EventIndex::from_source(
+            EventSource::QueryService,
+            state.num_events as usize,
+        ))
+    }
 }
 
 const TRANSFER_KEY_SIZES: &[(usize, usize)] = &[(1, 2), (2, 2), (2, 3)];

--- a/wallet/src/mocks.rs
+++ b/wallet/src/mocks.rs
@@ -688,6 +688,10 @@ impl<'a, Meta: Serialize + DeserializeOwned + Send> CapeWalletBackend<'a>
     fn asset_verifier(&self) -> VerKey {
         test_asset_signing_key().ver_key()
     }
+
+    async fn eqs_time(&self) -> Result<EventIndex, CapeWalletError> {
+        Ok(self.ledger.lock().await.network().events.now())
+    }
 }
 
 fn cape_to_wallet_err(err: CapeValidationError) -> WalletError<CapeLedger> {

--- a/wallet/src/ui.rs
+++ b/wallet/src/ui.rs
@@ -312,6 +312,10 @@ pub struct WalletSummary {
     pub viewing_keys: Vec<AuditorPubKey>,
     pub freezing_keys: Vec<FreezerPubKey>,
     pub assets: Vec<AssetInfo>,
+    /// The time (as an event index) at which the wallet last synced with the EQS.
+    pub sync_time: usize,
+    /// The real-world time (as an event index) according to the EQS.
+    pub real_time: usize,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/wallet/src/wallet-api/main.rs
+++ b/wallet/src/wallet-api/main.rs
@@ -394,16 +394,13 @@ mod tests {
             .unwrap();
         let info = server.get::<WalletSummary>("getinfo").await.unwrap();
 
-        assert_eq!(
-            info,
-            WalletSummary {
-                addresses: vec![],
-                sending_keys: vec![],
-                viewing_keys: vec![],
-                freezing_keys: vec![],
-                assets: vec![AssetInfo::native()]
-            }
-        )
+        assert_eq!(info.addresses, vec![]);
+        assert_eq!(info.sending_keys, vec![]);
+        assert_eq!(info.viewing_keys, vec![]);
+        assert_eq!(info.freezing_keys, vec![]);
+        assert_eq!(info.assets, vec![AssetInfo::native()]);
+        // The wallet should be up-to-date with the EQS.
+        assert_eq!(info.sync_time, info.real_time);
     }
 
     #[async_std::test]

--- a/wallet/src/wallet-api/routes.rs
+++ b/wallet/src/wallet-api/routes.rs
@@ -655,6 +655,7 @@ async fn listkeystores(options: &NodeOpt) -> Result<Vec<String>, tide::Error> {
 
 async fn getinfo(wallet: &mut Option<Wallet>) -> Result<WalletSummary, tide::Error> {
     let wallet = require_wallet(wallet)?;
+    let (sync_time, real_time) = wallet.scan_status().await.map_err(wallet_error)?;
     Ok(WalletSummary {
         addresses: wallet
             .pub_keys()
@@ -666,6 +667,8 @@ async fn getinfo(wallet: &mut Option<Wallet>) -> Result<WalletSummary, tide::Err
         viewing_keys: wallet.auditor_pub_keys().await,
         freezing_keys: wallet.freezer_pub_keys().await,
         assets: known_assets(wallet).await.into_values().collect(),
+        sync_time: sync_time.index(EventSource::QueryService),
+        real_time: real_time.index(EventSource::QueryService),
     })
 }
 


### PR DESCRIPTION
The GUI will use this to display a spinning circle or loading indicator if the wallet is too far behind the EQS.

Closes #782 