### PR TITLE
Verifier keys depuplication

### DIFF
--- a/contracts/rust/src/universal_param.rs
+++ b/contracts/rust/src/universal_param.rs
@@ -7,9 +7,13 @@
 
 #![deny(warnings)]
 use jf_cap::testing_apis::universal_setup_for_test;
+use jf_cap::TransactionVerifyingKey;
+use key_set::{KeySet, VerifierKeySet};
 use lazy_static::lazy_static;
 use rand_chacha::rand_core::SeedableRng;
 use rand_chacha::ChaChaRng;
+
+use crate::model::CAPE_MERKLE_HEIGHT;
 
 const MAX_DEGREE_SUPPORTED: usize = 2u64.pow(17) as usize;
 
@@ -17,4 +21,40 @@ lazy_static! {
     pub static ref UNIVERSAL_PARAM: jf_cap::proof::UniversalParam =
         universal_setup_for_test(MAX_DEGREE_SUPPORTED, &mut ChaChaRng::from_seed([0u8; 32]))
             .unwrap();
+}
+
+pub fn verifier_keys() -> VerifierKeySet {
+    let univ_setup = &*UNIVERSAL_PARAM;
+    let (_, xfr_verif_key_12, _) =
+        jf_cap::proof::transfer::preprocess(univ_setup, 1, 2, CAPE_MERKLE_HEIGHT).unwrap();
+    let (_, xfr_verif_key_22, _) =
+        jf_cap::proof::transfer::preprocess(univ_setup, 2, 2, CAPE_MERKLE_HEIGHT).unwrap();
+    let (_, xfr_verif_key_23, _) =
+        jf_cap::proof::transfer::preprocess(univ_setup, 2, 3, CAPE_MERKLE_HEIGHT).unwrap();
+    let (_, mint_verif_key, _) =
+        jf_cap::proof::mint::preprocess(univ_setup, CAPE_MERKLE_HEIGHT).unwrap();
+    let (_, freeze_verif_key_2, _) =
+        jf_cap::proof::freeze::preprocess(univ_setup, 2, CAPE_MERKLE_HEIGHT).unwrap();
+    let (_, freeze_verif_key_3, _) =
+        jf_cap::proof::freeze::preprocess(univ_setup, 3, CAPE_MERKLE_HEIGHT).unwrap();
+    VerifierKeySet {
+        mint: TransactionVerifyingKey::Mint(mint_verif_key),
+        xfr: KeySet::new(
+            vec![
+                TransactionVerifyingKey::Transfer(xfr_verif_key_12),
+                TransactionVerifyingKey::Transfer(xfr_verif_key_22),
+                TransactionVerifyingKey::Transfer(xfr_verif_key_23),
+            ]
+            .into_iter(),
+        )
+        .unwrap(),
+        freeze: KeySet::new(
+            vec![
+                TransactionVerifyingKey::Freeze(freeze_verif_key_2),
+                TransactionVerifyingKey::Freeze(freeze_verif_key_3),
+            ]
+            .into_iter(),
+        )
+        .unwrap(),
+    }
 }

--- a/eqs/src/configuration.rs
+++ b/eqs/src/configuration.rs
@@ -5,11 +5,8 @@
 // This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 // You should have received a copy of the GNU General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use cap_rust_sandbox::{model::CAPE_MERKLE_HEIGHT, universal_param::UNIVERSAL_PARAM};
 use dirs::data_local_dir;
 use ethers::prelude::Address;
-use jf_cap::TransactionVerifyingKey;
-use key_set::{KeySet, VerifierKeySet};
 use std::{env, path::PathBuf, time::Duration};
 use structopt::StructOpt;
 
@@ -122,43 +119,6 @@ impl EQSOptions {
 
     pub(crate) fn reset_state(&self) -> bool {
         self.reset_store_state
-    }
-
-    pub(crate) fn verifier_keys(&self) -> VerifierKeySet {
-        // Set up the validator.
-        let univ_setup = &*UNIVERSAL_PARAM;
-        let (_, xfr_verif_key_12, _) =
-            jf_cap::proof::transfer::preprocess(univ_setup, 1, 2, CAPE_MERKLE_HEIGHT).unwrap();
-        let (_, xfr_verif_key_22, _) =
-            jf_cap::proof::transfer::preprocess(univ_setup, 2, 2, CAPE_MERKLE_HEIGHT).unwrap();
-        let (_, xfr_verif_key_23, _) =
-            jf_cap::proof::transfer::preprocess(univ_setup, 2, 3, CAPE_MERKLE_HEIGHT).unwrap();
-        let (_, mint_verif_key, _) =
-            jf_cap::proof::mint::preprocess(univ_setup, CAPE_MERKLE_HEIGHT).unwrap();
-        let (_, freeze_verif_key_2, _) =
-            jf_cap::proof::freeze::preprocess(univ_setup, 2, CAPE_MERKLE_HEIGHT).unwrap();
-        let (_, freeze_verif_key_3, _) =
-            jf_cap::proof::freeze::preprocess(univ_setup, 3, CAPE_MERKLE_HEIGHT).unwrap();
-        VerifierKeySet {
-            mint: TransactionVerifyingKey::Mint(mint_verif_key),
-            xfr: KeySet::new(
-                vec![
-                    TransactionVerifyingKey::Transfer(xfr_verif_key_12),
-                    TransactionVerifyingKey::Transfer(xfr_verif_key_22),
-                    TransactionVerifyingKey::Transfer(xfr_verif_key_23),
-                ]
-                .into_iter(),
-            )
-            .unwrap(),
-            freeze: KeySet::new(
-                vec![
-                    TransactionVerifyingKey::Freeze(freeze_verif_key_2),
-                    TransactionVerifyingKey::Freeze(freeze_verif_key_3),
-                ]
-                .into_iter(),
-            )
-            .unwrap(),
-        }
     }
 
     pub(crate) fn query_frequency(&self) -> Duration {

--- a/eqs/src/entry.rs
+++ b/eqs/src/entry.rs
@@ -16,19 +16,20 @@ use async_std::{
     sync::{Arc, RwLock},
     task::sleep,
 };
+use cap_rust_sandbox::universal_param::verifier_keys;
 
 pub async fn run(opt: &EQSOptions) -> std::io::Result<()> {
     let (state_persistence, query_result_state) = if opt.reset_state() {
         (
             StatePersistence::new(&opt.store_path(), "eth_query").unwrap(),
-            Arc::new(RwLock::new(QueryResultState::new(opt.verifier_keys()))),
+            Arc::new(RwLock::new(QueryResultState::new(verifier_keys()))),
         )
     } else {
         let state_persistence = StatePersistence::load(&opt.store_path(), "eth_query").unwrap();
         let query_result_state = Arc::new(RwLock::new(
             state_persistence.load_latest_state().unwrap_or_else(|err| {
                 if let PersistenceError::FailedToFindExpectedResource { key: _ } = err {
-                    QueryResultState::new(opt.verifier_keys())
+                    QueryResultState::new(verifier_keys())
                 } else {
                     panic!("{:?}", err);
                 }

--- a/relayer/src/configuration.rs
+++ b/relayer/src/configuration.rs
@@ -5,10 +5,7 @@
 // This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 // You should have received a copy of the GNU General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use cap_rust_sandbox::{model::CAPE_MERKLE_HEIGHT, universal_param::UNIVERSAL_PARAM};
 use jf_cap::keys::{UserAddress, UserKeyPair};
-use jf_cap::TransactionVerifyingKey;
-use key_set::{KeySet, VerifierKeySet};
 
 use dirs::data_local_dir;
 use rand_chacha::{rand_core::SeedableRng, ChaChaRng};
@@ -69,32 +66,6 @@ pub(crate) fn store_path() -> PathBuf {
 
 pub(crate) fn reset_state() -> bool {
     RelayerOptions::from_args().reset_state_store
-}
-
-pub(crate) fn verifier_keys() -> VerifierKeySet {
-    // Set up the validator.
-    let univ_setup = &*UNIVERSAL_PARAM;
-    let (_, xfr_verif_key_12, _) =
-        jf_cap::proof::transfer::preprocess(univ_setup, 1, 2, CAPE_MERKLE_HEIGHT).unwrap();
-    let (_, xfr_verif_key_23, _) =
-        jf_cap::proof::transfer::preprocess(univ_setup, 2, 3, CAPE_MERKLE_HEIGHT).unwrap();
-    let (_, mint_verif_key, _) =
-        jf_cap::proof::mint::preprocess(univ_setup, CAPE_MERKLE_HEIGHT).unwrap();
-    let (_, freeze_verif_key, _) =
-        jf_cap::proof::freeze::preprocess(univ_setup, 2, CAPE_MERKLE_HEIGHT).unwrap();
-    VerifierKeySet {
-        mint: TransactionVerifyingKey::Mint(mint_verif_key),
-        xfr: KeySet::new(
-            vec![
-                TransactionVerifyingKey::Transfer(xfr_verif_key_12),
-                TransactionVerifyingKey::Transfer(xfr_verif_key_23),
-            ]
-            .into_iter(),
-        )
-        .unwrap(),
-        freeze: KeySet::new(vec![TransactionVerifyingKey::Freeze(freeze_verif_key)].into_iter())
-            .unwrap(),
-    }
 }
 
 lazy_static! {

--- a/relayer/src/main.rs
+++ b/relayer/src/main.rs
@@ -10,11 +10,12 @@ extern crate lazy_static;
 
 use crate::api_server::init_web_server;
 use crate::block_builder::Builder;
-use crate::configuration::{reset_state, store_path, verifier_keys};
+use crate::configuration::{reset_state, store_path};
 use crate::state_persistence::StatePersistence;
 use crate::txn_queue::TxnQueue;
 
 use cap_rust_sandbox::model::{CapeContractState, CAPE_MERKLE_HEIGHT};
+use cap_rust_sandbox::universal_param::verifier_keys;
 use jf_cap::MerkleTree;
 
 use async_std::sync::{Arc, RwLock};

--- a/wallet/src/testing.rs
+++ b/wallet/src/testing.rs
@@ -22,6 +22,7 @@ use async_std::task::{sleep, spawn, JoinHandle};
 use cap_rust_sandbox::deploy::EthMiddleware;
 use cap_rust_sandbox::ethereum::get_provider;
 use cap_rust_sandbox::ledger::CapeLedger;
+use cap_rust_sandbox::test_utils::keysets_for_test;
 use cap_rust_sandbox::types::SimpleToken;
 use eqs::{configuration::EQSOptions, run_eqs};
 use ethers::prelude::Address;
@@ -39,15 +40,12 @@ use jf_cap::structs::AssetDefinition;
 use jf_cap::structs::AssetPolicy;
 use jf_cap::structs::FreezeFlag;
 use jf_cap::structs::ReceiverMemo;
-use jf_cap::TransactionVerifyingKey;
-use key_set::VerifierKeySet;
 use lazy_static::lazy_static;
 use rand::{
     distributions::{Distribution, Standard},
     Rng,
 };
 use rand_chacha::ChaChaRng;
-use reef::Ledger;
 use relayer::testing::start_minimal_relayer_for_test;
 use seahorse::testing::await_transaction;
 use seahorse::txn_builder::RecordInfo;
@@ -115,58 +113,8 @@ pub async fn create_test_network<'a>(
     let relayer_url = Url::parse(&format!("http://localhost:{}", relayer_port)).unwrap();
     let sender_memo = ReceiverMemo::from_ro(rng, &sender_rec, &[]).unwrap();
 
-    let verif_crs = VerifierKeySet {
-        xfr: vec![
-            // For native transfers
-            TransactionVerifyingKey::Transfer(
-                jf_cap::proof::transfer::preprocess(
-                    universal_param,
-                    1,
-                    2,
-                    CapeLedger::merkle_height(),
-                )
-                .unwrap()
-                .1,
-            ),
-            // For non-native transfers
-            TransactionVerifyingKey::Transfer(
-                jf_cap::proof::transfer::preprocess(
-                    universal_param,
-                    2,
-                    3,
-                    CapeLedger::merkle_height(),
-                )
-                .unwrap()
-                .1,
-            ),
-            // For burns (which currently require exactly 2 inputs and outputs, but this is an
-            // artificial restriction which should be lifted)
-            TransactionVerifyingKey::Transfer(
-                jf_cap::proof::transfer::preprocess(
-                    universal_param,
-                    2,
-                    2,
-                    CapeLedger::merkle_height(),
-                )
-                .unwrap()
-                .1,
-            ),
-        ]
-        .into_iter()
-        .collect(),
-        freeze: vec![TransactionVerifyingKey::Freeze(
-            jf_cap::proof::freeze::preprocess(universal_param, 2, CapeLedger::merkle_height())
-                .unwrap()
-                .1,
-        )]
-        .into_iter()
-        .collect(),
-        mint: TransactionVerifyingKey::Mint(
-            jf_cap::proof::mint::preprocess(universal_param, CapeLedger::merkle_height())
-                .unwrap()
-                .1,
-        ),
-    };
+    let (_, verif_crs) = keysets_for_test(universal_param);
+
     let mut mock_eqs = MockCapeLedger::new(MockCapeNetwork::new(
         verif_crs,
         records,


### PR DESCRIPTION
Adds a function `verifier_keys` to the contract crate that can be used in the other crates.