### PR TITLE
Making the tracing-subscriber feature env-filter explicit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,7 +44,7 @@ dependencies = [
  "tempdir",
  "tide",
  "tracing",
- "tracing-subscriber 0.3.9",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1194,7 +1194,7 @@ dependencies = [
  "tracing",
  "tracing-distributed",
  "tracing-futures",
- "tracing-subscriber 0.3.9",
+ "tracing-subscriber",
  "tracing-test",
 ]
 
@@ -2095,7 +2095,7 @@ dependencies = [
  "tide-websockets",
  "toml",
  "tracing",
- "tracing-subscriber 0.3.9",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2750,7 +2750,7 @@ dependencies = [
  "tempdir",
  "tide",
  "tracing",
- "tracing-subscriber 0.3.9",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -3841,15 +3841,6 @@ dependencies = [
  "lazy_static",
  "pipeline",
  "regex",
-]
-
-[[package]]
-name = "matchers"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
-dependencies = [
- "regex-automata",
 ]
 
 [[package]]
@@ -4954,7 +4945,7 @@ dependencies = [
  "tide-websockets",
  "toml",
  "tracing",
- "tracing-subscriber 0.3.9",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -6346,14 +6337,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-distributed"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e351159c859c0bfa19dc77955731b8fc52d2f417cd8dc1d4585844d22f013f24"
+checksum = "de30b98573d9e63e82996b3c9bf950210ba3f2dcf363f7eec000acebef1a4377"
 dependencies = [
  "itertools 0.9.0",
  "tracing",
  "tracing-core",
- "tracing-subscriber 0.2.25",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -6378,38 +6369,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-serde"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
-dependencies = [
- "serde",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
-dependencies = [
- "ansi_term",
- "chrono",
- "lazy_static",
- "matchers 0.0.1",
- "regex",
- "serde",
- "serde_json",
- "sharded-slab",
- "smallvec",
- "thread_local",
- "tracing",
- "tracing-core",
- "tracing-log",
- "tracing-serde",
-]
-
-[[package]]
 name = "tracing-subscriber"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6417,7 +6376,7 @@ checksum = "9e0ab7bdc962035a87fba73f3acca9b8a8d0034c2e6f60b84aeaaddddc155dce"
 dependencies = [
  "ansi_term",
  "lazy_static",
- "matchers 0.1.0",
+ "matchers",
  "regex",
  "sharded-slab",
  "smallvec",
@@ -6435,7 +6394,7 @@ checksum = "3eb7bda2e93bbc9c5b247034acc6a4b3d04f033a3d4b8fc1cb87d4d1c7c7ebd7"
 dependencies = [
  "lazy_static",
  "tracing-core",
- "tracing-subscriber 0.3.9",
+ "tracing-subscriber",
  "tracing-test-macro",
 ]
 

--- a/address_book/Cargo.toml
+++ b/address_book/Cargo.toml
@@ -31,4 +31,4 @@ hex = "0.4.3"
 rand = "0.8.5"
 dirs = "4.0.0"
 tempdir = "0.3.7"
-tracing-subscriber = { version = "0.3" }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/eqs/Cargo.toml
+++ b/eqs/Cargo.toml
@@ -41,7 +41,7 @@ tide = "0.16.0"
 tide-websockets = "0.4.0"
 toml = "0.5"
 tracing = "0.1.26"
-tracing-subscriber = { version = "0.3" }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
 surf = "2.3.2"

--- a/faucet/Cargo.toml
+++ b/faucet/Cargo.toml
@@ -35,4 +35,4 @@ surf = "2.3.2"
 tempdir = "0.3.7"
 tide = "0.16.0"
 tracing = "0.1.26"
-tracing-subscriber = { version = "0.3" }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/relayer/Cargo.toml
+++ b/relayer/Cargo.toml
@@ -34,7 +34,7 @@ tide = "0.16.0"
 tide-websockets = "0.4.0"
 toml = "0.5"
 tracing = "0.1.26"
-tracing-subscriber = { version = "0.3" }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
 surf = "2.3.2"

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -53,9 +53,9 @@ tide = "0.16.0"
 tide-websockets = "0.4.0"
 toml = "0.5"
 tracing = "0.1.26"
-tracing-distributed = "0.3.1"
+tracing-distributed = "0.4"
 tracing-futures = "0.2"
-tracing-subscriber = { version = "0.3" }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
 ark-serialize = "0.3.0"


### PR DESCRIPTION
So, this one doesn't change anything about the current build.

But it should. It really should.

See, I made a mistake. I added an `EnvFilter` to the tracing-subscriber setup in all of the executable components, and didn't add `features = ["env-filter"]` to the dependency in each `Cargo.toml`.

But it worked. And this didn't make sense.

The tracing-subscriber crate requires `std` (on by default) and `env-filter` to use `EnvFilter`, otherwise it's undefined. I dug into the crate's source and confirmed that this feature flag is being applied correctly. That was fun, because they have the cfg for that inside [macro](https://github.com/tokio-rs/tracing/blob/2974ae973ba4a1f69d12895d33b5a4ecfd0f2b79/tracing-subscriber/src/lib.rs#L203) [evaluations](https://github.com/tokio-rs/tracing/blob/2974ae973ba4a1f69d12895d33b5a4ecfd0f2b79/tracing-subscriber/src/filter/mod.rs#L15).
So I started digging.

What I finally found was an [entry in the wallet's Cargo.toml](https://github.com/EspressoSystems/cape/blob/5c7046e068c0df9a8ee504a5f8d1f4669f583dc9/wallet/Cargo.toml#L62), under `[dev-dependencies]`, one `tracing-test`, which [depends on tracing-subscriber](https://crates.io/crates/tracing-test/0.2.1/dependencies), and enables the feature in question.

As of Rust's 2021 edition, there's a way to make Cargo not allow this kind of accidental feature toggling. The [new field](https://blog.rust-lang.org/2021/03/25/Rust-1.51.0.html#cargos-new-feature-resolver) `resolver = "2"` in the `[workspace]` block (or any relevant `[package]` block) will cause our build to break.

This was an interesting adventure, and I would like to propose that, after this gets merged, we update all targets to `edition = "2021"` and `resolver = "2"`.