### PR TITLE
Use edition "2021" and resolver "2"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 
 members = [
     "address_book",

--- a/address_book/Cargo.toml
+++ b/address_book/Cargo.toml
@@ -2,7 +2,7 @@
 name = "address_book"
 version = "0.0.2"
 authors = ["Espresso Systems <hello@espressosys.com>"]
-edition = "2018"
+edition = "2021"
 description = "Web server that maintains a persistent mapping from user addresses to user public keys"
 license = "GPL-3.0-or-later"
 default-run = "address-book"

--- a/contracts/rust/Cargo.toml
+++ b/contracts/rust/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cap-rust-sandbox"
 version = "0.2.0"
 authors = ["Espresso Systems <hello@espressosys.com>"]
-edition = "2018"
+edition = "2021"
 license = "GPL-3.0-or-later"
 
 [lib]

--- a/doc/workflow/Cargo.toml
+++ b/doc/workflow/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cape-workflow"
 version = "0.2.0"
 authors = ["Espresso Systems <hello@espressosys.com>"]
-edition = "2018"
+edition = "2021"
 license = "GPL-3.0-or-later"
 
 [dependencies]

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,4 +1,4 @@
-edition = "2018"
+edition = "2021"
 reorder_imports = true
 use_try_shorthand = true
 use_field_init_shorthand = true

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cape_wallet"
 version = "0.2.0"
 authors = ["Espresso Systems <hello@espressosys.com>"]
-edition = "2018"
+edition = "2021"
 license = "GPL-3.0-or-later"
 
 [[bin]]


### PR DESCRIPTION
Virtual manifests (workspaces w/o [package] sections) require explicitly
setting `resolver = "2"`.

> If you are using a virtual workspace, you will still need to
> explicitly set the resolver field in the [workspace] definition if you
> want to opt-in to the new resolver.

https://doc.rust-lang.org/edition-guide/rust-2021/default-cargo-resolver.html