### PR TITLE
Fix faucet balance zero in docker

### DIFF
--- a/bin/cape-demo-docker
+++ b/bin/cape-demo-docker
@@ -18,7 +18,40 @@ fi
 
 
 #
-#   1. Set up a geth chain and deploy the contracts. Then shut it down.
+# CAPE configuration
+#
+export CAPE_ADDRESS_BOOK_PORT=50000
+export CAPE_ADDRESS_BOOK_STORE_PATH=$(mktemp -d -t cape-address-book-store-XXXXXXX)
+
+export CAPE_EQS_PORT=50010
+
+export CAPE_RELAYER_PORT=50020
+export CAPE_RELAYER_WALLET_MNEMONIC="$TEST_MNEMONIC"
+
+export CAPE_FAUCET_PORT=50030
+export CAPE_FAUCET_WALLET_MNEMONIC="$TEST_MNEMONIC"
+export CAPE_FAUCET_MANAGER_MNEMONIC="$TEST_MNEMONIC"
+
+export CAPE_WALLET_PORT=50040
+
+# Create a faucet wallet and export variables printed to stdout
+export CAPE_FAUCET_WALLET_PATH="$(mktemp -d -t cape-faucet-wallet-XXXXXXX)"
+export CAPE_EQS_STORE_PATH="$(mktemp -d -t cape-eqs-store-path-XXXXXXX)"
+set -a; source <(cargo run --release --bin faucet-wallet-test-setup); set +a;
+
+# Clean up temporary directories when script exits.
+# TODO clean up files owned by root after mounting into docker.
+trap "exit" INT TERM
+trap cleanup EXIT
+cleanup(){
+    rmdir "$CAPE_FAUCET_WALLET_PATH"
+    rmdir "$CAPE_EQS_STORE_PATH"
+    rmdir "$CAPE_ADDRESS_BOOK_STORE_PATH"
+    rmdir "$GETH_DATA_DIR"
+}
+
+#
+# Set up a geth chain and deploy the contracts. Then shut it down.
 #
 GETH_DATA_DIR="$(mktemp -d -t "cap-ethereum-data-XXXXXXXX")"
 echo "Using keystore dir $GETH_DATA_DIR"
@@ -49,53 +82,26 @@ geth --http --dev --verbosity 1 \
      --datadir $GETH_DATA_DIR --unlock $ADDRESS_LIST &
 geth_pid=$!
 
-# Deploy contracts
+# Deploy contracts (this requires the address/key exported with the
+# faucet-wallet-test-setup binary)
 hardhat deploy --reset
 
 # Stop the geth node
 echo "Sending HUP signal to geth: PID $geth_pid"
 kill -HUP $geth_pid
 
-#
-# 2. CAPE configuration
-#
-export CAPE_ADDRESS_BOOK_PORT=50000
-export CAPE_ADDRESS_BOOK_STORE_PATH=$(mktemp -d -t cape-address-book-store-XXXXXXX)
-
-export CAPE_EQS_PORT=50010
-
-export CAPE_RELAYER_PORT=50020
-export CAPE_RELAYER_WALLET_MNEMONIC="$TEST_MNEMONIC"
-
-export CAPE_FAUCET_PORT=50030
-export CAPE_FAUCET_WALLET_MNEMONIC="$TEST_MNEMONIC"
-
-export CAPE_WALLET_PORT=50040
-
-# Create a faucet wallet and export variables printed to stdout
-export CAPE_FAUCET_WALLET_PATH="$(mktemp -d -t cape-faucet-wallet-XXXXXXX)"
-export CAPE_EQS_STORE_PATH="$(mktemp -d -t cape-eqs-store-path-XXXXXXX)"
-set -a; source <(cargo run --release --bin faucet-wallet-test-setup); set +a;
-
-# Clean up temporary directories when script exits.
-# TODO clean up files owned by root after mounting into docker.
-trap "exit" INT TERM
-trap cleanup EXIT
-cleanup(){
-    rmdir "$CAPE_FAUCET_WALLET_PATH"
-    rmdir "$CAPE_EQS_STORE_PATH"
-    rmdir "$CAPE_ADDRESS_BOOK_STORE_PATH"
-    rmdir "$GETH_DATA_DIR"
-}
-
-# Configure environment
+# Configure contract addresses
 export CAPE_TOKEN_ADDRESS="$(cat contracts/deployments/localhost/SimpleToken.json | jq -r .address)"
 export CAPE_CONTRACT_ADDRESS="$(cat contracts/deployments/localhost//CAPE.json | jq -r .address)"
 
+#
+# Export configuration
+#
+
+# Export the configuration *not* handled by docker compose for the docker compose demo.
 mkdir -p demo
 COMPOSE_ENV_FILE=demo/compose.env
 
-# Export the configuration *not* handled by docker compose for the docker compose demo.
 # Use a temp file to make sure the final file is complete once it exists.
 TMP_FILE="$(mktemp -t cape-tmp-env-XXXXXXX)"
 set | grep "CAPE_CONTRACT_ADDRESS.*=" | sort >> "$TMP_FILE"
@@ -113,10 +119,12 @@ echo "CAPE demo geth setup completed!"
 echo
 
 #
-# 3. Start the docker containers
+# Start the docker containers
 #
 
-docker compose --env-file demo/compose.env pull
+if [ -z "${CAPE_SERVICES_IMAGE:-}" ] && [ -z "${CAPE_WALLET_IMAGE:-}" ]; then
+    docker compose --env-file demo/compose.env pull
+fi
 docker compose --env-file demo/compose.env up
 
 wait

--- a/bin/cape-demo-docker
+++ b/bin/cape-demo-docker
@@ -87,8 +87,8 @@ geth_pid=$!
 hardhat deploy --reset
 
 # Stop the geth node
-echo "Sending HUP signal to geth: PID $geth_pid"
-kill -HUP $geth_pid
+echo "Sending TERM signal to geth: PID $geth_pid"
+kill -TERM $geth_pid
 
 # Configure contract addresses
 export CAPE_TOKEN_ADDRESS="$(cat contracts/deployments/localhost/SimpleToken.json | jq -r .address)"

--- a/bin/cape-demo-docker
+++ b/bin/cape-demo-docker
@@ -122,6 +122,7 @@ echo
 # Start the docker containers
 #
 
+# If we are *not* using local docker images, make sure we pull the latest images.
 if [ -z "${CAPE_SERVICES_IMAGE:-}" ] && [ -z "${CAPE_WALLET_IMAGE:-}" ]; then
     docker compose --env-file demo/compose.env pull
 fi

--- a/bin/cape-demo-docker
+++ b/bin/cape-demo-docker
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-function rmdir() {
+function remove-directory () {
     if [ -n "$1" ] && [ -d "$1" ]; then
         echo "Removing dir $1"
-        rm -rf "$1"
+        # Diretories were mounted into docker and files may be owned by root.
+        # Mount to /mnt inside docker and remove all regular and hidden files.
+        docker run --volume "$1":/mnt -it bash -c "rm -rf /mnt/{*,.[^.],.??*}"
+        rmdir $1
     fi
 }
 
@@ -24,30 +27,29 @@ export CAPE_ADDRESS_BOOK_PORT=50000
 export CAPE_ADDRESS_BOOK_STORE_PATH=$(mktemp -d -t cape-address-book-store-XXXXXXX)
 
 export CAPE_EQS_PORT=50010
+export CAPE_EQS_STORE_PATH="$(mktemp -d -t cape-eqs-store-path-XXXXXXX)"
 
 export CAPE_RELAYER_PORT=50020
 export CAPE_RELAYER_WALLET_MNEMONIC="$TEST_MNEMONIC"
 
 export CAPE_FAUCET_PORT=50030
 export CAPE_FAUCET_WALLET_MNEMONIC="$TEST_MNEMONIC"
-export CAPE_FAUCET_MANAGER_MNEMONIC="$TEST_MNEMONIC"
+export CAPE_FAUCET_WALLET_PATH="$(mktemp -d -t cape-faucet-wallet-XXXXXXX)"
 
 export CAPE_WALLET_PORT=50040
 
-# Create a faucet wallet and export variables printed to stdout
-export CAPE_FAUCET_WALLET_PATH="$(mktemp -d -t cape-faucet-wallet-XXXXXXX)"
-export CAPE_EQS_STORE_PATH="$(mktemp -d -t cape-eqs-store-path-XXXXXXX)"
+# Create a faucet manager wallet and export variables printed to stdout
+export CAPE_FAUCET_MANAGER_MNEMONIC="$TEST_MNEMONIC"
 set -a; source <(cargo run --release --bin faucet-wallet-test-setup); set +a;
 
 # Clean up temporary directories when script exits.
-# TODO clean up files owned by root after mounting into docker.
 trap "exit" INT TERM
 trap cleanup EXIT
 cleanup(){
-    rmdir "$CAPE_FAUCET_WALLET_PATH"
-    rmdir "$CAPE_EQS_STORE_PATH"
-    rmdir "$CAPE_ADDRESS_BOOK_STORE_PATH"
-    rmdir "$GETH_DATA_DIR"
+    remove-directory "$CAPE_FAUCET_WALLET_PATH"
+    remove-directory "$CAPE_EQS_STORE_PATH"
+    remove-directory "$CAPE_ADDRESS_BOOK_STORE_PATH"
+    remove-directory "$GETH_DATA_DIR"
 }
 
 #

--- a/bin/cape-demo-local
+++ b/bin/cape-demo-local
@@ -36,6 +36,7 @@ export CAPE_ADDRESS_BOOK_STORE_PATH=$(mktemp -d -t cape-address-book-store-XXXXX
 export CAPE_ADDRESS_BOOK_URL="http://localhost:$CAPE_ADDRESS_BOOK_PORT"
 
 export CAPE_EQS_PORT=50010
+export CAPE_EQS_STORE_PATH="$(mktemp -d -t caep-eqs-store-path-XXXXXXX)"
 export CAPE_EQS_URL="http://localhost:$CAPE_EQS_PORT"
 
 export CAPE_RELAYER_PORT=50020
@@ -45,12 +46,12 @@ export CAPE_RELAYER_WALLET_MNEMONIC="$TEST_MNEMONIC"
 export CAPE_FAUCET_PORT=50030
 export CAPE_FAUCET_URL="http://localhost:$CAPE_FAUCET_PORT"
 export CAPE_FAUCET_WALLET_MNEMONIC="$TEST_MNEMONIC"
+export CAPE_FAUCET_WALLET_PATH="$(mktemp -d -t cape-faucet-wallet-XXXXXXX)"
 
 export CAPE_WALLET_PORT=50040
 
 # Create a faucet wallet and export variables printed to stdout
-export CAPE_FAUCET_WALLET_PATH="$(mktemp -d -t cape-faucet-wallet-XXXXXXX)"
-export CAPE_EQS_STORE_PATH="$(mktemp -d -t caep-eqs-store-path-XXXXXXX)"
+export CAPE_FAUCET_MANAGER_MNEMONIC="$TEST_MNEMONIC"
 set -a; source <(target/release/faucet-wallet-test-setup); set +a;
 
 # Start a go-ethereum/geth node

--- a/bin/cape-demo-local
+++ b/bin/cape-demo-local
@@ -9,7 +9,7 @@ if nc -z localhost $GETH_PORT 2>&1; then
     exit 1
 fi
 
-function rmdir() {
+function remove-directory() {
     if [ -n "$1" ] && [ -d "$1" ]; then
         echo "Removing dir $1"
         rm -r "$1"
@@ -20,9 +20,9 @@ function rmdir() {
 trap "exit" INT TERM
 trap cleanup EXIT
 cleanup(){
-    rmdir "$CAPE_FAUCET_WALLET_PATH"
-    rmdir "$CAPE_EQS_STORE_PATH"
-    rmdir "$CAPE_ADDRESS_BOOK_STORE_PATH"
+    remove-directory "$CAPE_FAUCET_WALLET_PATH"
+    remove-directory "$CAPE_EQS_STORE_PATH"
+    remove-directory "$CAPE_ADDRESS_BOOK_STORE_PATH"
 }
 
 # Build all the rust executables
@@ -36,7 +36,7 @@ export CAPE_ADDRESS_BOOK_STORE_PATH=$(mktemp -d -t cape-address-book-store-XXXXX
 export CAPE_ADDRESS_BOOK_URL="http://localhost:$CAPE_ADDRESS_BOOK_PORT"
 
 export CAPE_EQS_PORT=50010
-export CAPE_EQS_STORE_PATH="$(mktemp -d -t caep-eqs-store-path-XXXXXXX)"
+export CAPE_EQS_STORE_PATH="$(mktemp -d -t cape-eqs-store-path-XXXXXXX)"
 export CAPE_EQS_URL="http://localhost:$CAPE_EQS_PORT"
 
 export CAPE_RELAYER_PORT=50020
@@ -50,7 +50,7 @@ export CAPE_FAUCET_WALLET_PATH="$(mktemp -d -t cape-faucet-wallet-XXXXXXX)"
 
 export CAPE_WALLET_PORT=50040
 
-# Create a faucet wallet and export variables printed to stdout
+# Create a faucet manager wallet and export variables printed to stdout
 export CAPE_FAUCET_MANAGER_MNEMONIC="$TEST_MNEMONIC"
 set -a; source <(target/release/faucet-wallet-test-setup); set +a;
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,27 +22,32 @@ services:
       - CAPE_RELAYER_URL=http://relayer:$CAPE_RELAYER_PORT
       - CAPE_WALLET_PORT=$CAPE_WALLET_PORT
       - CAPE_WEB3_PROVIDER_URL=http://geth:8545
+      - RUST_BACKTRACE=1
+      - RUST_LOG=info
     depends_on:
       - geth
 
   relayer:
     image: ${CAPE_SERVICES_IMAGE:-ghcr.io/espressosystems/cape/services:main}
-    expose:
-      - $CAPE_RELAYER_PORT
-    command: /app/relayer/minimal-relayer
+    ports:
+      - $CAPE_RELAYER_PORT:$CAPE_RELAYER_PORT
+    # Relayer panics if it can't connect to geth on startup.
+    command: sh -c "sleep 2 && /app/relayer/minimal-relayer"
     environment:
       - CAPE_CONTRACT_ADDRESS=$CAPE_CONTRACT_ADDRESS
       - CAPE_EQS_URL=http://eqs:$CAPE_RELAYER_PORT
       - CAPE_RELAYER_PORT=$CAPE_RELAYER_PORT
       - CAPE_RELAYER_WALLET_MNEMONIC=$CAPE_RELAYER_WALLET_MNEMONIC
       - CAPE_WEB3_PROVIDER_URL=http://geth:8545
+      - RUST_BACKTRACE=1
+      - RUST_LOG=info
     depends_on:
       - geth
 
   eqs:
     image: ${CAPE_SERVICES_IMAGE:-ghcr.io/espressosystems/cape/services:main}
-    expose:
-      - $CAPE_EQS_PORT
+    ports:
+      - $CAPE_EQS_PORT:$CAPE_EQS_PORT
     command: /app/eqs/eqs
     working_dir: /app/eqs
     volumes:
@@ -52,15 +57,17 @@ services:
       - CAPE_EQS_PORT=$CAPE_EQS_PORT
       - CAPE_EQS_STORE_PATH=/mnt/eqs
       - CAPE_WEB3_PROVIDER_URL=http://geth:8545
+      - RUST_BACKTRACE=1
+      - RUST_LOG=info
     depends_on:
       - geth
 
   faucet:
     image: ${CAPE_SERVICES_IMAGE:-ghcr.io/espressosystems/cape/services:main}
-    expose:
-      - $CAPE_FAUCET_PORT
+    ports:
+      - $CAPE_FAUCET_PORT:$CAPE_FAUCET_PORT
     # Faucet panics if it can't connect to EQS on startup.
-    command: bash -c "sleep 2 && /app/faucet/faucet"
+    command: sh -c "sleep 2 && /app/faucet/faucet"
     volumes:
       - $CAPE_FAUCET_WALLET_PATH:/mnt/faucet
     environment:
@@ -72,13 +79,15 @@ services:
       - CAPE_FAUCET_WALLET_PATH=/mnt/faucet
       - CAPE_RELAYER_URL=http://relayer:$CAPE_RELAYER_PORT
       - CAPE_WEB3_PROVIDER_URL=http://geth:8545
+      - RUST_BACKTRACE=1
+      - RUST_LOG=info
     depends_on:
       - geth
 
   address-book:
     image: ${CAPE_SERVICES_IMAGE:-ghcr.io/espressosystems/cape/services:main}
-    expose:
-      - $CAPE_ADDRESS_BOOK_PORT
+    ports:
+      - $CAPE_ADDRESS_BOOK_PORT:$CAPE_ADDRESS_BOOK_PORT
     command: /app/address-book/address-book
     volumes:
       - $CAPE_ADDRESS_BOOK_STORE_PATH:/mnt/address-book
@@ -86,6 +95,8 @@ services:
     environment:
       - CAPE_ADDRESS_BOOK_PORT=$CAPE_ADDRESS_BOOK_PORT
       - CAPE_ADDRESS_BOOK_STORE_PATH=/mnt/address-book
+      - RUST_BACKTRACE=1
+      - RUST_LOG=info
 
   geth:
     image: ethereum/client-go:v1.10.15

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,8 +66,7 @@ services:
     image: ${CAPE_SERVICES_IMAGE:-ghcr.io/espressosystems/cape/services:main}
     ports:
       - $CAPE_FAUCET_PORT:$CAPE_FAUCET_PORT
-    # Faucet panics if it can't connect to EQS on startup.
-    command: sh -c "sleep 2 && /app/faucet/faucet"
+    command: /app/faucet/faucet
     volumes:
       - $CAPE_FAUCET_WALLET_PATH:/mnt/faucet
     environment:

--- a/faucet/src/faucet_wallet_test_setup.rs
+++ b/faucet/src/faucet_wallet_test_setup.rs
@@ -14,7 +14,7 @@ pub fn u256_to_hex(n: U256) -> String {
 )]
 pub struct Options {
     /// mnemonic for the faucet wallet
-    #[structopt(long, env = "CAPE_FAUCET_WALLET_MNEMONIC")]
+    #[structopt(long, env = "CAPE_FAUCET_MANAGER_MNEMONIC")]
     pub mnemonic: String,
 }
 
@@ -31,6 +31,9 @@ async fn main() -> Result<(), std::io::Error> {
         .derive_sub_tree("user".as_bytes())
         .derive_user_key_pair(&0u64.to_le_bytes())
         .pub_key();
+
+    eprintln!("Encryption key: {}", pub_key);
+    eprintln!("Address: {}", net::UserAddress(pub_key.address()));
 
     let enc_key_bytes: [u8; 32] = pub_key.enc_key().into();
     let address: EdOnBN254Point = pub_key.address().into();

--- a/faucet/src/faucet_wallet_test_setup.rs
+++ b/faucet/src/faucet_wallet_test_setup.rs
@@ -32,8 +32,11 @@ async fn main() -> Result<(), std::io::Error> {
         .derive_user_key_pair(&0u64.to_le_bytes())
         .pub_key();
 
-    eprintln!("Encryption key: {}", pub_key);
-    eprintln!("Address: {}", net::UserAddress(pub_key.address()));
+    eprintln!("Faucet manager encryption key: {}", pub_key);
+    eprintln!(
+        "Faucet manager address: {}",
+        net::UserAddress(pub_key.address())
+    );
 
     let enc_key_bytes: [u8; 32] = pub_key.enc_key().into();
     let address: EdOnBN254Point = pub_key.address().into();


### PR DESCRIPTION
The problem was caused by using SIGHUP to kill geth instead of SIGTERM.

- Distinguish faucet wallet and faucet manager wallet.
- Cleanup directories mounted into docker.
- Use `CAPE_FAUCET_MANAGER_MNEMONIC` instead of `CAPE_FAUCET_WALLET_MNEMONIC` in the contract deployment setup helper `faucet-wallet-test-setup`.
- Make docker services available on host to allow running the random wallet test from the host.

Close #826 