### PR TITLE
Add cargo sort pre-commit hook

### DIFF
--- a/bin/lint-fix
+++ b/bin/lint-fix
@@ -3,4 +3,5 @@ set -euo pipefail
 
 (cd $CONTRACTS_DIR && solhint --fix 'contracts/**/*.sol')
 treefmt
+cargo sort -w
 cargo-clippy --fix --workspace -- -D warnings

--- a/contracts/rust/Cargo.toml
+++ b/contracts/rust/Cargo.toml
@@ -26,7 +26,6 @@ bincode = "1.3.3"
 commit = { git = "https://github.com/EspressoSystems/commit.git", tag = "0.1.0" }
 espresso-macros = { git = "https://github.com/EspressoSystems/espresso-macros.git" }
 
-
 # We need the legacy feature in order to avoid gas estimation issues. See https://github.com/gakonst/ethers-rs/issues/825
 ethers = { features = ["legacy"], git = "https://github.com/gakonst/ethers-rs", branch = "master" }
 ethers-contract = { features = ["legacy"], git = "https://github.com/gakonst/ethers-rs", branch = "master" }

--- a/flake.nix
+++ b/flake.nix
@@ -54,6 +54,12 @@
               files = "\\.rs$";
               pass_filenames = false;
             };
+            cargo-sort = {
+              enable = true;
+              description = "Ensure Cargo.toml are sorted";
+              entry = "cargo sort -w";
+              pass_filenames = false;
+            };
           };
         };
       };


### PR DESCRIPTION
The check on the CI will fail if `cargo sort -w` changes any files.

The behaviour is somewhat different from `--check`. Running `cargo sort
-w -c` on the code base passed but `cargo sort -w` removed an empty line
in `contracts/rust/Cargo.toml`.