### PR TITLE
Store named keystores using base64-encoded file names.

### DIFF
--- a/wallet/src/ui.rs
+++ b/wallet/src/ui.rs
@@ -29,7 +29,9 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt::{self, Display, Formatter};
 use std::io::Cursor;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
+use tagged_base64::TaggedBase64;
 
 /// UI-friendly asset definition.
 #[ser_test(ark(false))]
@@ -459,6 +461,40 @@ impl TransactionHistoryEntry {
                 None => "unknown".to_string(),
             },
         }
+    }
+}
+
+#[ser_test(ark(false))]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct KeyStoreLocation {
+    pub path: PathBuf,
+    pub name: Option<String>,
+}
+
+impl From<PathBuf> for KeyStoreLocation {
+    fn from(path: PathBuf) -> Self {
+        // Decode the name from TaggedBase64; if it fails to decode or has the wrong tag, then this
+        // is not a named keystore file.
+        let name = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .and_then(|name| TaggedBase64::parse(name).ok())
+            .and_then(|tb64| {
+                if tb64.tag() == "KEYSTORE" {
+                    std::str::from_utf8(&tb64.value())
+                        .ok()
+                        .map(|s| s.to_owned())
+                } else {
+                    None
+                }
+            });
+        Self { path, name }
+    }
+}
+
+impl From<&Path> for KeyStoreLocation {
+    fn from(path: &Path) -> Self {
+        path.to_owned().into()
     }
 }
 

--- a/wallet/src/ui.rs
+++ b/wallet/src/ui.rs
@@ -465,7 +465,7 @@ impl TransactionHistoryEntry {
 }
 
 #[ser_test(ark(false))]
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct KeyStoreLocation {
     pub path: PathBuf,
     pub name: Option<String>,

--- a/wallet/src/wallet-api/routes.rs
+++ b/wallet/src/wallet-api/routes.rs
@@ -618,7 +618,10 @@ async fn listkeystores(options: &NodeOpt) -> Result<Vec<String>, tide::Error> {
     let mut entries = read_dir(options.keystores_dir()).await?;
     let mut keystores = vec![];
     while let Some(entry) = entries.next().await {
-        keystores.push(entry?.file_name().to_str().unwrap().to_owned());
+        let path: PathBuf = entry?.path().into();
+        if let Some(name) = KeyStoreLocation::from(path).name {
+            keystores.push(name);
+        }
     }
     Ok(keystores)
 }
@@ -1017,8 +1020,8 @@ pub async fn get_records(wallet: &mut Option<Wallet>) -> Result<Vec<RecordInfo>,
     Ok(wallet.records().await.collect::<Vec<_>>())
 }
 
-pub async fn get_last_keystore(options: &NodeOpt) -> Result<Option<PathBuf>, tide::Error> {
-    Ok(read_last_path(options).await?)
+pub async fn get_last_keystore(options: &NodeOpt) -> Result<Option<KeyStoreLocation>, tide::Error> {
+    Ok(read_last_path(options).await?.map(KeyStoreLocation::from))
 }
 
 async fn getaccount(

--- a/wallet/src/wallet-api/web.rs
+++ b/wallet/src/wallet-api/web.rs
@@ -29,6 +29,7 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::time::Duration;
 use structopt::StructOpt;
+use tagged_base64::TaggedBase64;
 use tide::{
     http::{headers::HeaderValue, Method, Url},
     security::{CorsMiddleware, Origin},
@@ -178,7 +179,10 @@ impl NodeOpt {
     }
 
     pub fn keystore_path(&self, name: &str) -> PathBuf {
-        [self.keystores_dir().as_path(), Path::new(name)]
+        // base64-encode the name to remove characters with special meaning in the file system, like
+        // slashes.
+        let enc = TaggedBase64::new("KEYSTORE", name.as_bytes()).unwrap();
+        [self.keystores_dir().as_path(), Path::new(&enc.to_string())]
             .iter()
             .collect()
     }


### PR DESCRIPTION
This allows special characters like slashes to be included in
keystore names without being interpreted by the file system.

This change also refactors `lastusedkeystore` to return both the
path and, if applicable, the keystore name, since the name can no
longer be read directly from the file path.

Closes #835 