### PR TITLE
Certificates not found in docker container

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,22 @@
     }:
     flake-utils.lib.eachDefaultSystem (system:
     let
-      overlays = [ (import rust-overlay) ];
+      overlays = [
+        (import rust-overlay)
+        (final: prev:
+          let
+            runInLinuxVMNoKVM = drv:
+              final.lib.overrideDerivation (final.vmTools.runInLinuxVM drv)
+                (_: { requiredSystemFeatures = [ ]; });
+            modifiedVmTools = prev.vmTools // {
+              runInLinuxVM = runInLinuxVMNoKVM;
+            };
+          in
+          {
+            dockerTools =
+              prev.dockerTools.override { vmTools = modifiedVmTools; };
+          })
+      ];
       pkgs = import nixpkgs {
         inherit system overlays;
       };

--- a/flake.nix
+++ b/flake.nix
@@ -71,7 +71,12 @@
           curl
           coreutils
           bashInteractive
+          cacert
         ];
+        runAsRoot = ''
+          mkdir -p /etc/ssl/certs
+          cp ${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt /etc/ssl/certs/ca-certificates.crt
+        '';
       };
       devShell =
         let


### PR DESCRIPTION
Create /etc/ssl/certs/ca-certificates.crt

cc @DieracDelta @nmccarty in case you have an idea why `/etc/ssl/certs/ca-certificates.crt` would be missing in the docker container (even if `cacert` added).

edit; Why it's there on nixos: https://github.com/NixOS/nixpkgs/blob/9a813114b916d3abffd60b86a91ea707d98011cd/nixos/modules/security/ca.nix#L76