### PR TITLE
Retry queries for changes in token balance

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,4 +558,10 @@ Run [smoke-test-goerli](./bin/smoke-test-goerli) with a custom mnemonic (here `T
 env MY_FAUCET_MANAGER_MNEMONIC="$TEST_MNEMONIC" smoke-test-goerli
 ```
 
-If you get a `replacement fee too low` error, re-run the command.
+If you get a `replacement fee too low` error, re-run the command up to 2 to 3 times.
+
+To start from scratch and ignore existing deployments pass `--reset`:
+
+```console
+env MY_FAUCET_MANGER_MNEMONIC="$TEST_MNEMONIC" smoke-test-goerli --reset
+```

--- a/README.md
+++ b/README.md
@@ -563,5 +563,5 @@ If you get a `replacement fee too low` error, re-run the command up to 2 to 3 ti
 To start from scratch and ignore existing deployments pass `--reset`:
 
 ```console
-env MY_FAUCET_MANGER_MNEMONIC="$TEST_MNEMONIC" smoke-test-goerli --reset
+env MY_FAUCET_MANAGER_MNEMONIC="$TEST_MNEMONIC" smoke-test-goerli --reset
 ```

--- a/bin/smoke-test-goerli
+++ b/bin/smoke-test-goerli
@@ -8,7 +8,7 @@ echo "Exporting key for mnemonic"
 source <(cargo run --bin faucet-wallet-test-setup -- --mnemonic "$MNEMONIC")
 
 echo "Deploying contracts"
-hardhat deploy --network goerli
+hardhat deploy --network goerli "$@"
 
 echo "Running smoke test"
 export CAPE_CONTRACT_ADDRESS=$(cat contracts/deployments/goerli/CAPE.json | jq -r .address)


### PR DESCRIPTION
- Add `--reset` option to smoke test script.