### PR TITLE
Change transaction status to "accepted" from "unknown" for received transactions

### DIFF
--- a/wallet/src/ui.rs
+++ b/wallet/src/ui.rs
@@ -458,7 +458,7 @@ impl TransactionHistoryEntry {
                     Ok(status) => status.to_string(),
                     Err(_) => "unknown".to_string(),
                 },
-                None => "unknown".to_string(),
+                None => "accepted".to_string(),
             },
         }
     }

--- a/wallet/src/wallet-api/main.rs
+++ b/wallet/src/wallet-api/main.rs
@@ -1503,6 +1503,11 @@ mod tests {
             .get::<Vec<TransactionHistoryEntry>>("transactionhistory")
             .await
             .unwrap();
+
+        // At this point everything should be accepted, even the received transactions.
+        for h in &history {
+            assert_eq!(h.status, "accepted");
+        }
         // We just made 2 transfers, there may be more from populatefortest.
         assert!(history.len() >= 2);
         let history = history[history.len() - 2..].to_vec();


### PR DESCRIPTION
Recievers don't have a receipt but if they go the transaction we know it's
accepted.