### PR TITLE
Add Map from asset code to asset info when returning balances

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1085,7 +1085,7 @@ dependencies = [
  "async-trait",
  "bincode",
  "commit",
- "espresso-macros 0.1.0 (git+https://github.com/EspressoSystems/espresso-macros.git)",
+ "espresso-macros 0.1.0 (git+https://github.com/EspressoSystems/espresso-macros)",
  "ethers",
  "ethers-contract",
  "ethers-contract-abigen",
@@ -1148,7 +1148,7 @@ dependencies = [
  "commit",
  "eqs",
  "escargot",
- "espresso-macros 0.1.0 (git+https://github.com/EspressoSystems/espresso-macros.git)",
+ "espresso-macros 0.1.0 (git+https://github.com/EspressoSystems/espresso-macros)",
  "ethers",
  "futures",
  "futures-util",
@@ -2148,7 +2148,7 @@ dependencies = [
 [[package]]
 name = "espresso-macros"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/espresso-macros.git#9e0b0258c99757c567676c4dd92f1501db0cf580"
+source = "git+https://github.com/EspressoSystems/espresso-macros#9e0b0258c99757c567676c4dd92f1501db0cf580"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5058,7 +5058,7 @@ dependencies = [
  "chrono",
  "commit",
  "derivative",
- "espresso-macros 0.1.0 (git+https://github.com/EspressoSystems/espresso-macros.git)",
+ "espresso-macros 0.1.0 (git+https://github.com/EspressoSystems/espresso-macros)",
  "futures",
  "generic-array 0.14.5",
  "hmac 0.11.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1085,7 +1085,7 @@ dependencies = [
  "async-trait",
  "bincode",
  "commit",
- "espresso-macros 0.1.0 (git+https://github.com/EspressoSystems/espresso-macros)",
+ "espresso-macros 0.1.0 (git+https://github.com/EspressoSystems/espresso-macros.git)",
  "ethers",
  "ethers-contract",
  "ethers-contract-abigen",
@@ -1148,7 +1148,7 @@ dependencies = [
  "commit",
  "eqs",
  "escargot",
- "espresso-macros 0.1.0 (git+https://github.com/EspressoSystems/espresso-macros)",
+ "espresso-macros 0.1.0 (git+https://github.com/EspressoSystems/espresso-macros.git)",
  "ethers",
  "futures",
  "futures-util",
@@ -2148,7 +2148,7 @@ dependencies = [
 [[package]]
 name = "espresso-macros"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/espresso-macros#9e0b0258c99757c567676c4dd92f1501db0cf580"
+source = "git+https://github.com/EspressoSystems/espresso-macros.git#9e0b0258c99757c567676c4dd92f1501db0cf580"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5058,7 +5058,7 @@ dependencies = [
  "chrono",
  "commit",
  "derivative",
- "espresso-macros 0.1.0 (git+https://github.com/EspressoSystems/espresso-macros)",
+ "espresso-macros 0.1.0 (git+https://github.com/EspressoSystems/espresso-macros.git)",
  "futures",
  "generic-array 0.14.5",
  "hmac 0.11.0",

--- a/wallet/src/ui.rs
+++ b/wallet/src/ui.rs
@@ -313,14 +313,19 @@ pub enum PrivateKey {
     Freezing(FreezerKeyPair),
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum BalanceInfo {
     /// The balance of a single asset, in a single account.
     Balance(u64),
     /// All the balances of an account, by asset type.
-    AccountBalances(HashMap<AssetCode, u64>),
+    AccountBalances((HashMap<AssetCode, u64>, HashMap<AssetCode, AssetInfo>)),
     /// All the balances of all accounts owned by the wallet.
-    AllBalances(HashMap<UserAddress, HashMap<AssetCode, u64>>),
+    AllBalances(
+        (
+            HashMap<UserAddress, HashMap<AssetCode, u64>>,
+            HashMap<AssetCode, AssetInfo>,
+        ),
+    ),
 }
 
 #[ser_test(ark(false))]

--- a/wallet/src/ui.rs
+++ b/wallet/src/ui.rs
@@ -317,15 +317,10 @@ pub enum PrivateKey {
 pub enum BalanceInfo {
     /// The balance of a single asset, in a single account.
     Balance(u64),
-    /// All the balances of an account, by asset type.
-    AccountBalances((HashMap<AssetCode, u64>, HashMap<AssetCode, AssetInfo>)),
+    /// All the balances of an account, by asset type with asset info.
+    AccountBalances(HashMap<AssetCode, (u64, AssetInfo)>),
     /// All the balances of all accounts owned by the wallet.
-    AllBalances(
-        (
-            HashMap<UserAddress, HashMap<AssetCode, u64>>,
-            HashMap<AssetCode, AssetInfo>,
-        ),
-    ),
+    AllBalances(HashMap<UserAddress, HashMap<AssetCode, (u64, AssetInfo)>>),
 }
 
 #[ser_test(ark(false))]

--- a/wallet/src/wallet-api/main.rs
+++ b/wallet/src/wallet-api/main.rs
@@ -556,7 +556,7 @@ mod tests {
         // because we haven't added any keys or received any records.
         assert_eq!(
             server.get::<BalanceInfo>("getbalance/all").await.unwrap(),
-            BalanceInfo::AllBalances((HashMap::default(), HashMap::default()))
+            BalanceInfo::AllBalances(HashMap::default())
         );
         let assets = server.get::<WalletSummary>("getinfo").await.unwrap().assets;
         assert_eq!(
@@ -572,10 +572,9 @@ mod tests {
             // an empty map or an error.
             // let mut native_info = AssetInfo::default;
             // native_info.mint_info = Some("native")
-            BalanceInfo::AccountBalances((
-                once((AssetCode::native(), 0)).collect(),
-                once((AssetCode::native(), assets[0].clone())).collect()
-            ))
+            BalanceInfo::AccountBalances(
+                once((AssetCode::native(), (0, assets[0].clone()))).collect()
+            )
         );
         assert_eq!(
             server

--- a/wallet/src/wallet-api/main.rs
+++ b/wallet/src/wallet-api/main.rs
@@ -556,8 +556,9 @@ mod tests {
         // because we haven't added any keys or received any records.
         assert_eq!(
             server.get::<BalanceInfo>("getbalance/all").await.unwrap(),
-            BalanceInfo::AllBalances(HashMap::default())
+            BalanceInfo::AllBalances((HashMap::default(), HashMap::default()))
         );
+        let assets = server.get::<WalletSummary>("getinfo").await.unwrap().assets;
         assert_eq!(
             server
                 .get::<BalanceInfo>(&format!("getbalance/address/{}", addr))
@@ -569,7 +570,12 @@ mod tests {
             // find none, and return a balance of 0 for that asset type. Since the wallet always
             // knows about the native asset type, this will actually return some data, rather than
             // an empty map or an error.
-            BalanceInfo::AccountBalances(once((AssetCode::native(), 0)).collect())
+            // let mut native_info = AssetInfo::default;
+            // native_info.mint_info = Some("native")
+            BalanceInfo::AccountBalances((
+                once((AssetCode::native(), 0)).collect(),
+                once((AssetCode::native(), assets[0].clone())).collect()
+            ))
         );
         assert_eq!(
             server


### PR DESCRIPTION
Return a map of the known assets along with the balances.  This will make the UI a bit more efficient by not having to call `getinfo` to get the asset info after it calls `getbalance`

Cloeses: https://github.com/EspressoSystems/cape/issues/892