### PR TITLE
Add option to include pending txn count in nonce

### DIFF
--- a/contracts/rust/src/cape/events.rs
+++ b/contracts/rust/src/cape/events.rs
@@ -17,6 +17,7 @@ mod tests {
         types::{GenericInto, MerkleRootSol},
     };
     use anyhow::Result;
+    use ethers::prelude::BlockNumber;
     use itertools::Itertools;
     use jf_cap::KeyPair;
     use jf_cap::{
@@ -75,9 +76,13 @@ mod tests {
 
         let block_with_memos = BlockWithMemos::new(cape_block.clone(), memos_with_sigs.clone());
 
-        submit_cape_block_with_memos(&connection.contract, block_with_memos.clone())
-            .await?
-            .await?;
+        submit_cape_block_with_memos(
+            &connection.contract,
+            block_with_memos.clone(),
+            BlockNumber::Latest,
+        )
+        .await?
+        .await?;
 
         // A connection with a random wallet (for queries only)
         let query_connection = EthConnection::from_config_for_query(

--- a/contracts/rust/src/cape/submit_block.rs
+++ b/contracts/rust/src/cape/submit_block.rs
@@ -58,16 +58,27 @@ pub async fn submit_cape_block_with_memos(
     //  `contract.submit_cape_block_with_memos(...).send().await`.
     //
     //  We must manually call `fill_transaction` in order pass a `BlockNumber`.
-    //  The value is passed to `eth_getTransactionCount` to calculate the nonce.
+    //  `BlockNumber` can be an integer block number or "latest", "earliest" or
+    //  "pending". The value is passed to `eth_getTransactionCount` and the
+    //  return value of that call is used as the nonce of the Ethereum
+    //  transaction.
     //
-    //  For `BlockNumber::Latest` the nonce is calculated based on the last
-    //  mined block. This is also the default behaviour of `CotractCall.send`.
+    //  See https://eth.wiki/json-rpc/API#eth_gettransactioncount for details
+    //  about the Ethereum RPC endpoint.
     //
-    //  For `BlockNumber::Pending` pending transactions will be included. This
-    //  allow to submit new transactions before the previous one is mined and
-    //  therefore enables the relayer to submit more than a single txn per
-    //  block. Note: this would still create duplicate nonces if called a second time
-    //  before the previous transaction goes into the mempool of the node.
+    //  With `BlockNumber::Latest` the nonce is calculated based on the last
+    //  mined Ethereum block. This is also the default behaviour of
+    //  `ContractCall.send`.
+    //
+    //  With `BlockNumber::Pending` pending Ethereum transactions will be
+    //  included in the transaction count. This enables submitting new Ethereum
+    //  transactions before the previous one is mined and therefore enables the
+    //  relayer to submit more than a single Ethererum transaction per Ethereum
+    //  block.
+    //
+    //  Note: using `BlockNumber::Pending` will still create duplicate nonces if
+    //  called a second time before the previous transaction goes into the
+    //  mempool of the node.
     let mut tx = contract
         .submit_cape_block_with_memos(block.block.clone().into(), memos_bytes.into())
         .tx
@@ -76,7 +87,7 @@ pub async fn submit_cape_block_with_memos(
         .client()
         .fill_transaction(&mut tx, Some(block_number.into()))
         .await?;
-    Ok(contract.client().send_transaction(tx, None).await?)
+    contract.client().send_transaction(tx, None).await
 }
 
 #[cfg(test)]

--- a/contracts/rust/src/cape/submit_block.rs
+++ b/contracts/rust/src/cape/submit_block.rs
@@ -55,11 +55,19 @@ pub async fn submit_cape_block_with_memos(
     block.memos.serialize(&mut memos_bytes).unwrap();
 
     // There is some nonce subtlety going on here, in what amounts to a simple
-    //  `contract.submit_cape_block_with_memos(...).send().await`
-    //  We  must manually fall `fill_transaction` in order pass `BlockNumber::Pending` this ensures
-    //  that eth_getTransactionCount (whose value is used to calculate the nonce) also includes pending
-    //  transactions. This allows for more than one txn to be included in one Ethereum block.
-    //  Note: this would still create duplicate nonces if called concurrently.
+    //  `contract.submit_cape_block_with_memos(...).send().await`.
+    //
+    //  We must manually call `fill_transaction` in order pass a `BlockNumber`.
+    //  The value is passed to `eth_getTransactionCount` to calculate the nonce.
+    //
+    //  For `BlockNumber::Latest` the nonce is calculated based on the last
+    //  mined block. This is also the default behaviour of `CotractCall.send`.
+    //
+    //  For `BlockNumber::Pending` pending transactions will be included. This
+    //  allow to submit new transactions before the previous one is mined and
+    //  therefore enables the relayer to submit more than a single txn per
+    //  block. Note: this would still create duplicate nonces if called a second time
+    //  before the previous transaction goes into the mempool of the node.
     let mut tx = contract
         .submit_cape_block_with_memos(block.block.clone().into(), memos_bytes.into())
         .tx

--- a/relayer/src/bin/minimal-relayer.rs
+++ b/relayer/src/bin/minimal-relayer.rs
@@ -40,12 +40,19 @@ struct MinimalRelayerOptions {
     #[structopt(long, env = "CAPE_RELAYER_PORT", default_value = DEFAULT_RELAYER_PORT)]
     port: u16,
 
-    /// Describes how transaction nonces should be calculated.
-    /// "mined": only count mined transaction when creating the nonce.
-    /// "pending": include pending transactions when creating the nonce.
-    /// Including "pending" transactions allows the relayer to submit
-    /// the next transaction after the previous one hit the nodes' mempool.
-    #[structopt(long, env = "CAPE_RELAYER_NONCE_COUNT_RULE", default_value = "mined")]
+    /// Determines how transaction nonces should be calculated.
+    ///
+    /// * `"mined"` - only count mined transaction when creating the nonce.
+    /// * `"pending"` - also include pending transactions when creating the nonce.
+    ///
+    /// Including "pending" transactions allows the relayer to submit the next
+    /// transaction as soon as the previous one hit the nodes' mempool.
+    #[structopt(
+        long,
+        env = "CAPE_RELAYER_NONCE_COUNT_RULE",
+        default_value = "mined",
+        verbatim_doc_comment
+    )]
     nonce_count_rule: NonceCountRule,
 }
 

--- a/relayer/src/lib.rs
+++ b/relayer/src/lib.rs
@@ -6,7 +6,6 @@
 // You should have received a copy of the GNU General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 #![doc = include_str!("../README.md")]
-use std::str::FromStr;
 
 #[warn(unused_imports)]
 use async_std::task;
@@ -21,6 +20,7 @@ use jf_cap::{keys::UserPubKey, structs::ReceiverMemo, Signature};
 use net::server::{add_error_body, request_body, response};
 use serde::{Deserialize, Serialize};
 use snafu::Snafu;
+use std::str::FromStr;
 use tide::StatusCode;
 
 pub const DEFAULT_RELAYER_PORT: &str = "50077";
@@ -70,9 +70,12 @@ pub struct SubmitBody {
     pub signature: Signature,
 }
 
+/// Determines how transaction nonces should be calculated.
 #[derive(Clone, Debug, Copy, Serialize, Deserialize)]
 pub enum NonceCountRule {
+    /// Only count mined transaction when creating the nonce.
     Mined,
+    /// Also include pending transactions when creating the nonce.
     Pending,
 }
 

--- a/relayer/src/lib.rs
+++ b/relayer/src/lib.rs
@@ -6,6 +6,8 @@
 // You should have received a copy of the GNU General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 #![doc = include_str!("../README.md")]
+use std::str::FromStr;
+
 #[warn(unused_imports)]
 use async_std::task;
 use cap_rust_sandbox::{
@@ -14,12 +16,14 @@ use cap_rust_sandbox::{
     model::CapeModelTxn,
     types::CAPE,
 };
-use ethers::prelude::H256;
+use ethers::prelude::{BlockNumber, H256};
 use jf_cap::{keys::UserPubKey, structs::ReceiverMemo, Signature};
 use net::server::{add_error_body, request_body, response};
 use serde::{Deserialize, Serialize};
 use snafu::Snafu;
 use tide::StatusCode;
+
+pub const DEFAULT_RELAYER_PORT: &str = "50077";
 
 #[derive(Clone, Debug, Snafu, Serialize, Deserialize)]
 pub enum Error {
@@ -56,6 +60,7 @@ fn server_error<E: Into<Error>>(err: E) -> tide::Error {
 #[derive(Clone)]
 struct WebState {
     contract: CAPE<EthMiddleware>,
+    nonce_count_rule: NonceCountRule,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -63,6 +68,35 @@ pub struct SubmitBody {
     pub transaction: CapeModelTxn,
     pub memos: Vec<ReceiverMemo>,
     pub signature: Signature,
+}
+
+#[derive(Clone, Debug, Copy, Serialize, Deserialize)]
+pub enum NonceCountRule {
+    Mined,
+    Pending,
+}
+
+impl From<NonceCountRule> for BlockNumber {
+    fn from(policy: NonceCountRule) -> Self {
+        match policy {
+            NonceCountRule::Mined => BlockNumber::Latest,
+            NonceCountRule::Pending => BlockNumber::Pending,
+        }
+    }
+}
+
+type ParseNonceCountRuleError = &'static str;
+
+impl FromStr for NonceCountRule {
+    type Err = ParseNonceCountRuleError;
+
+    fn from_str(input: &str) -> Result<NonceCountRule, Self::Err> {
+        match input {
+            "mined" => Ok(NonceCountRule::Mined),
+            "pending" => Ok(NonceCountRule::Pending),
+            _ => Err("Unable to parse, use \"mined\" or \"pending\""),
+        }
+    }
 }
 
 /// Return a JSON expression with status 200 indicating the server
@@ -88,9 +122,15 @@ async fn submit_endpoint(mut req: tide::Request<WebState>) -> Result<tide::Respo
             msg: err.to_string(),
         })
     })?;
-    let ret = relay(&req.state().contract, transaction, memos, signature)
-        .await
-        .map_err(server_error)?;
+    let ret = relay(
+        &req.state().contract,
+        req.state().nonce_count_rule,
+        transaction,
+        memos,
+        signature,
+    )
+    .await
+    .map_err(server_error)?;
     response(&req, ret)
 }
 /// This function implements the core logic of the relayer
@@ -104,6 +144,7 @@ async fn submit_endpoint(mut req: tide::Request<WebState>) -> Result<tide::Respo
 /// transaction to be mined.
 async fn relay(
     contract: &CAPE<EthMiddleware>,
+    nonce_count_rule: NonceCountRule,
     transaction: CapeModelTxn,
     memos: Vec<ReceiverMemo>,
     sig: Signature,
@@ -117,7 +158,7 @@ async fn relay(
         )?,
         memos: vec![(memos, sig)],
     };
-    let pending = submit_cape_block_with_memos(contract, block)
+    let pending = submit_cape_block_with_memos(contract, block, nonce_count_rule.into())
         .await
         .map_err(|err| Error::Submission {
             msg: err.to_string(),
@@ -128,14 +169,16 @@ async fn relay(
     Ok(*pending)
 }
 
-pub const DEFAULT_RELAYER_PORT: u16 = 50077u16;
-
 /// This function starts the web server
 pub fn init_web_server(
     contract: CAPE<EthMiddleware>,
-    port: String,
+    port: u16,
+    nonce_count_rule: NonceCountRule,
 ) -> task::JoinHandle<Result<(), std::io::Error>> {
-    let mut web_server = tide::with_state(WebState { contract });
+    let mut web_server = tide::with_state(WebState {
+        contract,
+        nonce_count_rule,
+    });
     web_server.at("/healthcheck").get(healthcheck);
     web_server
         .with(add_error_body::<_, Error>)
@@ -189,7 +232,7 @@ pub mod testing {
 
     const RELAYER_STARTUP_RETRIES: usize = 8;
 
-    pub async fn wait_for_server(port: u64) {
+    pub async fn wait_for_server(port: u16) {
         // Wait for the server to come up and start serving.
         let mut backoff = Duration::from_millis(100);
         for _ in 0..RELAYER_STARTUP_RETRIES {
@@ -210,7 +253,7 @@ pub mod testing {
     ///    
     /// `faucet_key_pair` - If not provided, a random faucet key pair will be generated.
     pub async fn start_minimal_relayer_for_test(
-        port: u64,
+        port: u16,
         faucet_key_pair: Option<UserKeyPair>,
     ) -> (
         TestCAPE<EthMiddleware>,
@@ -220,7 +263,11 @@ pub mod testing {
     ) {
         let (contract, faucet, faucet_rec, records) =
             deploy_cape_contract_with_faucet(faucet_key_pair).await;
-        init_web_server(upcast_test_cape_to_cape(contract.clone()), port.to_string());
+        init_web_server(
+            upcast_test_cape_to_cape(contract.clone()),
+            port,
+            NonceCountRule::Mined,
+        );
         wait_for_server(port).await;
         (contract, faucet, faucet_rec, records)
     }
@@ -262,14 +309,14 @@ mod test {
     };
 
     lazy_static! {
-        static ref PORT: Arc<Mutex<u64>> = {
+        static ref PORT: Arc<Mutex<u16>> = {
             let port_offset =
                 std::env::var("PORT").unwrap_or_else(|_| DEFAULT_RELAYER_PORT.to_string());
             Arc::new(Mutex::new(port_offset.parse().unwrap()))
         };
     }
 
-    async fn get_port() -> u64 {
+    async fn get_port() -> u16 {
         let mut counter = PORT.lock().await;
         let port = *counter;
         *counter += 1;
@@ -318,7 +365,16 @@ mod test {
     }
 
     #[async_std::test]
-    async fn test_relay() {
+    async fn test_relay_nonce_count_mined() {
+        test_relay(NonceCountRule::Mined).await
+    }
+
+    #[async_std::test]
+    async fn test_relay_nonce_count_pending() {
+        test_relay(NonceCountRule::Pending).await
+    }
+
+    async fn test_relay(nonce_count_rule: NonceCountRule) {
         let mut rng = ChaChaRng::from_seed([42; 32]);
         let user = UserKeyPair::generate(&mut rng);
 
@@ -331,6 +387,7 @@ mod test {
         // records Merkle tree.
         let hash = relay(
             &upcast_test_cape_to_cape(contract.clone()),
+            nonce_count_rule,
             transaction.clone(),
             memos.clone(),
             sig.clone(),
@@ -345,6 +402,7 @@ mod test {
         // records Merkle tree is not modified.
         match relay(
             &upcast_test_cape_to_cape(contract.clone()),
+            nonce_count_rule,
             transaction,
             memos,
             sig,
@@ -357,7 +415,7 @@ mod test {
         assert_eq!(contract.get_num_leaves().call().await.unwrap(), 3.into());
     }
 
-    fn get_client(port: u64) -> surf::Client {
+    fn get_client(port: u16) -> surf::Client {
         let client: surf::Client = surf::Config::new()
             .set_base_url(Url::parse(&format!("http://localhost:{}", port)).unwrap())
             .try_into()
@@ -422,7 +480,7 @@ mod test {
             CAPE::new(address, deployer)
         };
         let port = get_port().await;
-        init_web_server(contract, port.to_string());
+        init_web_server(contract, port, NonceCountRule::Mined);
         wait_for_server(port).await;
         let client = get_client(port);
         match Error::from_client_error(

--- a/wallet/src/testing.rs
+++ b/wallet/src/testing.rs
@@ -57,13 +57,13 @@ use tempdir::TempDir;
 use tracing::{event, Level};
 
 lazy_static! {
-    static ref PORT: Arc<Mutex<u64>> = {
+    static ref PORT: Arc<Mutex<u16>> = {
         let port_offset = std::env::var("PORT").unwrap_or_else(|_| String::from("60000"));
         Arc::new(Mutex::new(port_offset.parse().unwrap()))
     };
 }
 
-pub async fn port() -> u64 {
+pub async fn port() -> u16 {
     let mut counter = PORT.lock().await;
     let port = *counter;
     *counter += 1;

--- a/wallet/src/wallet-api/main.rs
+++ b/wallet/src/wallet-api/main.rs
@@ -171,7 +171,7 @@ mod tests {
             &self.options
         }
 
-        async fn wait(port: u64) {
+        async fn wait(port: u16) {
             retry(|| async move {
                 // Use a one-off request, rather than going through the client, because we want to
                 // skip the middleware, which can cause connect() to return an Err() even if the


### PR DESCRIPTION
This PR should not change existing behavior but allows us to configure
 the nonce behaviour via an env var if desired.

- `CAPE_RELAYER_NONCE_COUNT_RULE` can be set to `"mined"` or `"pending"`.
- Add CLI argument for `CAPE_RELAYER_PORT`.
- Change some port variables to u16 type.
- Run `test_relay` with both nonce count rules. This isn't very useful at the moment because of instant mining geth but at least makes sure that the code path using `BlockNumber::Pending` is also executed.