### PR TITLE
Updated /healthcheck to respond with Initializing or Available

### DIFF
--- a/eqs/src/entry.rs
+++ b/eqs/src/entry.rs
@@ -55,9 +55,6 @@ pub async fn run(opt: &EQSOptions) -> std::io::Result<()> {
 
     loop {
         if let Ok(_height) = eth_poll.check().await {}
-
-        //query_result_state.write().await.catching_up = false;
-
         // sleep here
         sleep(opt.query_interval()).await;
     }

--- a/eqs/src/entry.rs
+++ b/eqs/src/entry.rs
@@ -55,6 +55,7 @@ pub async fn run(opt: &EQSOptions) -> std::io::Result<()> {
 
     loop {
         if let Ok(_height) = eth_poll.check().await {}
+        query_result_state.catching_up = false;
         // sleep here
         sleep(opt.query_interval()).await;
     }

--- a/eqs/src/entry.rs
+++ b/eqs/src/entry.rs
@@ -55,7 +55,9 @@ pub async fn run(opt: &EQSOptions) -> std::io::Result<()> {
 
     loop {
         if let Ok(_height) = eth_poll.check().await {}
-        query_result_state.catching_up = false;
+
+        //query_result_state.write().await.catching_up = false;
+
         // sleep here
         sleep(opt.query_interval()).await;
     }

--- a/eqs/src/eth_polling.rs
+++ b/eqs/src/eth_polling.rs
@@ -435,6 +435,9 @@ impl EthPolling {
             self.next_block_to_query = latest_block + 1;
         }
 
+        let mut qrs = self.query_result_state.write().await;
+        qrs.catching_up = false;
+
         Ok(0)
     }
 }

--- a/eqs/src/eth_polling.rs
+++ b/eqs/src/eth_polling.rs
@@ -6,7 +6,7 @@
 // You should have received a copy of the GNU General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 use crate::configuration::{Confirmations, EQSOptions};
-use crate::query_result_state::{EthEventIndex, QueryResultState};
+use crate::query_result_state::{EthEventIndex, QueryResultState, SystemStatus};
 use crate::state_persistence::StatePersistence;
 
 use async_std::sync::{Arc, RwLock};
@@ -436,7 +436,7 @@ impl EthPolling {
         }
 
         let mut qrs = self.query_result_state.write().await;
-        qrs.catching_up = false;
+        qrs.system_status = SystemStatus::Available;
 
         Ok(0)
     }

--- a/eqs/src/query_result_state.rs
+++ b/eqs/src/query_result_state.rs
@@ -44,6 +44,8 @@ pub struct QueryResultState {
     // additional indexed data for queries
     pub transaction_by_id: HashMap<(u64, u64), CommittedCapeTransition>,
     pub transaction_id_by_hash: HashMap<Commitment<CapeTransition>, (u64, u64)>,
+
+    pub catching_up: bool,
 }
 
 impl QueryResultState {
@@ -71,6 +73,8 @@ impl QueryResultState {
 
             transaction_by_id: HashMap::new(),
             transaction_id_by_hash: HashMap::new(),
+
+            catching_up: true,
         }
     }
 }

--- a/eqs/src/query_result_state.rs
+++ b/eqs/src/query_result_state.rs
@@ -15,6 +15,7 @@ use key_set::VerifierKeySet;
 use seahorse::events::LedgerEvent;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet, VecDeque};
+use strum_macros::{AsRefStr, EnumString};
 
 use crate::configuration::Confirmations;
 
@@ -25,6 +26,12 @@ use crate::configuration::Confirmations;
 /// event indices `i1: EthEventIndex` and `i2: EthEventIndex`, the event with index `i1` comes
 /// before the event with index `i2` chronologically if and only if `i1 < i2`.
 pub type EthEventIndex = (u64, u64);
+
+#[derive(AsRefStr, Clone, Debug, Deserialize, EnumString, Serialize)]
+pub enum SystemStatus {
+    Initializing,
+    Available,
+}
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct QueryResultState {
@@ -45,7 +52,7 @@ pub struct QueryResultState {
     pub transaction_by_id: HashMap<(u64, u64), CommittedCapeTransition>,
     pub transaction_id_by_hash: HashMap<Commitment<CapeTransition>, (u64, u64)>,
 
-    pub catching_up: bool,
+    pub system_status: SystemStatus,
 }
 
 impl QueryResultState {
@@ -74,7 +81,7 @@ impl QueryResultState {
             transaction_by_id: HashMap::new(),
             transaction_id_by_hash: HashMap::new(),
 
-            catching_up: true,
+            system_status: SystemStatus::Initializing,
         }
     }
 }

--- a/eqs/src/routes.rs
+++ b/eqs/src/routes.rs
@@ -185,17 +185,18 @@ pub async fn get_transaction_by_hash(
 /// "unavailable"} should be added.
 pub async fn healthcheck(
     query_result_state: &QueryResultState,
-) -> Result<tide::Response, tide::Error> {
+) -> Result<serde_json::value::Value, tide::Error> {
     let status = if query_result_state.catching_up {
         "initializing"
     } else {
         "available"
     };
 
-    Ok(tide::Response::builder(200)
-        .content_type(tide::http::mime::JSON)
-        .body(tide::prelude::json!({ "status": status }))
-        .build())
+    // Ok(tide::Response::builder(200)
+    //     .content_type(tide::http::mime::JSON)
+    //     .body(tide::prelude::json!({ "status": status }))
+    //     .build())
+    Ok(tide::prelude::json!({ "status": status }))
 }
 
 pub async fn dispatch_url(

--- a/eqs/src/routes.rs
+++ b/eqs/src/routes.rs
@@ -174,10 +174,10 @@ pub async fn get_transaction_by_hash(
 
 /// Return a JSON expression with status 200 indicating the server
 /// is up and running. The JSON expression is one of
-/// * {"status": "initializing"}
-/// * {"status": "available"}
+/// * {"status": "Initializing"}
+/// * {"status": "Available"}
 ///
-/// The initializing status simply means that the server has not loaded all
+/// The Initializing status simply means that the server has not loaded all
 /// the latest data yet. It can still process requests.
 ///
 /// When the server is running but unable to process requests
@@ -186,17 +186,7 @@ pub async fn get_transaction_by_hash(
 pub async fn healthcheck(
     query_result_state: &QueryResultState,
 ) -> Result<serde_json::value::Value, tide::Error> {
-    let status = if query_result_state.catching_up {
-        "initializing"
-    } else {
-        "available"
-    };
-
-    // Ok(tide::Response::builder(200)
-    //     .content_type(tide::http::mime::JSON)
-    //     .body(tide::prelude::json!({ "status": status }))
-    //     .build())
-    Ok(tide::prelude::json!({ "status": status }))
+    Ok(tide::prelude::json!({ "status": query_result_state.system_status }))
 }
 
 pub async fn dispatch_url(


### PR DESCRIPTION
Previously, the `/healthcheck` endpoint would always respond
```json
  {"status": "available"}
```
Now, until it finishes catching up, it responds
```json
  {"status": "Initializing"}
```
and 
```json
  {"status": "Available"}
```
Note the status value is capitalized to match the Rust enumeration naming convention. This can be fixed if it's a problem.

Thanks to a suggestion from Mathis, the system status is stored as an enumeration, so this will be easy to expand.

- [ ] Find a way to test this.