### PR TITLE
Do not add sponsored asset to library until we know it is ok.

### DIFF
--- a/wallet/api/api.toml
+++ b/wallet/api/api.toml
@@ -387,10 +387,29 @@ PATH = [
   "buildsponsor/symbol/:symbol/erc20/:erc20/sponsor/:sponsor/viewing_key/:viewing_key/viewing_threshold/:viewing_threshold",
   "buildsponsor/symbol/:symbol/erc20/:erc20/sponsor/:sponsor/viewing_key/:viewing_key",
   "buildsponsor/symbol/:symbol/erc20/:erc20/sponsor/:sponsor",
+  "buildsponsor/symbol/:symbol/description/:description/erc20/:erc20/sponsor/:sponsor/freezing_key/:freezing_key/viewing_key/:viewing_key/view_amount/:view_amount/view_address/:view_address/viewing_threshold/:viewing_threshold",
+  "buildsponsor/symbol/:symbol/description/:description/erc20/:erc20/sponsor/:sponsor/freezing_key/:freezing_key/viewing_key/:viewing_key/view_amount/:view_amount/view_address/:view_address",
+  "buildsponsor/symbol/:symbol/description/:description/erc20/:erc20/sponsor/:sponsor/freezing_key/:freezing_key/viewing_key/:viewing_key/view_amount/:view_amount/viewing_threshold/:viewing_threshold",
+  "buildsponsor/symbol/:symbol/description/:description/erc20/:erc20/sponsor/:sponsor/freezing_key/:freezing_key/viewing_key/:viewing_key/view_amount/:view_amount",
+  "buildsponsor/symbol/:symbol/description/:description/erc20/:erc20/sponsor/:sponsor/freezing_key/:freezing_key/viewing_key/:viewing_key/view_address/:view_address/viewing_threshold/:viewing_threshold",
+  "buildsponsor/symbol/:symbol/description/:description/erc20/:erc20/sponsor/:sponsor/freezing_key/:freezing_key/viewing_key/:viewing_key/view_address/:view_address",
+  "buildsponsor/symbol/:symbol/description/:description/erc20/:erc20/sponsor/:sponsor/freezing_key/:freezing_key/viewing_key/:viewing_key/viewing_threshold/:viewing_threshold",
+  "buildsponsor/symbol/:symbol/description/:description/erc20/:erc20/sponsor/:sponsor/freezing_key/:freezing_key/viewing_key/:viewing_key",
+  "buildsponsor/symbol/:symbol/description/:description/erc20/:erc20/sponsor/:sponsor/freezing_key/:freezing_key",
+  "buildsponsor/symbol/:symbol/description/:description/erc20/:erc20/sponsor/:sponsor/viewing_key/:viewing_key/view_amount/:view_amount/view_address/:view_address/viewing_threshold/:viewing_threshold",
+  "buildsponsor/symbol/:symbol/description/:description/erc20/:erc20/sponsor/:sponsor/viewing_key/:viewing_key/view_amount/:view_amount/view_address/:view_address",
+  "buildsponsor/symbol/:symbol/description/:description/erc20/:erc20/sponsor/:sponsor/viewing_key/:viewing_key/view_amount/:view_amount/viewing_threshold/:viewing_threshold",
+  "buildsponsor/symbol/:symbol/description/:description/erc20/:erc20/sponsor/:sponsor/viewing_key/:viewing_key/view_amount/:view_amount",
+  "buildsponsor/symbol/:symbol/description/:description/erc20/:erc20/sponsor/:sponsor/viewing_key/:viewing_key/view_address/:view_address/viewing_threshold/:viewing_threshold",
+  "buildsponsor/symbol/:symbol/description/:description/erc20/:erc20/sponsor/:sponsor/viewing_key/:viewing_key/view_address/:view_address",
+  "buildsponsor/symbol/:symbol/description/:description/erc20/:erc20/sponsor/:sponsor/viewing_key/:viewing_key/viewing_threshold/:viewing_threshold",
+  "buildsponsor/symbol/:symbol/description/:description/erc20/:erc20/sponsor/:sponsor/viewing_key/:viewing_key",
+  "buildsponsor/symbol/:symbol/description/:description/erc20/:erc20/sponsor/:sponsor",
 ]
 ":erc20" = "Literal"
 ":sponsor" = "Literal"
 ":symbol" = "Base64"
+":description" = "Base64"
 ":freezing_key" = "TaggedBase64"
 ":viewing_key" = "TaggedBase64"
 ":view_amount" = "Boolean"

--- a/wallet/src/wallet.rs
+++ b/wallet/src/wallet.rs
@@ -92,10 +92,10 @@ pub trait CapeWalletExt<'a, Backend: CapeWalletBackend<'a> + Sync + 'a> {
 
     /// Construct the information required to sponsor an asset, but do not submit a transaction.
     ///
-    /// A new asset definition is created, added to the asset library, and returned. This asset can
-    /// be passed to the contract's `sponsorCapeAsset` function, along with `erc20_code`, in order
-    /// to sponsor the asset, but this function will not invoke the contract. For a version which
-    /// does, use [CapeWalletExt::sponsor].
+    /// A new asset definition is created and returned. This asset can be passed to the contract's
+    /// `sponsorCapeAsset` function, along with `erc20_code`, in order to sponsor the asset, but
+    /// this function will not invoke the contract. For a version which does, use
+    /// [CapeWalletExt::sponsor].
     async fn build_sponsor(
         &mut self,
         erc20_code: Erc20Code,


### PR DESCRIPTION
Previously, the buildsponsor endpoint (and the corresponding
`build_sponsor` wallet method) would add the new AssetInfo to the
wallet's library before returning the `sol::AssetDefinition` to be
submitted to the contract. This can lead to confusing UX if the user
cancels the transaction before the asset is actually sponsored, or
if the Ethereum transaction is rejected or reverted, because it
would lead to an asset in the asset library which doesn't actually
correspond to anything.

Now, `buildsponsor` just returns the serialized AssetInfo instead of
adding it to the wallet. The asset can be added to the wallet at any
time after the sponsor transaction succeeds by calling `importasset`.