### PR TITLE
Add shell for static linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ describes the project at a high level.
   - [4. direnv (Optional, but recommended for development)](#4-direnv-optional-but-recommended-for-development)
 - [Build](#build)
   - [Docker images](#docker-images)
+  - [Statically Linked](#static-build)
 - [CAPE Demo](#cape-demo)
   - [Local demo](#local-demo)
   - [Docker compose](#docker-compose)
@@ -173,6 +174,16 @@ To build the project run
 
 The `--release` flag is recommended because without it many cryptographic
 computations the project relies one become unbearably slow.
+
+## Static build
+
+To build a statically linked version of the project with musl64 as a libc on a `x86_64-linux-unknown-gnu` host:
+
+```bash
+nix develop .#staticShell -c cargo build --release
+```
+
+The resulting build artifacts end up in `target/x86_64-unknown-linux-musl`, and may be run on any linux computer as they will not depend on glibc or any shared libs (`*.so`).
 
 ## Docker images
 

--- a/flake.nix
+++ b/flake.nix
@@ -33,117 +33,69 @@
     }:
     flake-utils.lib.eachDefaultSystem (system:
     let
-      overlays = [ (import rust-overlay) ];
-      pkgs = import nixpkgs {
-        inherit system overlays;
+      xpkgs = import nixpkgs {
+        system = "x86_64-linux"; 
+        overlays = [ (import rust-overlay) ];
       };
+      pkgs = import nixpkgs {
+        localSystem = "x86_64-linux"; 
+        crossSystem = { config = "x86_64-unknown-linux-musl"; };
+        # overlays = [ (import rust-overlay) ];
+      };
+      mySolc = xpkgs.callPackage ./nix/solc-bin { version = "0.8.10"; };
+      pythonEnv = xpkgs.poetry2nix.mkPoetryEnv {
+        projectDir = ./.;
+      };
+      myPython = with xpkgs; [
+        poetry
+        pythonEnv
+      ];
     in
     {
-      checks = {
-        pre-commit-check = pre-commit-hooks.lib.${system}.run {
-          src = ./.;
-          hooks = {
-            lint-solidity = {
-              enable = true;
-              files = "^contracts/contracts/";
-              entry = "lint-solidity";
-              types = [ "solidity" ];
-            };
-            check-format = {
-              enable = true;
-              entry = "treefmt --fail-on-change";
-            };
-            # The hook "clippy" that ships with nix-precommit-hooks is outdated.
-            cargo-clippy = {
-              enable = true;
-              description = "Lint Rust code.";
-              entry = "cargo-clippy --workspace -- -D warnings";
-              files = "\\.rs$";
-              pass_filenames = false;
-            };
-            cargo-sort = {
-              enable = true;
-              description = "Ensure Cargo.toml are sorted";
-              entry = "cargo sort -w";
-              pass_filenames = false;
-            };
-            license-header-c-style = {
-              enable = true;
-              description = "Ensure files with c-style comments have license header";
-              entry = "insert_license --license-filepath .license-header  --comment-style \"//\"";
-              types_or = [ "rust" "ts" "javascript" ];
-              excludes = [
-                "bindings/mod\\.rs" # generated file
-              ];
-              pass_filenames = true;
-            };
-            license-header-solidity = {
-              enable = true;
-              description = "Ensure solidity files have license header";
-              entry = "insert_license --license-filepath .license-header-solidity  --comment-style \"//\"";
-              types = [ "solidity" ];
-              pass_filenames = true;
-            };
-            license-header-hash = {
-              enable = true;
-              description = "Ensure files with hash style comments have license header";
-              entry = "insert_license --license-filepath .license-header --comment-style \"#\"";
-              types_or = [ "bash" "python" "toml" "nix" ];
-              excludes = [
-                "poetry.lock"
-              ];
-              pass_filenames = true;
-            };
-            license-header-html = {
-              enable = true;
-              description = "Ensure markdown files have license header";
-              entry = "insert_license --license-filepath .license-header --comment-style \"<!--| ~| -->\"";
-              types_or = [ "markdown" ];
-              pass_filenames = true;
-            };
-          };
-        };
-      };
       # A nix base image
-      packages.docker = pkgs.dockerTools.buildImage {
-        name = "nix-base-docker";
-        tag = "latest";
-        contents = with pkgs; [
-          curl
-          coreutils
-          bashInteractive
-          cacert
-        ];
-        config = {
-          Env = [
-            "SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt"
-          ];
-        };
-      };
+      # packages.docker = pkgs.dockerTools.buildImage {
+      #   name = "nix-base-docker";
+      #   tag = "latest";
+      #   contents = with pkgs; [
+      #     curl
+      #     coreutils
+      #     bashInteractive
+      #     cacert
+      #   ];
+      #   config = {
+      #     Env = [
+      #       "SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt"
+      #     ];
+      #   };
+      # };
       devShell =
         let
-          mySolc = pkgs.callPackage ./nix/solc-bin { version = "0.8.10"; };
-          pythonEnv = pkgs.poetry2nix.mkPoetryEnv {
-            projectDir = ./.;
-          };
-          myPython = with pkgs; [
-            poetry
-            pythonEnv
-          ];
+          # mySolc = pkgs.callPackage ./nix/solc-bin { version = "0.8.10"; };
+          # pythonEnv = pkgs.poetry2nix.mkPoetryEnv {
+          #   projectDir = ./.;
+          # };
+          # myPython = with pkgs; [
+          #   poetry
+          #   pythonEnv
+          # ];
 
-          stableToolchain = pkgs.rust-bin.stable."1.60.0".minimal.override {
+          stableToolchain = xpkgs.rust-bin.stable."1.60.0".minimal.override {
             extensions = [ "rustfmt" "clippy" "llvm-tools-preview" "rust-src" ];
+	    targets = [ "x86_64-unknown-linux-musl" ];
           };
+          openssl_musl = (((import nixpkgs { localSystem = "x86_64-linux"; crossSystem = { config = "x86_64-unknown-linux-musl"; }; }).openssl).override {static = true;}).dev;
+          # for some odd reason only `out` exposes libssl.a
+          openssl_musl_lib = (((import nixpkgs { localSystem = "x86_64-linux"; crossSystem = { config = "x86_64-unknown-linux-musl"; }; }).openssl).override {static = true;}).out;
           rustDeps = with pkgs; [
             pkgconfig
-            openssl
-
+            openssl_musl
+            openssl_musl_lib
             curl
-            plantuml
+            # plantuml
             stableToolchain
 
-            cargo-edit
-            cargo-sort
+            # cargo-edit
+            # cargo-sort
           ] ++ lib.optionals stdenv.isDarwin [
             # required to compile ethers-rs
             darwin.apple_sdk.frameworks.Security
@@ -152,38 +104,12 @@
             # https://github.com/NixOS/nixpkgs/issues/126182
             libiconv
           ] ++ lib.optionals (stdenv.system != "aarch64-darwin") [
-            cargo-watch # broken: https://github.com/NixOS/nixpkgs/issues/146349
+            # cargo-watch # broken: https://github.com/NixOS/nixpkgs/issues/146349
           ];
           # nixWithFlakes allows pre v2.4 nix installations to use flake commands (like `nix flake update`)
-          nixWithFlakes = pkgs.writeShellScriptBin "nix" ''
-            exec ${pkgs.nixFlakes}/bin/nix --experimental-features "nix-command flakes" "$@"
-          '';
         in
         pkgs.mkShell
           {
-            buildInputs = with pkgs; [
-              nixWithFlakes
-              go-ethereum
-              nodePackages.pnpm
-              mySolc
-              hivemind # process runner
-              nodejs-16_x # nodejs
-              jq
-              entr # watch files for changes, for example: ls contracts/*.sol | entr -c hardhat compile
-              treefmt # multi language formatter
-              nixpkgs-fmt
-              git # required for pre-commit hook installation
-              netcat-gnu # only used to check for open ports
-              cacert
-              mdbook # make-doc, documentation generation
-              moreutils # includes `ts`, used to add timestamps on CI
-            ]
-            ++ myPython
-            ++ rustDeps;
-
-            RUST_SRC_PATH = "${stableToolchain}/lib/rustlib/src/rust/library";
-            RUST_BACKTRACE = 1;
-            RUST_LOG = "info";
 
             SOLCX_BINARY_PATH = "${mySolc}/bin";
             SOLC_VERSION = mySolc.version;
@@ -191,20 +117,47 @@
             # TODO: increase this when contract size limit is not a problem
             SOLC_OPTIMIZER_RUNS = "20";
 
+            buildInputs = rustDeps ++ [
+            myPython
+              xpkgs.nodePackages.pnpm
+              mySolc
+              xpkgs.hivemind # process runner
+              xpkgs.nodejs-16_x
+              xpkgs.plantuml
+            ];
+
+            # with pkgs; [
+            # stableToolchain
+            #   nixWithFlakes
+            #   go-ethereum
+            #   nodePackages.pnpm
+            #   mySolc
+            #   hivemind # process runner
+            #   nodejs-16_x # nodejs
+            #   jq
+            #   entr # watch files for changes, for example: ls contracts/*.sol | entr -c hardhat compile
+            #   treefmt # multi language formatter
+            #   nixpkgs-fmt
+            #   git # required for pre-commit hook installation
+            #   netcat-gnu # only used to check for open ports
+            #   cacert
+            #   mdbook # make-doc, documentation generation
+            #   moreutils # includes `ts`, used to add timestamps on CI
+            #   # inputs.nixpkgs.legacyPackages.x86_64-musl.openssl
+            # ]
+            # ++ myPython
+            # ++ rustDeps;
+
+            RUST_SRC_PATH = "${stableToolchain}/lib/rustlib/src/rust/library";
+            RUST_BACKTRACE = 1;
+            RUST_LOG = "info";
+
             shellHook = ''
-              echo "Ensuring node dependencies are installed"
-              pnpm --recursive install
 
-              if [ ! -f .env ]; then
-                echo "Copying .env.sample to .env"
-                cp .env.sample .env
-              fi
-
-              echo "Exporting all vars in .env file"
-              set -a; source .env; set +a;
-
-              # on mac os `bin/pwd -P` returns the canonical path on case insenstive file-systems
               my_pwd=$(/bin/pwd -P 2> /dev/null || pwd)
+
+             set -a; source .env; set +a;
+             pnpm --recursive install
 
               export CONTRACTS_DIR=''${my_pwd}/contracts
               export HARDHAT_CONFIG=$CONTRACTS_DIR/hardhat.config.ts
@@ -213,10 +166,15 @@
               export PATH=''${my_pwd}/bin:$PATH
               export WALLET=''${my_pwd}/wallet
 
-              git config --local blame.ignoreRevsFile .git-blame-ignore-revs
-            ''
-            # install pre-commit hooks
-            + self.checks.${system}.pre-commit-check.shellHook;
+
+
+              export RUSTFLAGS='-C target-feature=+crt-static'
+              export CARGO_BUILD_TARGET='x86_64-unknown-linux-musl'
+              export OPENSSL_LIB_DIR='${openssl_musl}/lib/'
+              export OPENSSL_INCLUDE_DIR='${openssl_musl}/include/'
+              export OPENSSL_STATIC=true
+              export RUSTFLAGS='-L${openssl_musl_lib}/lib/'
+            '';
           };
 
     }

--- a/flake.nix
+++ b/flake.nix
@@ -22,80 +22,50 @@
   inputs.pre-commit-hooks.inputs.flake-utils.follows = "flake-utils";
   inputs.pre-commit-hooks.inputs.nixpkgs.follows = "nixpkgs";
 
-  outputs =
-    { self
-    , nixpkgs
-    , flake-utils
-    , flake-compat
-    , rust-overlay
-    , pre-commit-hooks
-    , ...
-    }:
+  outputs = { self, nixpkgs, flake-utils, flake-compat, rust-overlay
+    , pre-commit-hooks, ... }:
     flake-utils.lib.eachDefaultSystem (system:
-    let
-      xpkgs = import nixpkgs {
-        system = "x86_64-linux"; 
-        overlays = [ (import rust-overlay) ];
-      };
-      pkgs = import nixpkgs {
-        localSystem = "x86_64-linux"; 
-        crossSystem = { config = "x86_64-unknown-linux-musl"; };
-        # overlays = [ (import rust-overlay) ];
-      };
-      mySolc = xpkgs.callPackage ./nix/solc-bin { version = "0.8.10"; };
-      pythonEnv = xpkgs.poetry2nix.mkPoetryEnv {
-        projectDir = ./.;
-      };
-      myPython = with xpkgs; [
-        poetry
-        pythonEnv
-      ];
-    in
-    {
-      # A nix base image
-      # packages.docker = pkgs.dockerTools.buildImage {
-      #   name = "nix-base-docker";
-      #   tag = "latest";
-      #   contents = with pkgs; [
-      #     curl
-      #     coreutils
-      #     bashInteractive
-      #     cacert
-      #   ];
-      #   config = {
-      #     Env = [
-      #       "SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt"
-      #     ];
-      #   };
-      # };
-      devShell =
-        let
-          # mySolc = pkgs.callPackage ./nix/solc-bin { version = "0.8.10"; };
-          # pythonEnv = pkgs.poetry2nix.mkPoetryEnv {
-          #   projectDir = ./.;
-          # };
-          # myPython = with pkgs; [
-          #   poetry
-          #   pythonEnv
-          # ];
-
-          stableToolchain = xpkgs.rust-bin.stable."1.60.0".minimal.override {
+      let
+        # MUSL pkgs
+        muslPkgs = import nixpkgs {
+          localSystem = "x86_64-linux";
+          crossSystem = { config = "x86_64-unknown-linux-musl"; };
+        };
+        opensslMusl = muslPkgs.openssl.override { static = true; };
+        muslPythonEnv = muslPkgs.poetry2nix.mkPoetryEnv { projectDir = ./.; };
+        muslRustDeps = with muslPkgs; [
+          pkgconfig
+          curl
+          opensslMusl.dev
+          opensslMusl.out
+        ];
+        stableMuslRustToolchain =
+          pkgs.rust-bin.stable."1.60.0".minimal.override {
             extensions = [ "rustfmt" "clippy" "llvm-tools-preview" "rust-src" ];
-	    targets = [ "x86_64-unknown-linux-musl" ];
+            targets = [ "x86_64-unknown-linux-musl" ];
           };
-          openssl_musl = (((import nixpkgs { localSystem = "x86_64-linux"; crossSystem = { config = "x86_64-unknown-linux-musl"; }; }).openssl).override {static = true;}).dev;
-          # for some odd reason only `out` exposes libssl.a
-          openssl_musl_lib = (((import nixpkgs { localSystem = "x86_64-linux"; crossSystem = { config = "x86_64-unknown-linux-musl"; }; }).openssl).override {static = true;}).out;
-          rustDeps = with pkgs; [
-            pkgconfig
-            openssl_musl
-            openssl_musl_lib
-            curl
-            # plantuml
-            stableToolchain
 
-            # cargo-edit
-            # cargo-sort
+        # glibc pkgs
+        overlays = [ (import rust-overlay) ];
+        pkgs = import nixpkgs { inherit system overlays; };
+        mySolc = pkgs.callPackage ./nix/solc-bin { version = "0.8.10"; };
+        pythonEnv = pkgs.poetry2nix.mkPoetryEnv { projectDir = ./.; };
+        myPython = with pkgs; [ poetry pythonEnv ];
+
+        stableRustToolchain = pkgs.rust-bin.stable."1.60.0".minimal.override {
+          extensions = [ "rustfmt" "clippy" "llvm-tools-preview" "rust-src" ];
+        };
+        rustDeps = with pkgs;
+          [
+            pkgconfig
+            openssl
+
+            curl
+            plantuml
+            stableRustToolchain
+
+            cargo-edit
+            cargo-sort
           ] ++ lib.optionals stdenv.isDarwin [
             # required to compile ethers-rs
             darwin.apple_sdk.frameworks.Security
@@ -104,12 +74,164 @@
             # https://github.com/NixOS/nixpkgs/issues/126182
             libiconv
           ] ++ lib.optionals (stdenv.system != "aarch64-darwin") [
-            # cargo-watch # broken: https://github.com/NixOS/nixpkgs/issues/146349
+            cargo-watch # broken: https://github.com/NixOS/nixpkgs/issues/146349
           ];
-          # nixWithFlakes allows pre v2.4 nix installations to use flake commands (like `nix flake update`)
-        in
-        pkgs.mkShell
-          {
+        # nixWithFlakes allows pre v2.4 nix installations to use flake commands (like `nix flake update`)
+        nixWithFlakes = pkgs.writeShellScriptBin "nix" ''
+          exec ${pkgs.nixFlakes}/bin/nix --experimental-features "nix-command flakes" "$@"
+        '';
+        muslNixWithFlakes = pkgs.writeShellScriptBin "nix" ''
+          exec ${muslPkgs.nixFlakes}/bin/nix --experimental-features "nix-command flakes" "$@"
+        '';
+      in {
+        checks = {
+          pre-commit-check = pre-commit-hooks.lib.${system}.run {
+            src = ./.;
+            hooks = {
+              lint-solidity = {
+                enable = true;
+                files = "^contracts/contracts/";
+                entry = "lint-solidity";
+                types = [ "solidity" ];
+              };
+              check-format = {
+                enable = true;
+                entry = "treefmt --fail-on-change";
+              };
+              # The hook "clippy" that ships with nix-precommit-hooks is outdated.
+              cargo-clippy = {
+                enable = true;
+                description = "Lint Rust code.";
+                entry = "cargo-clippy --workspace -- -D warnings";
+                files = "\\.rs$";
+                pass_filenames = false;
+              };
+              cargo-sort = {
+                enable = true;
+                description = "Ensure Cargo.toml are sorted";
+                entry = "cargo sort -w";
+                pass_filenames = false;
+              };
+              license-header-c-style = {
+                enable = true;
+                description =
+                  "Ensure files with c-style comments have license header";
+                entry = ''
+                  insert_license --license-filepath .license-header  --comment-style "//"'';
+                types_or = [ "rust" "ts" "javascript" ];
+                excludes = [
+                  "bindings/mod\\.rs" # generated file
+                ];
+                pass_filenames = true;
+              };
+              license-header-solidity = {
+                enable = true;
+                description = "Ensure solidity files have license header";
+                entry = ''
+                  insert_license --license-filepath .license-header-solidity  --comment-style "//"'';
+                types = [ "solidity" ];
+                pass_filenames = true;
+              };
+              license-header-hash = {
+                enable = true;
+                description =
+                  "Ensure files with hash style comments have license header";
+                entry = ''
+                  insert_license --license-filepath .license-header --comment-style "#"'';
+                types_or = [ "bash" "python" "toml" "nix" ];
+                excludes = [ "poetry.lock" ];
+                pass_filenames = true;
+              };
+              license-header-html = {
+                enable = true;
+                description = "Ensure markdown files have license header";
+                entry = ''
+                  insert_license --license-filepath .license-header --comment-style "<!--| ~| -->"'';
+                types_or = [ "markdown" ];
+                pass_filenames = true;
+              };
+            };
+          };
+        };
+        # A nix base image
+        packages.docker = pkgs.dockerTools.buildImage {
+          name = "nix-base-docker";
+          tag = "latest";
+          contents = with pkgs; [ curl coreutils bashInteractive cacert ];
+          config = { Env = [ "SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt" ]; };
+        };
+        devShell = pkgs.mkShell {
+          buildInputs = with pkgs;
+            [
+              nixWithFlakes
+              go-ethereum
+              nodePackages.pnpm
+              mySolc
+              hivemind # process runner
+              nodejs-16_x # nodejs
+              jq
+              entr # watch files for changes, for example: ls contracts/*.sol | entr -c hardhat compile
+              treefmt # multi language formatter
+              nixpkgs-fmt
+              git # required for pre-commit hook installation
+              netcat-gnu # only used to check for open ports
+              cacert
+              mdbook # make-doc, documentation generation
+              moreutils # includes `ts`, used to add timestamps on CI
+            ] ++ myPython ++ rustDeps;
+
+          RUST_SRC_PATH = "${stableRustToolchain}/lib/rustlib/src/rust/library";
+          RUST_BACKTRACE = 1;
+          RUST_LOG = "info";
+
+          SOLCX_BINARY_PATH = "${mySolc}/bin";
+          SOLC_VERSION = mySolc.version;
+          SOLC_PATH = "${mySolc}/bin/solc";
+          # TODO: increase this when contract size limit is not a problem
+          SOLC_OPTIMIZER_RUNS = "20";
+
+          shellHook = ''
+            echo "Ensuring node dependencies are installed"
+            pnpm --recursive install
+
+            if [ ! -f .env ]; then
+              echo "Copying .env.sample to .env"
+              cp .env.sample .env
+            fi
+
+            echo "Exporting all vars in .env file"
+            set -a; source .env; set +a;
+
+            # on mac os `bin/pwd -P` returns the canonical path on case insenstive file-systems
+            my_pwd=$(/bin/pwd -P 2> /dev/null || pwd)
+
+            export CONTRACTS_DIR=''${my_pwd}/contracts
+            export HARDHAT_CONFIG=$CONTRACTS_DIR/hardhat.config.ts
+            export PATH=''${my_pwd}/node_modules/.bin:$PATH
+            export PATH=$CONTRACTS_DIR/node_modules/.bin:$PATH
+            export PATH=''${my_pwd}/bin:$PATH
+            export WALLET=''${my_pwd}/wallet
+
+            git config --local blame.ignoreRevsFile .git-blame-ignore-revs
+          ''
+            # install pre-commit hooks
+            + self.checks.${system}.pre-commit-check.shellHook;
+        };
+
+        devShells = {
+          # shell with all needed tools to build
+          # for a statically linked x86_64-unknown-linux-musl target.
+          # when running cargo build
+          staticShell = muslPkgs.mkShell {
+
+            # build as much as possible with musl
+            nativeBuildInputs = with muslPkgs;
+              [
+                muslNixWithFlakes
+                go-ethereum
+                mySolc
+                hivemind # process runner
+              ] ++ muslRustDeps;
 
             SOLCX_BINARY_PATH = "${mySolc}/bin";
             SOLC_VERSION = mySolc.version;
@@ -117,47 +239,20 @@
             # TODO: increase this when contract size limit is not a problem
             SOLC_OPTIMIZER_RUNS = "20";
 
-            buildInputs = rustDeps ++ [
-            myPython
-              xpkgs.nodePackages.pnpm
-              mySolc
-              xpkgs.hivemind # process runner
-              xpkgs.nodejs-16_x
-              xpkgs.plantuml
-            ];
-
-            # with pkgs; [
-            # stableToolchain
-            #   nixWithFlakes
-            #   go-ethereum
-            #   nodePackages.pnpm
-            #   mySolc
-            #   hivemind # process runner
-            #   nodejs-16_x # nodejs
-            #   jq
-            #   entr # watch files for changes, for example: ls contracts/*.sol | entr -c hardhat compile
-            #   treefmt # multi language formatter
-            #   nixpkgs-fmt
-            #   git # required for pre-commit hook installation
-            #   netcat-gnu # only used to check for open ports
-            #   cacert
-            #   mdbook # make-doc, documentation generation
-            #   moreutils # includes `ts`, used to add timestamps on CI
-            #   # inputs.nixpkgs.legacyPackages.x86_64-musl.openssl
-            # ]
-            # ++ myPython
-            # ++ rustDeps;
-
-            RUST_SRC_PATH = "${stableToolchain}/lib/rustlib/src/rust/library";
-            RUST_BACKTRACE = 1;
-            RUST_LOG = "info";
-
             shellHook = ''
+              echo "Ensuring node dependencies are installed"
+              ${pkgs.nodePackages.pnpm}/bin/pnpm --recursive install
 
+              if [ ! -f .env ]; then
+                echo "Copying .env.sample to .env"
+                cp .env.sample .env
+              fi
+
+              echo "Exporting all vars in .env file"
+              set -a; source .env; set +a;
+
+              # on mac os `bin/pwd -P` returns the canonical path on case insenstive file-systems
               my_pwd=$(/bin/pwd -P 2> /dev/null || pwd)
-
-             set -a; source .env; set +a;
-             pnpm --recursive install
 
               export CONTRACTS_DIR=''${my_pwd}/contracts
               export HARDHAT_CONFIG=$CONTRACTS_DIR/hardhat.config.ts
@@ -166,17 +261,18 @@
               export PATH=''${my_pwd}/bin:$PATH
               export WALLET=''${my_pwd}/wallet
 
-
-
               export RUSTFLAGS='-C target-feature=+crt-static'
               export CARGO_BUILD_TARGET='x86_64-unknown-linux-musl'
-              export OPENSSL_LIB_DIR='${openssl_musl}/lib/'
-              export OPENSSL_INCLUDE_DIR='${openssl_musl}/include/'
+              export OPENSSL_LIB_DIR='${opensslMusl.dev}/lib/'
+              export OPENSSL_INCLUDE_DIR='${opensslMusl.dev}/include/'
               export OPENSSL_STATIC=true
-              export RUSTFLAGS='-L${openssl_musl_lib}/lib/'
+              export RUSTFLAGS='-L${opensslMusl.out}/lib/'
+              export CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER="${muslPkgs.llvmPackages_latest.lld}/bin/lld";
+              export PATH="${pkgs.nodePackages.pnpm}/bin:${pkgs.nodejs-16_x}/bin:${stableMuslRustToolchain}/bin:${pkgs.gcc}/bin/:$PATH"
             '';
           };
+        };
+      });
 
-    }
-    );
 }
+

--- a/flake.nix
+++ b/flake.nix
@@ -22,177 +22,240 @@
   inputs.pre-commit-hooks.inputs.flake-utils.follows = "flake-utils";
   inputs.pre-commit-hooks.inputs.nixpkgs.follows = "nixpkgs";
 
-  outputs = { self, nixpkgs, flake-utils, flake-compat, rust-overlay
-    , pre-commit-hooks, ... }:
+  outputs =
+    { self
+    , nixpkgs
+    , flake-utils
+    , flake-compat
+    , rust-overlay
+    , pre-commit-hooks
+    , ...
+    }:
     flake-utils.lib.eachDefaultSystem (system:
-      let
-        # MUSL pkgs
-        muslPkgs = import nixpkgs {
-          localSystem = "x86_64-linux";
-          crossSystem = { config = "x86_64-unknown-linux-musl"; };
-        };
-        opensslMusl = muslPkgs.openssl.override { static = true; };
-        muslPythonEnv = muslPkgs.poetry2nix.mkPoetryEnv { projectDir = ./.; };
-        muslRustDeps = with muslPkgs; [
-          pkgconfig
-          curl
-          opensslMusl.dev
-          opensslMusl.out
-        ];
-        stableMuslRustToolchain =
-          pkgs.rust-bin.stable."1.60.0".minimal.override {
-            extensions = [ "rustfmt" "clippy" "llvm-tools-preview" "rust-src" ];
-            targets = [ "x86_64-unknown-linux-musl" ];
-          };
-
-        # glibc pkgs
-        overlays = [ (import rust-overlay) ];
-        pkgs = import nixpkgs { inherit system overlays; };
-        mySolc = pkgs.callPackage ./nix/solc-bin { version = "0.8.10"; };
-        pythonEnv = pkgs.poetry2nix.mkPoetryEnv { projectDir = ./.; };
-        myPython = with pkgs; [ poetry pythonEnv ];
-
-        stableRustToolchain = pkgs.rust-bin.stable."1.60.0".minimal.override {
+    let
+      # MUSL pkgs
+      muslPkgs = import nixpkgs {
+        localSystem = "x86_64-linux";
+        crossSystem = { config = "x86_64-unknown-linux-musl"; };
+      };
+      opensslMusl = muslPkgs.openssl.override { static = true; };
+      muslPythonEnv = muslPkgs.poetry2nix.mkPoetryEnv { projectDir = ./.; };
+      muslRustDeps = with muslPkgs; [
+        pkgconfig
+        curl
+        opensslMusl.dev
+        opensslMusl.out
+      ];
+      stableMuslRustToolchain =
+        pkgs.rust-bin.stable."1.60.0".minimal.override {
           extensions = [ "rustfmt" "clippy" "llvm-tools-preview" "rust-src" ];
+          targets = [ "x86_64-unknown-linux-musl" ];
         };
-        rustDeps = with pkgs;
-          [
-            pkgconfig
-            openssl
 
-            curl
-            plantuml
-            stableRustToolchain
+      # glibc pkgs
+      overlays = [ (import rust-overlay) ];
+      pkgs = import nixpkgs { inherit system overlays; };
+      mySolc = pkgs.callPackage ./nix/solc-bin { version = "0.8.10"; };
+      pythonEnv = pkgs.poetry2nix.mkPoetryEnv { projectDir = ./.; };
+      myPython = with pkgs; [ poetry pythonEnv ];
 
-            cargo-edit
-            cargo-sort
-          ] ++ lib.optionals stdenv.isDarwin [
-            # required to compile ethers-rs
-            darwin.apple_sdk.frameworks.Security
-            darwin.apple_sdk.frameworks.CoreFoundation
+      stableRustToolchain = pkgs.rust-bin.stable."1.60.0".minimal.override {
+        extensions = [ "rustfmt" "clippy" "llvm-tools-preview" "rust-src" ];
+      };
+      rustDeps = with pkgs;
+        [
+          pkgconfig
+          openssl
 
-            # https://github.com/NixOS/nixpkgs/issues/126182
-            libiconv
-          ] ++ lib.optionals (stdenv.system != "aarch64-darwin") [
-            cargo-watch # broken: https://github.com/NixOS/nixpkgs/issues/146349
-          ];
-        # nixWithFlakes allows pre v2.4 nix installations to use flake commands (like `nix flake update`)
-        nixWithFlakes = pkgs.writeShellScriptBin "nix" ''
-          exec ${pkgs.nixFlakes}/bin/nix --experimental-features "nix-command flakes" "$@"
-        '';
-        muslNixWithFlakes = pkgs.writeShellScriptBin "nix" ''
-          exec ${muslPkgs.nixFlakes}/bin/nix --experimental-features "nix-command flakes" "$@"
-        '';
-      in {
-        checks = {
-          pre-commit-check = pre-commit-hooks.lib.${system}.run {
-            src = ./.;
-            hooks = {
-              lint-solidity = {
-                enable = true;
-                files = "^contracts/contracts/";
-                entry = "lint-solidity";
-                types = [ "solidity" ];
-              };
-              check-format = {
-                enable = true;
-                entry = "treefmt --fail-on-change";
-              };
-              # The hook "clippy" that ships with nix-precommit-hooks is outdated.
-              cargo-clippy = {
-                enable = true;
-                description = "Lint Rust code.";
-                entry = "cargo-clippy --workspace -- -D warnings";
-                files = "\\.rs$";
-                pass_filenames = false;
-              };
-              cargo-sort = {
-                enable = true;
-                description = "Ensure Cargo.toml are sorted";
-                entry = "cargo sort -w";
-                pass_filenames = false;
-              };
-              license-header-c-style = {
-                enable = true;
-                description =
-                  "Ensure files with c-style comments have license header";
-                entry = ''
-                  insert_license --license-filepath .license-header  --comment-style "//"'';
-                types_or = [ "rust" "ts" "javascript" ];
-                excludes = [
-                  "bindings/mod\\.rs" # generated file
-                ];
-                pass_filenames = true;
-              };
-              license-header-solidity = {
-                enable = true;
-                description = "Ensure solidity files have license header";
-                entry = ''
-                  insert_license --license-filepath .license-header-solidity  --comment-style "//"'';
-                types = [ "solidity" ];
-                pass_filenames = true;
-              };
-              license-header-hash = {
-                enable = true;
-                description =
-                  "Ensure files with hash style comments have license header";
-                entry = ''
-                  insert_license --license-filepath .license-header --comment-style "#"'';
-                types_or = [ "bash" "python" "toml" "nix" ];
-                excludes = [ "poetry.lock" ];
-                pass_filenames = true;
-              };
-              license-header-html = {
-                enable = true;
-                description = "Ensure markdown files have license header";
-                entry = ''
-                  insert_license --license-filepath .license-header --comment-style "<!--| ~| -->"'';
-                types_or = [ "markdown" ];
-                pass_filenames = true;
-              };
+          curl
+          plantuml
+          stableRustToolchain
+
+          cargo-edit
+          cargo-sort
+        ] ++ lib.optionals stdenv.isDarwin [
+          # required to compile ethers-rs
+          darwin.apple_sdk.frameworks.Security
+          darwin.apple_sdk.frameworks.CoreFoundation
+
+          # https://github.com/NixOS/nixpkgs/issues/126182
+          libiconv
+        ] ++ lib.optionals (stdenv.system != "aarch64-darwin") [
+          cargo-watch # broken: https://github.com/NixOS/nixpkgs/issues/146349
+        ];
+      # nixWithFlakes allows pre v2.4 nix installations to use flake commands (like `nix flake update`)
+      nixWithFlakes = pkgs.writeShellScriptBin "nix" ''
+        exec ${pkgs.nixFlakes}/bin/nix --experimental-features "nix-command flakes" "$@"
+      '';
+      muslNixWithFlakes = pkgs.writeShellScriptBin "nix" ''
+        exec ${muslPkgs.nixFlakes}/bin/nix --experimental-features "nix-command flakes" "$@"
+      '';
+    in
+    {
+      checks = {
+        pre-commit-check = pre-commit-hooks.lib.${system}.run {
+          src = ./.;
+          hooks = {
+            lint-solidity = {
+              enable = true;
+              files = "^contracts/contracts/";
+              entry = "lint-solidity";
+              types = [ "solidity" ];
+            };
+            check-format = {
+              enable = true;
+              entry = "treefmt --fail-on-change";
+            };
+            # The hook "clippy" that ships with nix-precommit-hooks is outdated.
+            cargo-clippy = {
+              enable = true;
+              description = "Lint Rust code.";
+              entry = "cargo-clippy --workspace -- -D warnings";
+              files = "\\.rs$";
+              pass_filenames = false;
+            };
+            cargo-sort = {
+              enable = true;
+              description = "Ensure Cargo.toml are sorted";
+              entry = "cargo sort -w";
+              pass_filenames = false;
+            };
+            license-header-c-style = {
+              enable = true;
+              description =
+                "Ensure files with c-style comments have license header";
+              entry = ''
+                insert_license --license-filepath .license-header  --comment-style "//"'';
+              types_or = [ "rust" "ts" "javascript" ];
+              excludes = [
+                "bindings/mod\\.rs" # generated file
+              ];
+              pass_filenames = true;
+            };
+            license-header-solidity = {
+              enable = true;
+              description = "Ensure solidity files have license header";
+              entry = ''
+                insert_license --license-filepath .license-header-solidity  --comment-style "//"'';
+              types = [ "solidity" ];
+              pass_filenames = true;
+            };
+            license-header-hash = {
+              enable = true;
+              description =
+                "Ensure files with hash style comments have license header";
+              entry = ''
+                insert_license --license-filepath .license-header --comment-style "#"'';
+              types_or = [ "bash" "python" "toml" "nix" ];
+              excludes = [ "poetry.lock" ];
+              pass_filenames = true;
+            };
+            license-header-html = {
+              enable = true;
+              description = "Ensure markdown files have license header";
+              entry = ''
+                insert_license --license-filepath .license-header --comment-style "<!--| ~| -->"'';
+              types_or = [ "markdown" ];
+              pass_filenames = true;
             };
           };
         };
-        # A nix base image
-        packages.docker = pkgs.dockerTools.buildImage {
-          name = "nix-base-docker";
-          tag = "latest";
-          contents = with pkgs; [ curl coreutils bashInteractive cacert ];
-          config = { Env = [ "SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt" ]; };
-        };
-        devShell = pkgs.mkShell {
-          buildInputs = with pkgs;
+      };
+      # A nix base image
+      packages.docker = pkgs.dockerTools.buildImage {
+        name = "nix-base-docker";
+        tag = "latest";
+        contents = with pkgs; [ curl coreutils bashInteractive cacert ];
+        config = { Env = [ "SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt" ]; };
+      };
+      devShell = pkgs.mkShell {
+        buildInputs = with pkgs;
+          [
+            nixWithFlakes
+            go-ethereum
+            nodePackages.pnpm
+            mySolc
+            hivemind # process runner
+            nodejs-16_x # nodejs
+            jq
+            entr # watch files for changes, for example: ls contracts/*.sol | entr -c hardhat compile
+            treefmt # multi language formatter
+            nixpkgs-fmt
+            git # required for pre-commit hook installation
+            netcat-gnu # only used to check for open ports
+            cacert
+            mdbook # make-doc, documentation generation
+            moreutils # includes `ts`, used to add timestamps on CI
+          ] ++ myPython ++ rustDeps;
+
+        RUST_SRC_PATH = "${stableRustToolchain}/lib/rustlib/src/rust/library";
+        RUST_BACKTRACE = 1;
+        RUST_LOG = "info";
+
+        SOLCX_BINARY_PATH = "${mySolc}/bin";
+        SOLC_VERSION = mySolc.version;
+        SOLC_PATH = "${mySolc}/bin/solc";
+        # TODO: increase this when contract size limit is not a problem
+        SOLC_OPTIMIZER_RUNS = "20";
+
+        shellHook = ''
+          echo "Ensuring node dependencies are installed"
+          pnpm --recursive install
+
+          if [ ! -f .env ]; then
+            echo "Copying .env.sample to .env"
+            cp .env.sample .env
+          fi
+
+          echo "Exporting all vars in .env file"
+          set -a; source .env; set +a;
+
+          # on mac os `bin/pwd -P` returns the canonical path on case insenstive file-systems
+          my_pwd=$(/bin/pwd -P 2> /dev/null || pwd)
+
+          export CONTRACTS_DIR=''${my_pwd}/contracts
+          export HARDHAT_CONFIG=$CONTRACTS_DIR/hardhat.config.ts
+          export PATH=''${my_pwd}/node_modules/.bin:$PATH
+          export PATH=$CONTRACTS_DIR/node_modules/.bin:$PATH
+          export PATH=''${my_pwd}/bin:$PATH
+          export WALLET=''${my_pwd}/wallet
+
+          git config --local blame.ignoreRevsFile .git-blame-ignore-revs
+        ''
+        # install pre-commit hooks
+        + self.checks.${system}.pre-commit-check.shellHook;
+      };
+
+      devShells = {
+        # shell with all needed tools to build
+        # for a statically linked x86_64-unknown-linux-musl target.
+        # when running cargo build
+        staticShell = muslPkgs.mkShell {
+
+          # build as much as possible with musl
+          nativeBuildInputs = with muslPkgs;
             [
-              nixWithFlakes
+              muslNixWithFlakes
               go-ethereum
-              nodePackages.pnpm
               mySolc
               hivemind # process runner
-              nodejs-16_x # nodejs
-              jq
-              entr # watch files for changes, for example: ls contracts/*.sol | entr -c hardhat compile
-              treefmt # multi language formatter
-              nixpkgs-fmt
-              git # required for pre-commit hook installation
-              netcat-gnu # only used to check for open ports
-              cacert
-              mdbook # make-doc, documentation generation
-              moreutils # includes `ts`, used to add timestamps on CI
-            ] ++ myPython ++ rustDeps;
-
-          RUST_SRC_PATH = "${stableRustToolchain}/lib/rustlib/src/rust/library";
-          RUST_BACKTRACE = 1;
-          RUST_LOG = "info";
+            ] ++ muslRustDeps;
 
           SOLCX_BINARY_PATH = "${mySolc}/bin";
           SOLC_VERSION = mySolc.version;
           SOLC_PATH = "${mySolc}/bin/solc";
           # TODO: increase this when contract size limit is not a problem
           SOLC_OPTIMIZER_RUNS = "20";
+          CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER = "${muslPkgs.llvmPackages_latest.lld}/bin/lld";
+          RUSTFLAGS = "-C target-feature=+crt-static -L${opensslMusl.out}/lib/";
+          OPENSSL_STATIC = "true";
+          OPENSSL_INCLUDE_DIR = "${opensslMusl.dev}/include/";
+          OPENSSL_LIB_DIR = "${opensslMusl.dev}/lib/";
+          CARGO_BUILD_TARGET = "x86_64-unknown-linux-musl";
 
           shellHook = ''
             echo "Ensuring node dependencies are installed"
-            pnpm --recursive install
+            ${pkgs.nodePackages.pnpm}/bin/pnpm --recursive install
 
             if [ ! -f .env ]; then
               echo "Copying .env.sample to .env"
@@ -212,67 +275,11 @@
             export PATH=''${my_pwd}/bin:$PATH
             export WALLET=''${my_pwd}/wallet
 
-            git config --local blame.ignoreRevsFile .git-blame-ignore-revs
-          ''
-            # install pre-commit hooks
-            + self.checks.${system}.pre-commit-check.shellHook;
+            export PATH="${pkgs.nodePackages.pnpm}/bin:${pkgs.nodejs-16_x}/bin:${stableMuslRustToolchain}/bin:${pkgs.gcc}/bin/:$PATH"
+          '';
         };
-
-        devShells = {
-          # shell with all needed tools to build
-          # for a statically linked x86_64-unknown-linux-musl target.
-          # when running cargo build
-          staticShell = muslPkgs.mkShell {
-
-            # build as much as possible with musl
-            nativeBuildInputs = with muslPkgs;
-              [
-                muslNixWithFlakes
-                go-ethereum
-                mySolc
-                hivemind # process runner
-              ] ++ muslRustDeps;
-
-            SOLCX_BINARY_PATH = "${mySolc}/bin";
-            SOLC_VERSION = mySolc.version;
-            SOLC_PATH = "${mySolc}/bin/solc";
-            # TODO: increase this when contract size limit is not a problem
-            SOLC_OPTIMIZER_RUNS = "20";
-
-            shellHook = ''
-              echo "Ensuring node dependencies are installed"
-              ${pkgs.nodePackages.pnpm}/bin/pnpm --recursive install
-
-              if [ ! -f .env ]; then
-                echo "Copying .env.sample to .env"
-                cp .env.sample .env
-              fi
-
-              echo "Exporting all vars in .env file"
-              set -a; source .env; set +a;
-
-              # on mac os `bin/pwd -P` returns the canonical path on case insenstive file-systems
-              my_pwd=$(/bin/pwd -P 2> /dev/null || pwd)
-
-              export CONTRACTS_DIR=''${my_pwd}/contracts
-              export HARDHAT_CONFIG=$CONTRACTS_DIR/hardhat.config.ts
-              export PATH=''${my_pwd}/node_modules/.bin:$PATH
-              export PATH=$CONTRACTS_DIR/node_modules/.bin:$PATH
-              export PATH=''${my_pwd}/bin:$PATH
-              export WALLET=''${my_pwd}/wallet
-
-              export RUSTFLAGS='-C target-feature=+crt-static'
-              export CARGO_BUILD_TARGET='x86_64-unknown-linux-musl'
-              export OPENSSL_LIB_DIR='${opensslMusl.dev}/lib/'
-              export OPENSSL_INCLUDE_DIR='${opensslMusl.dev}/include/'
-              export OPENSSL_STATIC=true
-              export RUSTFLAGS='-L${opensslMusl.out}/lib/'
-              export CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER="${muslPkgs.llvmPackages_latest.lld}/bin/lld";
-              export PATH="${pkgs.nodePackages.pnpm}/bin:${pkgs.nodejs-16_x}/bin:${stableMuslRustToolchain}/bin:${pkgs.gcc}/bin/:$PATH"
-            '';
-          };
-        };
-      });
+      };
+    });
 
 }
 


### PR DESCRIPTION
Initial attempt at a nix shell that provides tooling for building statically linked rust binaries for the workspace. Usage: `nix develop .#staticShell -c cargo build --release`. Note that I have not tested this beyond checking that all binary targets compile, `wallet-api` runs, and `ldd wallet-api` comes back empty. I haven't set up a linux box with FDE to test on, and `nix-portable` fails to initialize the shell.

EDIT: what is used to format the `flake.nix`? I used `nixpkgs-fmt` and it looks like it changed a bunch of stuff.