### PR TITLE
Include policy in derivation of wrapped asset code.

### DIFF
--- a/contracts/contracts/AssetRegistry.sol
+++ b/contracts/contracts/AssetRegistry.sol
@@ -70,7 +70,7 @@ contract AssetRegistry {
         require(erc20Address != address(0), "Bad asset address");
         require(!isCapeAssetRegistered(newAsset), "Asset already registered");
 
-        _checkForeignAssetCode(newAsset.code, erc20Address, msg.sender);
+        _checkForeignAssetCode(newAsset.code, erc20Address, msg.sender, newAsset.policy);
 
         bytes32 key = keccak256(abi.encode(newAsset));
         assets[key] = erc20Address;
@@ -86,9 +86,10 @@ contract AssetRegistry {
     function _checkForeignAssetCode(
         uint256 assetDefinitionCode,
         address erc20Address,
-        address sponsor
+        address sponsor,
+        AssetPolicy memory policy
     ) internal pure {
-        bytes memory description = _computeAssetDescription(erc20Address, sponsor);
+        bytes memory description = _computeAssetDescription(erc20Address, sponsor, policy);
         require(
             assetDefinitionCode ==
                 BN254.fromLeBytesModOrder(
@@ -126,12 +127,19 @@ contract AssetRegistry {
     /// @param erc20Address address of the erc20 token
     /// @param sponsor address of the sponsor
     /// @return The asset description
-    function _computeAssetDescription(address erc20Address, address sponsor)
-        internal
-        pure
-        returns (bytes memory)
-    {
+    function _computeAssetDescription(
+        address erc20Address,
+        address sponsor,
+        AssetPolicy memory policy
+    ) internal pure returns (bytes memory) {
         return
-            bytes.concat("EsSCAPE ERC20", bytes20(erc20Address), "sponsored by", bytes20(sponsor));
+            bytes.concat(
+                "EsSCAPE ERC20",
+                bytes20(erc20Address),
+                "sponsored by",
+                bytes20(sponsor),
+                "policy",
+                abi.encode(policy)
+            );
     }
 }

--- a/contracts/contracts/AssetRegistry.sol
+++ b/contracts/contracts/AssetRegistry.sol
@@ -83,6 +83,7 @@ contract AssetRegistry {
     /// @param assetDefinitionCode The code of an asset definition
     /// @param erc20Address The ERC-20 address bound to the asset definition
     /// @param sponsor The sponsor address of this wrapped asset
+    /// @param policy asset policy
     function _checkForeignAssetCode(
         uint256 assetDefinitionCode,
         address erc20Address,
@@ -126,6 +127,7 @@ contract AssetRegistry {
     /// ERC-20 token and the address of the sponsor.
     /// @param erc20Address address of the erc20 token
     /// @param sponsor address of the sponsor
+    /// @param policy asset policy
     /// @return The asset description
     function _computeAssetDescription(
         address erc20Address,

--- a/contracts/contracts/mocks/TestCAPE.sol
+++ b/contracts/contracts/mocks/TestCAPE.sol
@@ -71,9 +71,10 @@ contract TestCAPE is CAPE {
     function checkForeignAssetCode(
         uint256 assetDefinitionCode,
         address erc20Address,
-        address sponsor
+        address sponsor,
+        AssetPolicy memory policy
     ) public pure {
-        _checkForeignAssetCode(assetDefinitionCode, erc20Address, sponsor);
+        _checkForeignAssetCode(assetDefinitionCode, erc20Address, sponsor, policy);
     }
 
     function checkDomesticAssetCode(uint256 assetDefinitionCode, uint256 internalAssetCode)
@@ -83,12 +84,12 @@ contract TestCAPE is CAPE {
         _checkDomesticAssetCode(assetDefinitionCode, internalAssetCode);
     }
 
-    function computeAssetDescription(address erc20Address, address sponsor)
-        public
-        pure
-        returns (bytes memory)
-    {
-        return _computeAssetDescription(erc20Address, sponsor);
+    function computeAssetDescription(
+        address erc20Address,
+        address sponsor,
+        AssetPolicy memory policy
+    ) public pure returns (bytes memory) {
+        return _computeAssetDescription(erc20Address, sponsor, policy);
     }
 
     function pendingDepositsLength() public view returns (uint256) {

--- a/contracts/rust/src/asset_registry.rs
+++ b/contracts/rust/src/asset_registry.rs
@@ -38,6 +38,7 @@ async fn test_asset_registry() -> Result<()> {
     let description = erc20_asset_description(
         &erc20_code,
         &EthereumAddr(sponsor.address().to_fixed_bytes()),
+        AssetPolicy::default(),
     );
     let asset_code = AssetCode::new_foreign(&description);
     let asset_def = AssetDefinition::new(asset_code, AssetPolicy::default())?;

--- a/contracts/rust/src/cape/reentrancy.rs
+++ b/contracts/rust/src/cape/reentrancy.rs
@@ -36,12 +36,13 @@ async fn test_reentrancy_guard() -> Result<()> {
 
     let sponsor = owner_of_erc20_tokens_client.address();
 
-    let description = erc20_asset_description(&erc20_code, &EthereumAddr(sponsor.to_fixed_bytes()));
-    let asset_def = AssetDefinition::new(
-        AssetCode::new_foreign(&description),
-        AssetPolicy::rand_for_test(rng),
-    )
-    .unwrap();
+    let policy = AssetPolicy::rand_for_test(rng);
+    let description = erc20_asset_description(
+        &erc20_code,
+        &EthereumAddr(sponsor.to_fixed_bytes()),
+        policy.clone(),
+    );
+    let asset_def = AssetDefinition::new(AssetCode::new_foreign(&description), policy).unwrap();
 
     // Prepare call to CAPE.deposit
     cape_contract_erc20_owner

--- a/contracts/rust/src/model.rs
+++ b/contracts/rust/src/model.rs
@@ -7,12 +7,14 @@
 
 #![deny(warnings)]
 
+use crate::types;
 use ark_serialize::*;
 use core::convert::TryFrom;
 use core::fmt::Debug;
+use ethers::abi::AbiEncode;
 use jf_cap::{
     errors::TxnApiError,
-    structs::{AssetDefinition, Nullifier, RecordCommitment, RecordOpening},
+    structs::{AssetDefinition, AssetPolicy, Nullifier, RecordCommitment, RecordOpening},
     transfer::TransferNote,
     txn_batch_verify, MerkleCommitment, MerkleFrontier, MerkleTree, NodeValue, TransactionNote,
 };
@@ -285,12 +287,19 @@ pub struct CapeContractState {
     pub erc20_deposits: Vec<RecordCommitment>,
 }
 
-pub fn erc20_asset_description(erc20_code: &Erc20Code, sponsor: &EthereumAddr) -> Vec<u8> {
+pub fn erc20_asset_description(
+    erc20_code: &Erc20Code,
+    sponsor: &EthereumAddr,
+    policy: AssetPolicy,
+) -> Vec<u8> {
+    let policy_bytes = AbiEncode::encode(types::AssetPolicy::from(policy));
     [
         "EsSCAPE ERC20".as_bytes(),
         (erc20_code.0).0.as_ref(),
         "sponsored by".as_bytes(),
         sponsor.0.as_ref(),
+        "policy".as_bytes(),
+        &policy_bytes,
     ]
     .concat()
 }
@@ -300,7 +309,7 @@ pub fn is_erc20_asset_def_valid(
     erc20_code: &Erc20Code,
     sponsor: &EthereumAddr,
 ) -> bool {
-    let description = erc20_asset_description(erc20_code, sponsor);
+    let description = erc20_asset_description(erc20_code, sponsor, def.policy_ref().clone());
     def.code.verify_foreign(&description).is_ok()
 }
 

--- a/contracts/rust/tests/combined/smoke_tests_deployed_contract.rs
+++ b/contracts/rust/tests/combined/smoke_tests_deployed_contract.rs
@@ -78,13 +78,16 @@ async fn smoke_tests() -> Result<()> {
         contracts_info.erc20_token_address.to_fixed_bytes(),
     ));
 
-    let sponsor = contracts_info.owner_of_erc20_tokens_client_address;
-    let description = erc20_asset_description(&erc20_code, &EthereumAddr(sponsor.to_fixed_bytes()));
-    let asset_code = AssetCode::new_foreign(&description);
-
     // We use an asset policy that does not track the user's credential.
     let asset_policy =
         AssetPolicy::rand_for_test(rng).set_cred_issuer_pub_key(CredIssuerPubKey::default());
+    let sponsor = contracts_info.owner_of_erc20_tokens_client_address;
+    let description = erc20_asset_description(
+        &erc20_code,
+        &EthereumAddr(sponsor.to_fixed_bytes()),
+        asset_policy.clone(),
+    );
+    let asset_code = AssetCode::new_foreign(&description);
 
     let asset_def = AssetDefinition::new(asset_code, asset_policy).unwrap();
     let asset_def_sol = asset_def.clone().generic_into::<sol::AssetDefinition>();

--- a/contracts/rust/tests/combined/unwrapping.rs
+++ b/contracts/rust/tests/combined/unwrapping.rs
@@ -51,13 +51,16 @@ async fn integration_test_unwrapping() -> Result<()> {
         contracts_info.erc20_token_address.to_fixed_bytes(),
     ));
 
-    let sponsor = contracts_info.owner_of_erc20_tokens_client_address;
-    let description = erc20_asset_description(&erc20_code, &EthereumAddr(sponsor.to_fixed_bytes()));
-    let asset_code = AssetCode::new_foreign(&description);
-
     // We use an asset policy that does not track the user's credential.
     let asset_policy =
         AssetPolicy::rand_for_test(rng).set_cred_issuer_pub_key(CredIssuerPubKey::default());
+    let sponsor = contracts_info.owner_of_erc20_tokens_client_address;
+    let description = erc20_asset_description(
+        &erc20_code,
+        &EthereumAddr(sponsor.to_fixed_bytes()),
+        asset_policy.clone(),
+    );
+    let asset_code = AssetCode::new_foreign(&description);
 
     let asset_def = AssetDefinition::new(asset_code, asset_policy).unwrap();
     let asset_def_sol = asset_def.clone().generic_into::<sol::AssetDefinition>();

--- a/contracts/rust/tests/combined/wrapped_assets_can_be_frozen.rs
+++ b/contracts/rust/tests/combined/wrapped_assets_can_be_frozen.rs
@@ -61,15 +61,18 @@ async fn integration_test_wrapped_assets_can_be_frozen() -> Result<()> {
         contracts_info.erc20_token_address.to_fixed_bytes(),
     ));
 
-    let sponsor = contracts_info.owner_of_erc20_tokens_client_address;
-    let description = erc20_asset_description(&erc20_code, &EthereumAddr(sponsor.to_fixed_bytes()));
-    let asset_code = AssetCode::new_foreign(&description);
-
     // We use an asset policy that does not track the user's credential but can handle freezing.
     let freeze_keypair = FreezerKeyPair::generate(rng);
     let asset_policy = AssetPolicy::rand_for_test(rng)
         .set_cred_issuer_pub_key(CredIssuerPubKey::default())
         .set_freezer_pub_key(freeze_keypair.pub_key());
+    let sponsor = contracts_info.owner_of_erc20_tokens_client_address;
+    let description = erc20_asset_description(
+        &erc20_code,
+        &EthereumAddr(sponsor.to_fixed_bytes()),
+        asset_policy.clone(),
+    );
+    let asset_code = AssetCode::new_foreign(&description);
 
     let asset_def = AssetDefinition::new(asset_code, asset_policy).unwrap();
     let asset_def_sol = asset_def.clone().generic_into::<sol::AssetDefinition>();

--- a/contracts/rust/tests/combined/wrapping.rs
+++ b/contracts/rust/tests/combined/wrapping.rs
@@ -107,9 +107,14 @@ async fn call_and_check_deposit_erc20(
 
     let sponsor = contracts_info.owner_of_erc20_tokens_client_address;
 
-    let description = erc20_asset_description(&erc20_code, &EthereumAddr(sponsor.to_fixed_bytes()));
+    let policy = AssetPolicy::rand_for_test(rng);
+    let description = erc20_asset_description(
+        &erc20_code,
+        &EthereumAddr(sponsor.to_fixed_bytes()),
+        policy.clone(),
+    );
     let asset_code = AssetCode::new_foreign(&description);
-    let asset_def = AssetDefinition::new(asset_code, AssetPolicy::rand_for_test(rng)).unwrap();
+    let asset_def = AssetDefinition::new(asset_code, policy).unwrap();
     let asset_def_sol = asset_def.clone().generic_into::<sol::AssetDefinition>();
 
     if register_asset {

--- a/wallet/src/wallet.rs
+++ b/wallet/src/wallet.rs
@@ -240,7 +240,8 @@ impl<'a, Backend: CapeWalletBackend<'a> + Sync + 'a> CapeWalletExt<'a, Backend>
         sponsor_addr: EthereumAddr,
         cap_asset_policy: AssetPolicy,
     ) -> Result<AssetDefinition, CapeWalletError> {
-        let description = erc20_asset_description(&erc20_code, &sponsor_addr);
+        let description =
+            erc20_asset_description(&erc20_code, &sponsor_addr, cap_asset_policy.clone());
         let code = AssetCode::new_foreign(&description);
         let asset = AssetDefinition::new(code, cap_asset_policy)
             .map_err(|source| CapeWalletError::CryptoError { source })?;
@@ -256,7 +257,11 @@ impl<'a, Backend: CapeWalletBackend<'a> + Sync + 'a> CapeWalletExt<'a, Backend>
         // Check that the asset code is properly constructed.
         asset
             .code
-            .verify_foreign(&erc20_asset_description(&erc20_code, &sponsor_addr))
+            .verify_foreign(&erc20_asset_description(
+                &erc20_code,
+                &sponsor_addr,
+                asset.policy_ref().clone(),
+            ))
             .map_err(|source| CapeWalletError::CryptoError { source })?;
 
         self.lock()


### PR DESCRIPTION
This ensures that assets with identical definitions have identical
codes, which upholds invariants expected by the wallet. It allows
the same user to sponsor the same ERC20 twice with different policies,
which previously lead to crashes.

Closes #1009