### PR TITLE
Deploy tokens from tokenOwner (2nd account)

### DIFF
--- a/contracts/deploy/00_cape.ts
+++ b/contracts/deploy/00_cape.ts
@@ -7,11 +7,7 @@
 
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 import { DeployFunction } from "hardhat-deploy/types";
-import { utils, BigNumber } from "ethers";
-
-function fromEnv(env_var: string, fallback: string): string {
-  return process.env[env_var] || fallback;
-}
+import { BigNumber } from "ethers";
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployments, getNamedAccounts } = hre;

--- a/contracts/deploy/10_token.ts
+++ b/contracts/deploy/10_token.ts
@@ -11,11 +11,11 @@ import { DeployFunction } from "hardhat-deploy/types";
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployments, getNamedAccounts } = hre;
   const { deploy } = deployments;
-  const { deployer } = await getNamedAccounts();
+  const { tokenOwner } = await getNamedAccounts();
 
-  await deploy("SimpleToken", { from: deployer, log: true });
-  await deploy("WETH", { from: deployer, log: true });
-  await deploy("DAI", { from: deployer, log: true });
+  await deploy("SimpleToken", { from: tokenOwner, log: true });
+  await deploy("WETH", { from: tokenOwner, log: true });
+  await deploy("DAI", { from: tokenOwner, log: true });
 };
 
 export default func;

--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -59,6 +59,7 @@ const config: HardhatUserConfig = {
   },
   namedAccounts: {
     deployer: 0,
+    tokenOwner: 1,
   },
   networks: {
     hardhat: {


### PR DESCRIPTION
Have not tested this with the GUI.

 When using metamask with the test mnemonic, use the 2nd Account (`0x70997970C51812dc3A010C7d01b50e0d17dc79C8`).

Note that the token addresses change to

    CAPE_TOKEN_ADDRESS_DAI=0x948B3c65b89DF0B4894ABE91E6D02FE579834F8F
    CAPE_TOKEN_ADDRESS_SIT=0x8464135c8F25Da09e49BC8782676a84730C318bC    
    CAPE_TOKEN_ADDRESS_WETH=0x71C95911E9a5D330f4D621842EC243EE1343292e