### PR TITLE
Allow cross-origin JSON-RPC requests for local demo

### DIFF
--- a/bin/cape-demo-local
+++ b/bin/cape-demo-local
@@ -78,7 +78,7 @@ export CAPE_FAUCET_MANAGER_MNEMONIC="$CAPE_FAUCET_WALLET_MNEMONIC"
 source <(target/release/faucet-wallet-test-setup)
 
 # Start a go-ethereum/geth node
-env GETH_PERIOD=1 run-geth --verbosity 1 &
+env GETH_PERIOD=1 run-geth --verbosity 1 --http.corsdomain "*" &
 
 # Wait for geth to be listening
 wait-port $GETH_PORT


### PR DESCRIPTION
I ran through the full demo script with this change, no issues, so at least it doesn't make things worse. Not sure how to test that it actually fixes the CORS issue but according to [the docs](https://geth.ethereum.org/docs/rpc/server#http-server) it should.