### PR TITLE
Revert "Use big integers to represent aggregate amounts (#1026)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5202,8 +5202,8 @@ dependencies = [
 
 [[package]]
 name = "seahorse"
-version = "0.2.3"
-source = "git+https://github.com/EspressoSystems/seahorse.git?tag=0.2.3#b0f9a00f5a42be2fc75c711855fd99623f902c98"
+version = "0.2.2"
+source = "git+https://github.com/EspressoSystems/seahorse.git?tag=0.2.2#8e78fd84a65f5422e1f69faea2f39b6425fd4eb8"
 dependencies = [
  "arbitrary",
  "arbitrary-wrappers 0.2.1 (git+https://github.com/EspressoSystems/arbitrary-wrappers.git?tag=0.2.1)",
@@ -5232,10 +5232,7 @@ dependencies = [
  "key-set",
  "lazy_static",
  "net",
- "num-bigint 0.4.3",
- "num-traits",
  "pipe",
- "primitive-types",
  "proptest",
  "rand_chacha 0.3.1",
  "reef",

--- a/contracts/rust/Cargo.toml
+++ b/contracts/rust/Cargo.toml
@@ -63,7 +63,7 @@ rand = "0.8.4"
 rand_chacha = "0.3.1"
 reef = { git = "https://github.com/EspressoSystems/reef.git", tag = "0.2.1" }
 regex = "1.5.5"
-seahorse = { git = "https://github.com/EspressoSystems/seahorse.git", tag = "0.2.3" }
+seahorse = { git = "https://github.com/EspressoSystems/seahorse.git", tag = "0.2.2" }
 serde = { version = "1.0.124", features = ["derive"] }
 serde_json = "1.0.67"
 sha3 = "0.9.1"

--- a/eqs/Cargo.toml
+++ b/eqs/Cargo.toml
@@ -32,7 +32,7 @@ net = { git = "https://github.com/EspressoSystems/net.git", tag = "0.2.1" }
 rand = "0.8.4"
 rand_chacha = { version = "0.3.1", features = ["serde1"] }
 reef = { git = "https://github.com/EspressoSystems/reef.git", tag = "0.2.1" }
-seahorse = { git = "https://github.com/EspressoSystems/seahorse.git", tag = "0.2.3", features = ["testing"] }
+seahorse = { git = "https://github.com/EspressoSystems/seahorse.git", tag = "0.2.2", features = ["testing"] }
 serde = { version = "1.0.123", features = ["derive", "rc"] }
 serde_derive = "1.0.118"
 serde_json = "1.0.61"

--- a/faucet/Cargo.toml
+++ b/faucet/Cargo.toml
@@ -46,7 +46,7 @@ key-set = { git = "https://github.com/EspressoSystems/key-set.git", tag = "0.2.2
 net = { git = "https://github.com/EspressoSystems/net.git", tag = "0.2.1" }
 rand = "0.8.5"
 rand_chacha = "0.3.1"
-seahorse = { git = "https://github.com/EspressoSystems/seahorse.git", tag = "0.2.3" }
+seahorse = { git = "https://github.com/EspressoSystems/seahorse.git", tag = "0.2.2" }
 serde = "1.0.136"
 serde_json = "1.0.67"
 snafu = "0.7.0"

--- a/faucet/src/bin/faucet-shower.rs
+++ b/faucet/src/bin/faucet-shower.rs
@@ -15,7 +15,7 @@ use cape_wallet::{
     backend::{CapeBackend, CapeBackendConfig},
     wallet::{CapeWallet, CapeWalletError},
 };
-use ethers::prelude::{Address, U256};
+use ethers::prelude::Address;
 use futures::stream::{iter, StreamExt};
 use jf_cap::structs::AssetCode;
 use rand_chacha::{
@@ -166,8 +166,7 @@ async fn main() {
     // can discover a record to transfer from.
     parent.await_key_scan(&parent_key.address()).await.unwrap();
     let balance = parent.balance(&AssetCode::native()).await;
-    let total_per_wallet = U256::from(opt.record_size) * opt.num_records;
-    if balance < total_per_wallet * opt.num_wallets {
+    if balance < opt.record_size * (opt.num_records as u64) * (opt.num_wallets as u64) {
         eprintln!(
             "Insufficient balance for transferring {} units to {} wallets: {}",
             opt.record_size * opt.num_records,
@@ -182,7 +181,7 @@ async fn main() {
     // already reported all of the mnemonics needed to recover the funds.
     println!(
         "Transferring {} units each to the following wallets:",
-        total_per_wallet
+        opt.record_size * opt.num_records
     );
     for (_, mnemonic, key) in &children {
         println!("{} {}", mnemonic, key);
@@ -217,8 +216,12 @@ async fn main() {
 
     // Wait for the children to report the new balances.
     for (wallet, _, key) in &children {
-        while wallet.balance(&AssetCode::native()).await < total_per_wallet {
-            eprintln!("Waiting for {} to receive {} tokens", key, total_per_wallet);
+        while wallet.balance(&AssetCode::native()).await < opt.record_size * opt.num_records {
+            eprintln!(
+                "Waiting for {} to receive {} tokens",
+                key,
+                opt.record_size * opt.num_records
+            );
             async_std::task::sleep(Duration::from_secs(1)).await;
         }
     }

--- a/faucet/src/faucet.rs
+++ b/faucet/src/faucet.rs
@@ -368,6 +368,6 @@ mod test {
         println!("Asset transferred.");
 
         // Check the balance.
-        retry(|| async { receiver.balance(&AssetCode::native()).await == grant_size.into() }).await;
+        retry(|| async { receiver.balance(&AssetCode::native()).await == grant_size }).await;
     }
 }

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -53,7 +53,7 @@ rand_chacha = "0.3.1"
 reef = { git = "https://github.com/EspressoSystems/reef.git", tag = "0.2.1" }
 regex = "1.5.4"
 relayer = { path = "../relayer", features = ["testing"] }
-seahorse = { git = "https://github.com/EspressoSystems/seahorse.git", tag = "0.2.3", features = ["testing"] }
+seahorse = { git = "https://github.com/EspressoSystems/seahorse.git", tag = "0.2.2", features = ["testing"] }
 serde = { version = "1.0.123", features = ["derive", "rc"] }
 serde_derive = "1.0.118"
 serde_json = "1.0.61"
@@ -77,7 +77,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 [dev-dependencies]
 ark-serialize = "0.3.0"
 reef = { git = "https://github.com/EspressoSystems/reef.git", tag = "0.2.1", features = ["testing"] }
-seahorse = { git = "https://github.com/EspressoSystems/seahorse.git", tag = "0.2.3", features = ["testing"] }
+seahorse = { git = "https://github.com/EspressoSystems/seahorse.git", tag = "0.2.2", features = ["testing"] }
 tracing-test = "0.2.1"
 
 [features]

--- a/wallet/src/backend.rs
+++ b/wallet/src/backend.rs
@@ -655,7 +655,7 @@ mod test {
             sender
                 .balance_breakdown(&sender_key.address(), &AssetCode::native())
                 .await
-                > 0u64.into()
+                > 0
         })
         .await;
         let total_balance = sender
@@ -710,7 +710,7 @@ mod test {
             receiver
                 .balance_breakdown(&receiver_key.address(), &AssetCode::native())
                 .await,
-            2u64.into()
+            2
         );
 
         // Transfer back, just to make sure the receiver is actually able to spend the records it
@@ -735,7 +735,7 @@ mod test {
             receiver
                 .balance_breakdown(&receiver_key.address(), &AssetCode::native())
                 .await,
-            0u64.into()
+            0
         );
     }
 
@@ -809,7 +809,7 @@ mod test {
             wrapper
                 .balance_breakdown(&wrapper_key.address(), &AssetCode::native())
                 .await
-                > 0u64.into()
+                > 0
         })
         .await;
         let total_native_balance = wrapper
@@ -875,14 +875,14 @@ mod test {
             sponsor
                 .balance_breakdown(&sponsor_key.address(), &AssetCode::native())
                 .await,
-            1u64.into()
+            1
         );
         // The transfer transaction caused the wrap record to be created.
         assert_eq!(
             wrapper
                 .balance_breakdown(&wrapper_key.address(), &cape_asset.code)
                 .await,
-            100u64.into()
+            100
         );
 
         assert!(wrapper.is_wrapped_asset(cape_asset.code).await);
@@ -904,13 +904,13 @@ mod test {
             wrapper
                 .balance_breakdown(&wrapper_key.address(), &cape_asset.code)
                 .await,
-            0u64.into()
+            0
         );
         assert_eq!(
             sponsor
                 .balance_breakdown(&sponsor_key.address(), &cape_asset.code)
                 .await,
-            100u64.into()
+            100
         );
 
         // Finally, withdraw the wrapped tokens back into the ERC20 token type.
@@ -929,7 +929,7 @@ mod test {
             sponsor
                 .balance_breakdown(&sponsor_key.address(), &cape_asset.code)
                 .await,
-            0u64.into()
+            0
         );
         assert_eq!(
             erc20_contract

--- a/wallet/src/bin/random-wallet-in-mem.rs
+++ b/wallet/src/bin/random-wallet-in-mem.rs
@@ -190,7 +190,7 @@ async fn create_backend_and_sender_wallet<'a>(
     while wallet
         .balance_breakdown(&address, &AssetCode::native())
         .await
-        == 0u64.into()
+        == 0
     {
         event!(Level::INFO, "waiting for initial balance");
         retry_delay().await;
@@ -349,7 +349,7 @@ async fn main() {
         while wallet
             .balance_breakdown(&pk.address(), &AssetCode::native())
             .await
-            == 0u64.into()
+            == 0
         {
             event!(Level::INFO, "waiting for initial balance");
             retry_delay().await;
@@ -452,7 +452,7 @@ async fn main() {
                     if sender
                         .balance_breakdown(&sender_address, &asset.definition.code)
                         .await
-                        > 0u64.into()
+                        > 0
                     {
                         asset_balances.push(asset.definition.code);
                     }

--- a/wallet/src/bin/random-wallet.rs
+++ b/wallet/src/bin/random-wallet.rs
@@ -210,7 +210,7 @@ async fn main() {
     while wallet
         .balance_breakdown(&address, &AssetCode::native())
         .await
-        == 0u64.into()
+        == 0
     {
         event!(Level::INFO, "waiting for initial balance");
         retry_delay().await;
@@ -250,7 +250,7 @@ async fn main() {
         }
     };
     // If we don't yet have a balance of our asset type, mint some.
-    if wallet.balance_breakdown(&address, &my_asset.code).await == 0u64.into() {
+    if wallet.balance_breakdown(&address, &my_asset.code).await == 0 {
         event!(Level::INFO, "minting my asset type {}", my_asset.code);
         loop {
             let txn = wallet
@@ -309,7 +309,7 @@ async fn main() {
                     if wallet
                         .balance_breakdown(&address, &asset.definition.code)
                         .await
-                        > 0u64.into()
+                        > 0
                     {
                         asset_balances.push(asset.definition.code);
                     }

--- a/wallet/src/mocks.rs
+++ b/wallet/src/mocks.rs
@@ -837,7 +837,7 @@ mod cape_wallet_tests {
                 .0
                 .balance_breakdown(&owner, &AssetCode::native())
                 .await,
-            initial_grant.into()
+            initial_grant
         );
 
         // Create an ERC20 code, sponsor address, and asset information.
@@ -901,7 +901,7 @@ mod cape_wallet_tests {
                 .0
                 .balance_breakdown(&owner, &cap_asset.code)
                 .await,
-            0u64.into()
+            0
         );
 
         // Submit dummy transactions to finalize the wrap.
@@ -933,14 +933,14 @@ mod cape_wallet_tests {
                 .0
                 .balance_breakdown(&owner, &AssetCode::native())
                 .await,
-            (initial_grant - mint_fee).into()
+            initial_grant - mint_fee
         );
         assert_eq!(
             wallets[0]
                 .0
                 .balance_breakdown(&owner, &cap_asset.code)
                 .await,
-            wrap_amount.into()
+            wrap_amount
         );
 
         // Burning an amount more than the wrapped asset should fail.
@@ -991,14 +991,14 @@ mod cape_wallet_tests {
                 .0
                 .balance_breakdown(&owner, &cap_asset.code)
                 .await,
-            0u64.into()
+            0
         );
         assert_eq!(
             wallets[0]
                 .0
                 .balance_breakdown(&owner, &AssetCode::native())
                 .await,
-            (initial_grant - mint_fee - burn_fee).into()
+            initial_grant - mint_fee - burn_fee
         );
 
         Ok(())
@@ -1086,14 +1086,14 @@ mod cape_wallet_tests {
                 .0
                 .balance_breakdown(&wrap_account, &cap_asset.code)
                 .await,
-            5u64.into()
+            5
         );
         assert_eq!(
             wallets[0]
                 .0
                 .balance_breakdown(&wrap_account, &AssetCode::native())
                 .await,
-            0u64.into()
+            0
         );
 
         // Burn the wrapped asset.
@@ -1114,7 +1114,7 @@ mod cape_wallet_tests {
                 .0
                 .balance_breakdown(&wrap_account, &cap_asset.code)
                 .await,
-            0u64.into()
+            0
         );
 
         Ok(())
@@ -1190,7 +1190,7 @@ mod cape_wallet_tests {
                 .0
                 .balance_breakdown(&owner, &cap_asset.code)
                 .await,
-            5u64.into()
+            5
         );
 
         // Burn the wrapped asset.
@@ -1209,7 +1209,7 @@ mod cape_wallet_tests {
                 .0
                 .balance_breakdown(&owner, &cap_asset.code)
                 .await,
-            2u64.into()
+            2
         );
 
         Ok(())
@@ -1290,7 +1290,7 @@ mod cape_wallet_tests {
                 .0
                 .balance_breakdown(&owner, &cap_asset.code)
                 .await,
-            5u64.into()
+            5
         );
 
         // Burn the wrapped asset.
@@ -1309,7 +1309,7 @@ mod cape_wallet_tests {
                 .0
                 .balance_breakdown(&owner, &cap_asset.code)
                 .await,
-            0u64.into()
+            0
         );
 
         Ok(())
@@ -1380,7 +1380,7 @@ mod cape_wallet_tests {
             "Dummy transactions submitted and wrap finalized: {}s",
             now.elapsed().as_secs_f32()
         );
-        assert_eq!(wallets[0].0.balance(&cap_asset.code).await, 3u64.into());
+        assert_eq!(wallets[0].0.balance(&cap_asset.code).await, 3);
 
         // Unwrap with change.
         wallets[0]
@@ -1389,7 +1389,7 @@ mod cape_wallet_tests {
             .await
             .unwrap();
         t.sync(&ledger, &wallets).await;
-        assert_eq!(wallets[0].0.balance(&cap_asset.code).await, 1u64.into());
+        assert_eq!(wallets[0].0.balance(&cap_asset.code).await, 1);
 
         // We should be able to view the change record from the unwrap, but _not_ the burned record.
         let records = wallets[0]
@@ -1408,6 +1408,6 @@ mod cape_wallet_tests {
             .await
             .unwrap();
         t.sync(&ledger, &wallets).await;
-        assert_eq!(wallets[0].0.balance(&cap_asset.code).await, 0u64.into());
+        assert_eq!(wallets[0].0.balance(&cap_asset.code).await, 0);
     }
 }

--- a/wallet/src/testing.rs
+++ b/wallet/src/testing.rs
@@ -296,7 +296,7 @@ pub async fn freeze_token<'a>(
 ) -> Result<TransactionReceipt<CapeLedger>, CapeWalletError> {
     let freeze_address = freezer.pub_keys().await[0].address();
     freezer
-        .freeze(&freeze_address, 1, asset, amount.into(), owner_address)
+        .freeze(&freeze_address, 1, asset, amount, owner_address)
         .await
 }
 
@@ -308,7 +308,7 @@ pub async fn unfreeze_token<'a>(
 ) -> Result<TransactionReceipt<CapeLedger>, CapeWalletError> {
     let unfreeze_address = freezer.pub_keys().await[0].address();
     freezer
-        .unfreeze(&unfreeze_address, 1, asset, amount.into(), owner_address)
+        .unfreeze(&unfreeze_address, 1, asset, amount, owner_address)
         .await
 }
 

--- a/wallet/src/ui.rs
+++ b/wallet/src/ui.rs
@@ -11,7 +11,7 @@ use crate::wallet::{CapeWallet, CapeWalletBackend, CapeWalletExt};
 use cap_rust_sandbox::ledger::{CapeLedger, CapeTransactionKind};
 use cap_rust_sandbox::model::Erc20Code;
 use espresso_macros::ser_test;
-use ethers::prelude::{Address, U256};
+use ethers::prelude::Address;
 use futures::stream::{iter, StreamExt};
 use jf_cap::{
     keys::{AuditorKeyPair, AuditorPubKey, FreezerKeyPair, FreezerPubKey, UserKeyPair, UserPubKey},
@@ -361,11 +361,11 @@ pub enum PrivateKey {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum BalanceInfo {
     /// The balance of a single asset, in a single account.
-    Balance(U256),
+    Balance(u64),
     /// All the balances of an account, by asset type with asset info.
-    AccountBalances(HashMap<AssetCode, (U256, AssetInfo)>),
+    AccountBalances(HashMap<AssetCode, (u64, AssetInfo)>),
     /// All the balances of all accounts owned by the wallet.
-    AllBalances(HashMap<UserAddress, HashMap<AssetCode, (U256, AssetInfo)>>),
+    AllBalances(HashMap<UserAddress, HashMap<AssetCode, (u64, AssetInfo)>>),
 }
 
 #[ser_test(ark(false))]
@@ -435,7 +435,7 @@ impl Ui for FreezerPubKey {
 pub struct Account {
     pub pub_key: String,
     pub records: Vec<Record>,
-    pub balances: HashMap<AssetCode, U256>,
+    pub balances: HashMap<AssetCode, u64>,
     pub assets: HashMap<AssetCode, AssetInfo>,
     pub description: String,
     pub used: bool,

--- a/wallet/src/wallet-api/main.rs
+++ b/wallet/src/wallet-api/main.rs
@@ -75,7 +75,7 @@ mod tests {
         testing::{port, retry},
         ui::*,
     };
-    use ethers::prelude::{Address, U256};
+    use ethers::prelude::Address;
     use jf_cap::{
         keys::{AuditorKeyPair, AuditorPubKey, FreezerKeyPair, FreezerPubKey, UserKeyPair},
         structs::{AssetCode, AssetDefinition as JfAssetDefinition, AssetPolicy},
@@ -590,7 +590,7 @@ mod tests {
             // let mut native_info = AssetInfo::default;
             // native_info.mint_info = Some("native")
             BalanceInfo::AccountBalances(
-                once((AssetCode::native(), (0u64.into(), assets[0].clone()))).collect()
+                once((AssetCode::native(), (0, assets[0].clone()))).collect()
             )
         );
         assert_eq!(
@@ -598,7 +598,7 @@ mod tests {
                 .get::<BalanceInfo>(&format!("getbalance/address/{}/asset/{}", addr, asset))
                 .await
                 .unwrap(),
-            BalanceInfo::Balance(0u64.into()),
+            BalanceInfo::Balance(0),
         );
         // If we query for a specific asset code, we should get a balance of 0 even if the wallet
         // doesn't know about this asset yet.
@@ -611,7 +611,7 @@ mod tests {
                 ))
                 .await
                 .unwrap(),
-            BalanceInfo::Balance(0u64.into()),
+            BalanceInfo::Balance(0),
         );
 
         // Should fail with an invalid address (we'll get an invalid address by serializing an asset
@@ -1229,7 +1229,7 @@ mod tests {
                 .get::<BalanceInfo>(&format!("getbalance/address/{}/asset/{}", recipient, asset))
                 .await
                 .unwrap()
-                == BalanceInfo::Balance(amount.into())
+                == BalanceInfo::Balance(amount)
         })
         .await;
         retry(|| async {
@@ -1241,7 +1241,7 @@ mod tests {
                 ))
                 .await
                 .unwrap()
-                == BalanceInfo::Balance((DEFAULT_NATIVE_AMT_IN_FAUCET_ADDR - fee).into())
+                == BalanceInfo::Balance(DEFAULT_NATIVE_AMT_IN_FAUCET_ADDR - fee)
         })
         .await;
     }
@@ -1280,11 +1280,10 @@ mod tests {
         // Get the source address with the wrapped asset.
         let mut source_addr: Option<UserAddress> = None;
         for address in info.addresses {
-            if BalanceInfo::Balance(DEFAULT_WRAPPED_AMT.into())
-                == server
-                    .get::<BalanceInfo>(&format!("getbalance/address/{}/asset/{}", address, asset))
-                    .await
-                    .unwrap()
+            if let BalanceInfo::Balance(DEFAULT_WRAPPED_AMT) = server
+                .get::<BalanceInfo>(&format!("getbalance/address/{}/asset/{}", address, asset))
+                .await
+                .unwrap()
             {
                 source_addr = Some(address);
                 break;
@@ -1334,7 +1333,7 @@ mod tests {
                 .get::<BalanceInfo>(&format!("getbalance/address/{}/asset/{}", source, asset))
                 .await
                 .unwrap()
-                == BalanceInfo::Balance(0u64.into())
+                == BalanceInfo::Balance(0)
         })
         .await;
         retry(|| async {
@@ -1346,7 +1345,7 @@ mod tests {
                 ))
                 .await
                 .unwrap()
-                == BalanceInfo::Balance((DEFAULT_NATIVE_AMT_IN_WRAPPER_ADDR - fee).into())
+                == BalanceInfo::Balance(DEFAULT_NATIVE_AMT_IN_WRAPPER_ADDR - fee)
         })
         .await;
     }
@@ -1379,15 +1378,14 @@ mod tests {
         // One of the addresses should have a non-zero balance of the native asset type.
         let mut found_native = false;
         for address in &info.addresses {
-            if BalanceInfo::Balance(DEFAULT_NATIVE_AMT_IN_FAUCET_ADDR.into())
-                == server
-                    .get::<BalanceInfo>(&format!(
-                        "getbalance/address/{}/asset/{}",
-                        address,
-                        AssetCode::native()
-                    ))
-                    .await
-                    .unwrap()
+            if let BalanceInfo::Balance(DEFAULT_NATIVE_AMT_IN_FAUCET_ADDR) = server
+                .get::<BalanceInfo>(&format!(
+                    "getbalance/address/{}/asset/{}",
+                    address,
+                    AssetCode::native()
+                ))
+                .await
+                .unwrap()
             {
                 found_native = true;
                 break;
@@ -1408,14 +1406,13 @@ mod tests {
         // One of the addresses should have the expected balance of the wrapped asset type.
         let mut found_wrapped = false;
         for address in &info.addresses {
-            if BalanceInfo::Balance(DEFAULT_WRAPPED_AMT.into())
-                == server
-                    .get::<BalanceInfo>(&format!(
-                        "getbalance/address/{}/asset/{}",
-                        address, wrapped_asset
-                    ))
-                    .await
-                    .unwrap()
+            if let BalanceInfo::Balance(DEFAULT_WRAPPED_AMT) = server
+                .get::<BalanceInfo>(&format!(
+                    "getbalance/address/{}/asset/{}",
+                    address, wrapped_asset
+                ))
+                .await
+                .unwrap()
             {
                 found_wrapped = true;
                 break;
@@ -1472,15 +1469,14 @@ mod tests {
         // of the server uses its own ledger. So we settle for an intra-wallet transfer.
         let mut unfunded_account = None;
         for address in info.addresses {
-            if BalanceInfo::Balance(0u64.into())
-                == server
-                    .get::<BalanceInfo>(&format!(
-                        "getbalance/address/{}/asset/{}",
-                        address,
-                        AssetCode::native()
-                    ))
-                    .await
-                    .unwrap()
+            if let BalanceInfo::Balance(0) = server
+                .get::<BalanceInfo>(&format!(
+                    "getbalance/address/{}/asset/{}",
+                    address,
+                    AssetCode::native()
+                ))
+                .await
+                .unwrap()
             {
                 unfunded_account = Some(address);
                 break;
@@ -1512,7 +1508,7 @@ mod tests {
                 ))
                 .await
                 .unwrap()
-                == BalanceInfo::Balance(100u64.into())
+                == BalanceInfo::Balance(100)
         })
         .await;
 
@@ -1526,7 +1522,7 @@ mod tests {
                 ))
                 .await
                 .unwrap()
-                == BalanceInfo::Balance((DEFAULT_NATIVE_AMT_IN_FAUCET_ADDR - 101).into())
+                == BalanceInfo::Balance(DEFAULT_NATIVE_AMT_IN_FAUCET_ADDR - 101)
         })
         .await;
 
@@ -1552,7 +1548,7 @@ mod tests {
                 ))
                 .await
                 .unwrap()
-                == BalanceInfo::Balance(200u64.into())
+                == BalanceInfo::Balance(200)
         })
         .await;
 
@@ -1689,15 +1685,14 @@ mod tests {
                     .await
                     .unwrap()
             );
-            if BalanceInfo::Balance(DEFAULT_NATIVE_AMT_IN_WRAPPER_ADDR.into())
-                == server
-                    .get::<BalanceInfo>(&format!(
-                        "getbalance/address/{}/asset/{}",
-                        address,
-                        AssetCode::native()
-                    ))
-                    .await
-                    .unwrap()
+            if let BalanceInfo::Balance(DEFAULT_NATIVE_AMT_IN_WRAPPER_ADDR) = server
+                .get::<BalanceInfo>(&format!(
+                    "getbalance/address/{}/asset/{}",
+                    address,
+                    AssetCode::native()
+                ))
+                .await
+                .unwrap()
             {
                 break address;
             }
@@ -2511,128 +2506,5 @@ mod tests {
         assert_eq!(ro.amount, 10);
         assert_eq!(ro.asset_def.code, asset.into());
         assert!(!ro.freeze_flag);
-    }
-
-    #[async_std::test]
-    async fn test_large_balance() {
-        // Set parameters for sponsor and wrap.
-        let erc20_code = Address::from([1u8; 20]);
-        let sponsor_addr = Address::from([2u8; 20]);
-
-        // Open a wallet.
-        let server = TestServer::new().await;
-        server
-            .post::<()>(&format!(
-                "newwallet/{}/{}/path/{}",
-                server.get::<String>("getmnemonic").await.unwrap(),
-                base64("my-password".as_bytes()),
-                server.path()
-            ))
-            .await
-            .unwrap();
-        server
-            .get::<TransactionReceipt<CapeLedger>>("populatefortest")
-            .await
-            .unwrap();
-
-        // Sponsor an asset.
-        let (asset, info) = server
-            .post::<(sol::AssetDefinition, String)>(&format!(
-                "buildsponsor/erc20/{:#x}/sponsor/{:#x}",
-                erc20_code, sponsor_addr
-            ))
-            .await
-            .unwrap();
-        server
-            .client
-            .post("importasset")
-            .body_json(&info)
-            .unwrap()
-            .send()
-            .await
-            .unwrap();
-        server
-            .client
-            .post(&format!(
-                "submitsponsor/erc20/{:#x}/sponsor/{:#x}",
-                erc20_code, sponsor_addr
-            ))
-            .body_json(&asset)
-            .unwrap()
-            .send()
-            .await
-            .unwrap();
-        let asset: JfAssetDefinition = asset.into();
-
-        // Create an address to receive the wrapped asset.
-        server.post::<PubKey>("newkey/sending").await.unwrap();
-        let info = server.get::<WalletSummary>("getinfo").await.unwrap();
-        let sending_key = &info.sending_keys[0];
-        let destination: UserAddress = sending_key.address().into();
-
-        // Wrap the maximum single-record amount, thrice, so that our total balance exceeds both the
-        // max single record amount and the max of a u64.
-        let max_record = 2u64.pow(63) - 1;
-        for _ in 0..3 {
-            let ro = server
-                .post::<sol::RecordOpening>(&format!(
-                    "buildwrap/destination/{}/asset/{}/amount/{}",
-                    destination, asset.code, max_record
-                ))
-                .await
-                .unwrap();
-            server
-                .client
-                .post(&format!("submitwrap/ethaddress/{:#x}", sponsor_addr))
-                .body_json(&ro)
-                .unwrap()
-                .send()
-                .await
-                .unwrap();
-        }
-
-        // Submit a dummy transaction to finalize the wraps.
-        server
-            .post::<TransactionReceipt<CapeLedger>>(&format!(
-                "send/asset/{}/recipient/{}/amount/1/fee/1",
-                AssetCode::native(),
-                destination,
-            ))
-            .await
-            .unwrap();
-
-        // Wait for the wraps to be finalized.
-        retry(|| async {
-            server
-                .get::<BalanceInfo>(&format!(
-                    "getbalance/address/{}/asset/{}",
-                    destination, asset.code
-                ))
-                .await
-                .unwrap()
-                != BalanceInfo::Balance(0u64.into())
-        })
-        .await;
-
-        // Make sure the balances are correct.
-        let expected_balance = U256::from_dec_str("27670116110564327421").unwrap();
-        assert_eq!(
-            server
-                .get::<BalanceInfo>(&format!(
-                    "getbalance/address/{}/asset/{}",
-                    destination, asset.code
-                ))
-                .await
-                .unwrap(),
-            BalanceInfo::Balance(expected_balance)
-        );
-        assert_eq!(
-            server
-                .get::<Account>(&format!("getaccount/{}", destination))
-                .await
-                .unwrap()
-                .balances[&asset.code],
-            expected_balance
-        );
     }
 }

--- a/wallet/src/wallet-api/web.rs
+++ b/wallet/src/wallet-api/web.rs
@@ -511,14 +511,14 @@ async fn populatefortest(req: tide::Request<WebState>) -> Result<tide::Response,
         wallet
             .balance_breakdown(&wrapped_asset_addr, &AssetCode::native())
             .await
-            != 0u64.into()
+            != 0
     })
     .await;
     retry(|| async {
         wallet
             .balance_breakdown(&wrapped_asset_addr, &asset_def.code)
             .await
-            != 0u64.into()
+            != 0
     })
     .await;
 

--- a/wallet/src/wallet.rs
+++ b/wallet/src/wallet.rs
@@ -335,8 +335,8 @@ impl<'a, Backend: CapeWalletBackend<'a> + Sync + 'a> CapeWalletExt<'a, Backend>
             .get(0)
             .ok_or(TransactionError::InsufficientBalance {
                 asset: *cap_asset,
-                required: amount.into(),
-                actual: 0u64.into(),
+                required: amount,
+                actual: 0,
             })?
             .address();
 


### PR DESCRIPTION
This reverts commit 2ceec5e9b9931787d8d68a6d1dbd0bdacc290c0a.

This commit changed the serialization of balances from numbers to
strings, since they can now exceed the capacity of a JSON number.
This caused a problem in the GUI where it was aggregating balances,
where it ended up concatenating strings rather than adding integers.

Since it is a nontrivial change to fix this in the GUI, with the demo
tomorrow, I am reverting this commit for now. Next week, we should
either fix the GUI to handle strings properly, or just do the balance
aggregation in the backend, or both. After that we can commit this
again.