### PR TITLE
Include pending transaction in nonce count by default

### DIFF
--- a/bin/cape-demo-local
+++ b/bin/cape-demo-local
@@ -52,7 +52,6 @@ export CAPE_EQS_NUM_CONFIRMATIONS=1 # More responsive local demo.
 export CAPE_RELAYER_PORT=50020
 export CAPE_RELAYER_URL="http://localhost:$CAPE_RELAYER_PORT"
 export CAPE_RELAYER_WALLET_MNEMONIC="organ task tattoo favorite salon effort matrix main original guitar drastic elder"
-export CAPE_RELAYER_NONCE_COUNT_RULE="pending"
 
 export CAPE_FAUCET_PORT=50030
 export CAPE_FAUCET_URL="http://localhost:$CAPE_FAUCET_PORT"

--- a/relayer/src/bin/minimal-relayer.rs
+++ b/relayer/src/bin/minimal-relayer.rs
@@ -50,7 +50,7 @@ struct MinimalRelayerOptions {
     #[structopt(
         long,
         env = "CAPE_RELAYER_NONCE_COUNT_RULE",
-        default_value = "mined",
+        default_value = "pending",
         verbatim_doc_comment
     )]
     nonce_count_rule: NonceCountRule,


### PR DESCRIPTION
This allows the relayer to include more than one Ethereum txn per block.

However it does not fix all race condition and submitting a new
transaction before the previous one is in the mempool will still lead to
an error.

We could use ethers-rs' nonce manager middleware to perform the nonce
count locally but this also present a some new challenges like handling
the case where the count is out of sync.

Close #1032 