### PR TITLE
Problem: relayer Eth txn easily runs out of gas

### DIFF
--- a/contracts/rust/src/assertion.rs
+++ b/contracts/rust/src/assertion.rs
@@ -68,3 +68,16 @@ impl EnsureMined for Option<TransactionReceipt> {
         self
     }
 }
+
+pub trait EnsureRejected {
+    fn ensure_rejected(self) -> Self;
+}
+
+impl EnsureRejected for Option<TransactionReceipt> {
+    fn ensure_rejected(self) -> Self {
+        if self.as_ref().unwrap().status.unwrap() != U64::from(0) {
+            panic!("Transaction not rejected");
+        }
+        self
+    }
+}

--- a/contracts/rust/src/cape/events.rs
+++ b/contracts/rust/src/cape/events.rs
@@ -80,6 +80,7 @@ mod tests {
             &connection.contract,
             block_with_memos.clone(),
             BlockNumber::Latest,
+            10_000_000, // gas limit
         )
         .await?
         .await?;


### PR DESCRIPTION
Solution: specify the gas limit manually.

Adds a `CAPE_RELAYER_GAS_LIMIT` env var so we can adjust the value
without changing code if needed.

It would be better to create a custom type for the gas limit to avoid
confusing it with other u64s. It may also we worth it to group all the
Ethereum config together instead of passing around so many variables.
In light of time pressure I went with what was quicker to implement.

Close #1056 