### PR TITLE
Run multiple random wallet instances against local backend

### DIFF
--- a/bin/run-random-wallet
+++ b/bin/run-random-wallet
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Copyright (c) 2022 Espresso Systems (espressosys.com)
+# This file is part of the Configurable Asset Privacy for Ethereum (CAPE) library.
+#
+# This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+#
+# usage:
+#
+#   run-random-wallet $name $seed
+#
+# usage examples:
+#
+#   run-random-wallet alice 0
+#   run-random-wallet bob 1
+set -euo pipefail
+
+mkdir -vp ~/temp
+
+env TEMPDIR=~/temp/$1 target/release/random-wallet-in-mem 5 \
+    --seed $2 \
+    --demo-connection=true \
+    --eqs-url http://localhost:50010 \
+    --address-book-url http://localhost:50000 \
+    --relayer-url http://localhost:50020 \
+    --faucet-url http://localhost:50030 \
+    --contract-address 0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9 2>&1 | tee ~/temp/$1.log

--- a/random-wallets.Procfile
+++ b/random-wallets.Procfile
@@ -1,0 +1,6 @@
+# Usage:
+#   1. Terminal: cape-demo-local
+#   2. Terminal: hivemind random-wallets.Procfile
+alice: run-random-wallet alice 1
+bob: sleep 20 && run-random-wallet bob 2
+charlie: sleep 40 && run-random-wallet charlie 3

--- a/relayer/src/lib.rs
+++ b/relayer/src/lib.rs
@@ -8,6 +8,7 @@
 #![doc = include_str!("../README.md")]
 
 #[warn(unused_imports)]
+use async_std::sync::{Arc, Mutex};
 use async_std::task;
 use cap_rust_sandbox::{
     cape::{submit_block::submit_cape_block_with_memos, BlockWithMemos, CapeBlock},
@@ -73,6 +74,22 @@ struct WebState {
     contract: CAPE<EthMiddleware>,
     nonce_count_rule: NonceCountRule,
     gas_limit: u64,
+    block_submission_mutex: Arc<Mutex<u64>>,
+}
+
+impl WebState {
+    fn new(
+        contract: CAPE<EthMiddleware>,
+        nonce_count_rule: NonceCountRule,
+        gas_limit: u64,
+    ) -> Self {
+        Self {
+            contract,
+            nonce_count_rule,
+            gas_limit,
+            block_submission_mutex: Arc::new(Mutex::new(0)),
+        }
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -137,16 +154,9 @@ async fn submit_endpoint(mut req: tide::Request<WebState>) -> Result<tide::Respo
             msg: err.to_string(),
         })
     })?;
-    let ret = relay(
-        &req.state().contract,
-        req.state().nonce_count_rule,
-        req.state().gas_limit,
-        transaction,
-        memos,
-        signature,
-    )
-    .await
-    .map_err(server_error)?;
+    let ret = relay(req.state(), transaction, memos, signature)
+        .await
+        .map_err(server_error)?;
     response(&req, ret)
 }
 /// This function implements the core logic of the relayer
@@ -159,9 +169,7 @@ async fn submit_endpoint(mut req: tide::Request<WebState>) -> Result<tide::Respo
 /// Waits for the transaction to be submitted and returns its hash. Does not wait for the
 /// transaction to be mined.
 async fn relay(
-    contract: &CAPE<EthMiddleware>,
-    nonce_count_rule: NonceCountRule,
-    gas_limit: u64,
+    web_state: &WebState,
     transaction: CapeModelTxn,
     memos: Vec<ReceiverMemo>,
     sig: Signature,
@@ -183,14 +191,10 @@ async fn relay(
         "Submitting CAPE block: {:?}",
         cap_rust_sandbox::types::CapeBlock::from(block.block.clone())
     );
-    submit_block(contract, nonce_count_rule, gas_limit, block).await
+    submit_block(web_state, block).await
 }
 
-async fn submit_empty_block(
-    contract: &CAPE<EthMiddleware>,
-    nonce_count_rule: NonceCountRule,
-    gas_limit: u64,
-) -> Result<H256, Error> {
+async fn submit_empty_block(web_state: &WebState) -> Result<H256, Error> {
     let miner = UserPubKey::default();
     let block = BlockWithMemos {
         block: CapeBlock::from_cape_transactions(vec![], miner.address()).map_err(|err| {
@@ -200,20 +204,22 @@ async fn submit_empty_block(
         })?,
         memos: vec![],
     };
-    submit_block(contract, nonce_count_rule, gas_limit, block).await
+    submit_block(web_state, block).await
 }
 
-async fn submit_block(
-    contract: &CAPE<EthMiddleware>,
-    nonce_count_rule: NonceCountRule,
-    gas_limit: u64,
-    block: BlockWithMemos,
-) -> Result<H256, Error> {
-    let pending = submit_cape_block_with_memos(contract, block, nonce_count_rule.into(), gas_limit)
-        .await
-        .map_err(|err| Error::Submission {
-            msg: err.to_string(),
-        })?;
+async fn submit_block(web_state: &WebState, block: BlockWithMemos) -> Result<H256, Error> {
+    let _guard = web_state.block_submission_mutex.lock().await;
+    let pending = submit_cape_block_with_memos(
+        &web_state.contract,
+        block,
+        web_state.nonce_count_rule.into(),
+        web_state.gas_limit,
+    )
+    .await
+    .map_err(|err| Error::Submission {
+        msg: err.to_string(),
+    })?;
+
     // The pending transaction itself doesn't serialize well, but all the relevant information is
     // contained in the transaction hash. The client can reconstruct the pending transaction from
     // the hash using a particular provider.
@@ -231,20 +237,22 @@ pub async fn submit_empty_block_loop(
     gas_limit: u64,
     empty_block_interval: Duration,
 ) -> Result<(), Error> {
+    let web_state = WebState::new(contract, nonce_count_rule, gas_limit);
     loop {
         async_std::task::sleep(empty_block_interval).await;
 
         // If the pending deposits queue is NOT empty, submit an empty block
 
         // The queue is empty if we cannot access the first element.
-        let queue_is_empty = contract
+        let queue_is_empty = web_state
+            .contract
             .pending_deposits(U256::from(0u64))
             .call()
             .await
             .is_err();
 
         if !queue_is_empty {
-            match submit_empty_block(&contract, nonce_count_rule, gas_limit).await {
+            match submit_empty_block(&web_state).await {
                 Ok(_) => {
                     event!(Level::INFO, "Empty block submitted.");
                 }
@@ -261,11 +269,7 @@ pub fn init_web_server(
     nonce_count_rule: NonceCountRule,
     gas_limit: u64,
 ) -> task::JoinHandle<Result<(), std::io::Error>> {
-    let mut web_server = tide::with_state(WebState {
-        contract,
-        nonce_count_rule,
-        gas_limit,
-    });
+    let mut web_server = tide::with_state(WebState::new(contract, nonce_count_rule, gas_limit));
     web_server.with(
         CorsMiddleware::new()
             .allow_methods("GET, POST".parse::<HeaderValue>().unwrap())
@@ -297,6 +301,17 @@ pub mod testing {
     };
     use reef::Ledger;
     use std::time::Duration;
+
+    #[allow(dead_code)]
+    impl WebState {
+        pub fn for_test(contract: &TestCAPE<EthMiddleware>) -> Self {
+            Self::new(
+                upcast_test_cape_to_cape(contract.clone()),
+                NonceCountRule::Pending,
+                DEFAULT_RELAYER_GAS_LIMIT.parse().unwrap(),
+            )
+        }
+    }
 
     /// `faucet_key_pair` - If not provided, a random faucet key pair will be generated.
     pub async fn deploy_cape_contract_with_faucet(
@@ -479,34 +494,24 @@ mod test {
             generate_transfer(&mut rng, &faucet, faucet_rec, user.pub_key(), &records);
         let provider = contract.client().provider().clone();
 
-        // Submit a transaction and verify that the 2 output commitments get added to the contract's
-        // records Merkle tree.
-        let hash = relay(
-            &upcast_test_cape_to_cape(contract.clone()),
+        let web_state = WebState::new(
+            upcast_test_cape_to_cape(contract.clone()),
             nonce_count_rule,
             DEFAULT_RELAYER_GAS_LIMIT.parse().unwrap(),
-            transaction.clone(),
-            memos.clone(),
-            sig.clone(),
-        )
-        .await
-        .unwrap();
+        );
+
+        // Submit a transaction and verify that the 2 output commitments get added to the contract's
+        // records Merkle tree.
+        let hash = relay(&web_state, transaction.clone(), memos.clone(), sig.clone())
+            .await
+            .unwrap();
         let receipt = PendingTransaction::new(hash, &provider);
         receipt.await.unwrap().ensure_mined();
         assert_eq!(contract.get_num_leaves().call().await.unwrap(), 3.into());
 
         // Submit an invalid transaction (e.g.the same one again) and check that the contract's
         // records Merkle tree is not modified.
-        match relay(
-            &upcast_test_cape_to_cape(contract.clone()),
-            nonce_count_rule,
-            DEFAULT_RELAYER_GAS_LIMIT.parse().unwrap(),
-            transaction,
-            memos,
-            sig,
-        )
-        .await
-        {
+        match relay(&web_state, transaction, memos, sig).await {
             Err(Error::Submission { .. }) => {}
             res => panic!("expected submission error, got {:?}", res),
         }
@@ -524,16 +529,14 @@ mod test {
         let provider = contract.client().provider().clone();
 
         // Submit transaction with insufficient gas limit.
-        let hash = relay(
-            &upcast_test_cape_to_cape(contract.clone()),
+        let web_state = WebState::new(
+            upcast_test_cape_to_cape(contract.clone()),
             NonceCountRule::Pending,
-            1_000_000,
-            transaction.clone(),
-            memos.clone(),
-            sig.clone(),
-        )
-        .await
-        .unwrap();
+            1_000_000, // gas limit
+        );
+        let hash = relay(&web_state, transaction.clone(), memos.clone(), sig.clone())
+            .await
+            .unwrap();
 
         PendingTransaction::new(hash, &provider)
             .await
@@ -542,9 +545,7 @@ mod test {
 
         // Submit transaction with sufficient gas limit.
         let hash = relay(
-            &upcast_test_cape_to_cape(contract.clone()),
-            NonceCountRule::Pending,
-            10_000_000,
+            &WebState::for_test(&contract),
             transaction.clone(),
             memos.clone(),
             sig.clone(),


### PR DESCRIPTION
This (commit 5a3da09427e27c5206dd08d77dcba49a99e5c17d) is an experiment to see if we can run multiple random wallet test instances against the local demo.

It almost works a bit too smoothly. I think in order to make it useful we need to simulate more realistic network conditions with higher latency and packet drops.
