### PR TITLE
Add 0x prefix to ethereum transaction hash

### DIFF
--- a/relayer/src/lib.rs
+++ b/relayer/src/lib.rs
@@ -225,7 +225,7 @@ async fn submit_block(web_state: &WebState, block: BlockWithMemos) -> Result<H25
     // the hash using a particular provider.
     event!(
         Level::INFO,
-        "Submitted Ethereum transaction hash ETH H256: {:x}",
+        "Submitted Ethereum transaction hash ETH H256: {:#x}",
         *pending
     );
     Ok(*pending)


### PR DESCRIPTION
It's more common to include the 0x prefix and this also makes it easier
to copy/paste into etherscan.