### PR TITLE
Feat/t1017 circuit 128 bit followup (v2)

### DIFF
--- a/contracts/rust/src/cape_e2e_test_mint.rs
+++ b/contracts/rust/src/cape_e2e_test_mint.rs
@@ -77,7 +77,7 @@ async fn test_mint_maybe_submit(should_submit: bool) -> Result<()> {
 
     let alice_rec1 = RecordOpening::new(
         &mut prng,
-        2u128.into(),
+        2u64.into(),
         coin.clone(),
         alice_key.pub_key(),
         FreezeFlag::Unfrozen,
@@ -96,7 +96,7 @@ async fn test_mint_maybe_submit(should_submit: bool) -> Result<()> {
     if let Some(contract) = contract.as_ref() {
         assert_eq!(
             contract.get_root_value().call().await.unwrap(),
-            U256::from(0u128)
+            U256::from(0u64)
         );
 
         contract
@@ -111,7 +111,7 @@ async fn test_mint_maybe_submit(should_submit: bool) -> Result<()> {
 
         assert_eq!(
             contract.get_num_leaves().call().await.unwrap(),
-            U256::from(1u128)
+            U256::from(1u64)
         );
 
         assert_eq!(
@@ -164,10 +164,10 @@ async fn test_mint_maybe_submit(should_submit: bool) -> Result<()> {
         let policy = AssetPolicy::default();
         let new_coin = AssetDefinition::new(code, policy).unwrap();
 
-        let (fee_info, _fee_ro) = TxnFeeInfo::new(&mut prng, fee_input, 1u128.into()).unwrap();
+        let (fee_info, _fee_ro) = TxnFeeInfo::new(&mut prng, fee_input, 1u64.into()).unwrap();
         let mint_ro = RecordOpening::new(
             &mut prng,
-            1u128.into(), /* 1 less, for the transaction fee */
+            1u64.into(), /* 1 less, for the transaction fee */
             new_coin,
             alice_key.pub_key(),
             FreezeFlag::Unfrozen,

--- a/contracts/rust/src/cape_e2e_test_transfer.rs
+++ b/contracts/rust/src/cape_e2e_test_transfer.rs
@@ -75,7 +75,7 @@ async fn test_2user_maybe_submit(should_submit: bool) -> Result<()> {
 
     let alice_rec1 = RecordOpening::new(
         &mut prng,
-        2u128.into(),
+        2u64.into(),
         coin.clone(),
         alice_key.pub_key(),
         FreezeFlag::Unfrozen,
@@ -94,7 +94,7 @@ async fn test_2user_maybe_submit(should_submit: bool) -> Result<()> {
     if let Some(contract) = contract.as_ref() {
         assert_eq!(
             contract.get_root_value().call().await.unwrap(),
-            U256::from(0u128)
+            U256::from(0u64)
         );
 
         contract
@@ -109,7 +109,7 @@ async fn test_2user_maybe_submit(should_submit: bool) -> Result<()> {
 
         assert_eq!(
             contract.get_num_leaves().call().await.unwrap(),
-            U256::from(1u128)
+            U256::from(1u64)
         );
 
         assert_eq!(
@@ -159,7 +159,7 @@ async fn test_2user_maybe_submit(should_submit: bool) -> Result<()> {
     let ((txn1, _, _), bob_rec) = {
         let bob_rec = RecordOpening::new(
             &mut prng,
-            1u128.into(), /* 1 less, for the transaction fee */
+            1u64.into(), /* 1 less, for the transaction fee */
             coin,
             bob_key.pub_key(),
             FreezeFlag::Unfrozen,

--- a/contracts/rust/src/test_utils.rs
+++ b/contracts/rust/src/test_utils.rs
@@ -177,7 +177,7 @@ pub fn generate_burn_tx(
         owner_keypair: faucet_key_pair,
     };
 
-    let txn_fee_info = TxnFeeInfo::new(&mut rng, fee_input, 10u128.into())
+    let txn_fee_info = TxnFeeInfo::new(&mut rng, fee_input, 10u64.into())
         .unwrap()
         .0;
 

--- a/doc/workflow/src/lib.rs
+++ b/doc/workflow/src/lib.rs
@@ -246,7 +246,7 @@ impl CapeContract {
 
         // 1.1 (optional) more sanity check on user provided CAPE asset record,
         // may help prevent users from crediting into some unspendable record or waste more gas.
-        assert!(ro.amount > 0u128.into());
+        assert!(ro.amount > 0u64.into());
         assert_ne!(ro.pub_key, UserPubKey::default()); // this would be EC point equality check
         assert_eq!(ro.freeze_flag, FreezeFlag::Unfrozen); // just a boolean flag
 

--- a/wallet/src/testing.rs
+++ b/wallet/src/testing.rs
@@ -23,7 +23,6 @@ use cap_rust_sandbox::deploy::EthMiddleware;
 use cap_rust_sandbox::ethereum::get_provider;
 use cap_rust_sandbox::ledger::CapeLedger;
 use cap_rust_sandbox::test_utils::keysets_for_test;
-use cap_rust_sandbox::types::GenericInto;
 use cap_rust_sandbox::types::SimpleToken;
 use eqs::configuration::Confirmations;
 use eqs::{configuration::EQSOptions, run_eqs};
@@ -165,7 +164,7 @@ pub async fn get_burn_amount<'a>(
         .collect::<Vec<_>>();
     if filtered.is_empty() {
         event!(Level::INFO, "No records to burn");
-        0u128.into()
+        0u64.into()
     } else {
         filtered[0].amount()
     }
@@ -331,10 +330,7 @@ pub async fn wrap_simple_token<'a>(
     let wrapper_eth_addr = wrapper.eth_address().await.unwrap();
     // Prepare to wrap: deposit some ERC20 tokens into the wrapper's ETH wallet.
     erc20_contract
-        .transfer(
-            wrapper_eth_addr.clone().into(),
-            amount.generic_into::<u128>().into(),
-        )
+        .transfer(wrapper_eth_addr.clone().into(), amount.into())
         .send()
         .await
         .unwrap()

--- a/wallet/src/wallet-api/main.rs
+++ b/wallet/src/wallet-api/main.rs
@@ -915,7 +915,7 @@ mod tests {
         let server = TestServer::new().await;
 
         // Set parameters for newasset.
-        let viewing_threshold = RecordAmount::from(10u128);
+        let viewing_threshold = RecordAmount::from(10u64);
         let view_amount = true;
         let view_address = false;
         let description = base64::encode_config(&[3u8; 32], base64::URL_SAFE_NO_PAD);
@@ -986,7 +986,7 @@ mod tests {
             .await
             .unwrap();
         assert!(asset.definition.viewing_key.is_none());
-        assert_eq!(asset.definition.viewing_threshold, 0u128.into());
+        assert_eq!(asset.definition.viewing_threshold, 0u64.into());
 
         // newasset should return an asset with no reveal threshold if it's not given.
         let asset = server
@@ -996,7 +996,7 @@ mod tests {
             ))
             .await
             .unwrap();
-        assert_eq!(asset.definition.viewing_threshold, 0u128.into());
+        assert_eq!(asset.definition.viewing_threshold, 0u64.into());
 
         // newasset should return an asset with a given symbol.
         let asset = server
@@ -1018,7 +1018,7 @@ mod tests {
         // Set parameters for /sponsor.
         let erc20_code = Address::from([1u8; 20]);
         let sponsor_addr = Address::from([2u8; 20]);
-        let viewing_threshold = RecordAmount::from(10u128);
+        let viewing_threshold = RecordAmount::from(10u64);
         let view_amount = true;
         let view_address = false;
 
@@ -1142,7 +1142,7 @@ mod tests {
             ))
             .await
             .unwrap();
-        assert_eq!(asset.policy.reveal_threshold, 0u128.into());
+        assert_eq!(asset.policy.reveal_threshold, 0u64.into());
         assert!(!AssetPolicy::from(asset.policy).is_auditor_pub_key_set());
 
         // buildsponsor should return an asset with no reveal threshold if it's not given.
@@ -1154,7 +1154,7 @@ mod tests {
                 ))
                 .await
                 .unwrap();
-        assert_eq!(asset.policy.reveal_threshold, 0u128.into());
+        assert_eq!(asset.policy.reveal_threshold, 0u64.into());
 
         // buildsponsor should create an asset with a given symbol and description.
         let erc20_code = Address::from([5u8; 20]);
@@ -2672,7 +2672,7 @@ mod tests {
             ))
             .await
             .unwrap();
-        assert_eq!(ro.amount, 10u128.into());
+        assert_eq!(ro.amount, 10u64.into());
         assert_eq!(ro.asset_def.code, asset.into());
         assert!(ro.freeze_flag);
         let ro = server
@@ -2682,7 +2682,7 @@ mod tests {
             ))
             .await
             .unwrap();
-        assert_eq!(ro.amount, 10u128.into());
+        assert_eq!(ro.amount, 10u64.into());
         assert_eq!(ro.asset_def.code, asset.into());
         assert!(!ro.freeze_flag);
     }

--- a/wallet/src/wallet-api/web.rs
+++ b/wallet/src/wallet-api/web.rs
@@ -35,7 +35,6 @@ use tide::{
 };
 
 pub const DEFAULT_ETH_ADDR: Address = H160([2; 20]);
-// TODO change these to Amount type
 pub const DEFAULT_WRAPPED_AMT: u128 = 1000;
 pub const DEFAULT_NATIVE_AMT_IN_FAUCET_ADDR: u128 = 500;
 pub const DEFAULT_NATIVE_AMT_IN_WRAPPER_ADDR: u128 = 400;
@@ -467,7 +466,9 @@ async fn populatefortest(req: tide::Request<WebState>) -> Result<tide::Response,
                 wrapped_asset_addr.clone(),
                 DEFAULT_NATIVE_AMT_IN_WRAPPER_ADDR,
             )],
-            1000 - DEFAULT_NATIVE_AMT_IN_FAUCET_ADDR - DEFAULT_NATIVE_AMT_IN_WRAPPER_ADDR,
+            DEFAULT_WRAPPED_AMT
+                - DEFAULT_NATIVE_AMT_IN_FAUCET_ADDR
+                - DEFAULT_NATIVE_AMT_IN_WRAPPER_ADDR,
         )
         .await
         .map_err(wallet_error)?;


### PR DESCRIPTION
- Remove some unnecessary type conversions.
- Use u64 for small uints instead of u128.
- Replace magic value `1000` with `DEFAULT_WRAPPED_AMOUNT`