### PR TITLE
Add wallet docs to documentation publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,9 @@ jobs:
       - name: Generate Docs
         run: nix-shell --run "prepend-timestamps make-doc"
 
+      - name: Generate Wallet
+        run: ./target/release/export-wallet-api-docs --api ./wallet/api/api.toml --assets ./wallet/public/ ./doc/mdbook/book/wallet
+
       - name: Deploy Docs
         uses: peaceiris/actions-gh-pages@v3
         if: ${{ github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
I believe this should generate the wallet api docs in a path that will be exported to https://cape.docs.espressosys.com/wallet/