### PR TITLE
Change RecordAmount to String for UI

### DIFF
--- a/wallet/src/ui.rs
+++ b/wallet/src/ui.rs
@@ -538,7 +538,7 @@ pub struct TransactionHistoryEntry {
     /// senders are and this field may be empty.
     pub senders: Vec<UserAddress>,
     /// Receivers and corresponding amounts.
-    pub receivers: Vec<(UserAddress, RecordAmount)>,
+    pub receivers: Vec<(UserAddress, String)>,
     /// Amount of change included in the transaction from the fee.
     ///
     /// Every transaction includes a fee, but the record used to pay the fee may be larger than the
@@ -549,7 +549,7 @@ pub struct TransactionHistoryEntry {
     /// change, which would be indicated by `Some(0)`. The amount of change may be unknown if, for
     /// example, this is a transaction we received from someone else, in which case we may not know
     /// how much of a fee they paid and how much change they expect to get.
-    pub fee_change: Option<RecordAmount>,
+    pub fee_change: Option<String>,
     /// Amount of change included in the transaction in the asset being transferred.
     ///
     /// For non-native transfers, the amount of the asset being transferred which is consumed by the
@@ -567,7 +567,7 @@ pub struct TransactionHistoryEntry {
     /// change, which would be indicated by `Some(0)`. The amount of change may be unknown if, for
     /// example, this is a transaction we received from someone else, and we do not hold the
     /// necessary viewing keys to inspect the change outputs of the transaction.
-    pub asset_change: Option<RecordAmount>,
+    pub asset_change: Option<String>,
     pub status: String,
 }
 
@@ -603,10 +603,10 @@ impl TransactionHistoryEntry {
             receivers: entry
                 .receivers
                 .into_iter()
-                .map(|(addr, amt)| (addr.into(), amt))
+                .map(|(addr, amt)| (addr.into(), amt.to_string()))
                 .collect(),
-            fee_change: entry.fee_change,
-            asset_change: entry.asset_change,
+            fee_change: entry.fee_change.map(|amt| amt.to_string()),
+            asset_change: entry.asset_change.map(|amt| amt.to_string()),
             status: match entry.receipt {
                 Some(receipt) => match wallet.transaction_status(&receipt).await {
                     Ok(status) => status.to_string(),

--- a/wallet/src/wallet-api/main.rs
+++ b/wallet/src/wallet-api/main.rs
@@ -1755,7 +1755,7 @@ mod tests {
         assert_eq!(history[0].senders, vec![src_address]);
         assert_eq!(
             history[0].receivers,
-            vec![(dst_address.clone(), 100u64.into())]
+            vec![(dst_address.clone(), "100".to_string())]
         );
         assert_eq!(history[0].status, "accepted");
 
@@ -1763,7 +1763,7 @@ mod tests {
         assert_eq!(history[1].asset, AssetCode::native());
         // We don't necessarily know the senders for the second transaction, since we allowed the
         // wallet to choose.
-        assert_eq!(history[1].receivers, vec![(dst_address, 100u64.into())]);
+        assert_eq!(history[1].receivers, vec![(dst_address, "100".to_string())]);
         assert_eq!(history[1].status, "accepted");
 
         // Check :from and :count.

--- a/wallet/src/wallet-api/main.rs
+++ b/wallet/src/wallet-api/main.rs
@@ -84,7 +84,6 @@ mod tests {
         asset_library::{Icon, VerifiedAssetLibrary},
         hd::{KeyTree, Mnemonic},
         txn_builder::{RecordInfo, TransactionReceipt},
-        RecordAmount,
     };
     use serde::de::DeserializeOwned;
     use std::collections::{HashMap, HashSet};
@@ -915,7 +914,7 @@ mod tests {
         let server = TestServer::new().await;
 
         // Set parameters for newasset.
-        let viewing_threshold = RecordAmount::from(10u64);
+        let viewing_threshold = "10".to_string();
         let view_amount = true;
         let view_address = false;
         let description = base64::encode_config(&[3u8; 32], base64::URL_SAFE_NO_PAD);
@@ -986,7 +985,7 @@ mod tests {
             .await
             .unwrap();
         assert!(asset.definition.viewing_key.is_none());
-        assert_eq!(asset.definition.viewing_threshold, 0u64.into());
+        assert_eq!(asset.definition.viewing_threshold, "0".to_string());
 
         // newasset should return an asset with no reveal threshold if it's not given.
         let asset = server
@@ -996,7 +995,7 @@ mod tests {
             ))
             .await
             .unwrap();
-        assert_eq!(asset.definition.viewing_threshold, 0u64.into());
+        assert_eq!(asset.definition.viewing_threshold, "0".to_string());
 
         // newasset should return an asset with a given symbol.
         let asset = server
@@ -1018,7 +1017,7 @@ mod tests {
         // Set parameters for /sponsor.
         let erc20_code = Address::from([1u8; 20]);
         let sponsor_addr = Address::from([2u8; 20]);
-        let viewing_threshold = RecordAmount::from(10u64);
+        let viewing_threshold = "10".to_string();
         let view_amount = true;
         let view_address = false;
 
@@ -1064,7 +1063,7 @@ mod tests {
             &FreezerPubKey::from(asset.policy.freezer_pk.clone()),
             freezing_key
         );
-        assert_eq!(asset.policy.reveal_threshold, viewing_threshold);
+        assert_eq!(asset.policy.reveal_threshold.to_string(), viewing_threshold);
         // Add the asset to the library.
         server
             .client
@@ -1142,7 +1141,7 @@ mod tests {
             ))
             .await
             .unwrap();
-        assert_eq!(asset.policy.reveal_threshold, 0u64.into());
+        assert_eq!(asset.policy.reveal_threshold, "0".to_string());
         assert!(!AssetPolicy::from(asset.policy).is_auditor_pub_key_set());
 
         // buildsponsor should return an asset with no reveal threshold if it's not given.
@@ -1154,7 +1153,7 @@ mod tests {
                 ))
                 .await
                 .unwrap();
-        assert_eq!(asset.policy.reveal_threshold, 0u64.into());
+        assert_eq!(asset.policy.reveal_threshold, "0".to_string());
 
         // buildsponsor should create an asset with a given symbol and description.
         let erc20_code = Address::from([5u8; 20]);
@@ -1892,13 +1891,13 @@ mod tests {
             Record {
                 address: address.clone(),
                 asset: AssetCode::native(),
-                amount: DEFAULT_NATIVE_AMT_IN_WRAPPER_ADDR.into(),
+                amount: DEFAULT_NATIVE_AMT_IN_WRAPPER_ADDR.to_string(),
                 uid: 2,
             },
             Record {
                 address,
                 asset: asset.definition.code,
-                amount: DEFAULT_WRAPPED_AMT.into(),
+                amount: DEFAULT_WRAPPED_AMT.to_string(),
                 uid: 3,
             },
         ];
@@ -2672,7 +2671,7 @@ mod tests {
             ))
             .await
             .unwrap();
-        assert_eq!(ro.amount, 10u64.into());
+        assert_eq!(ro.amount, "10".to_string());
         assert_eq!(ro.asset_def.code, asset.into());
         assert!(ro.freeze_flag);
         let ro = server
@@ -2682,7 +2681,7 @@ mod tests {
             ))
             .await
             .unwrap();
-        assert_eq!(ro.amount, 10u64.into());
+        assert_eq!(ro.amount, "10".to_string());
         assert_eq!(ro.asset_def.code, asset.into());
         assert!(!ro.freeze_flag);
     }


### PR DESCRIPTION
Serializes amount fields in `ui.rs` as `String` rather than `RecordAmount`.

Closes https://github.com/EspressoSystems/cape/issues/1115.