### PR TITLE
EQS: add endpoint to get CAPE contract address

### DIFF
--- a/eqs/api/api.toml
+++ b/eqs/api/api.toml
@@ -73,3 +73,7 @@ DOC = "Responds with JSON {\"status\": \"available\"}."
 PATH = [ "get_wrapped_erc20_address/:asset" ]
 ":asset" = "TaggedBase64"
 DOC = "Returns contract address for wrapped asset, or None for domestic asset."
+
+[route.get_cape_contract_address]
+PATH = [ "get_cape_contract_address" ]
+DOC = "Returns the Ethereum address of the CAPE contract the EQS is connected to."

--- a/eqs/src/routes.rs
+++ b/eqs/src/routes.rs
@@ -33,6 +33,7 @@ pub enum ApiRouteKey {
     get_transaction_by_hash,
     healthcheck,
     get_wrapped_erc20_address,
+    get_cape_contract_address,
 }
 
 /// Verify that every variant of enum ApiRouteKey is defined in api.toml
@@ -205,6 +206,18 @@ pub async fn healthcheck() -> Result<tide::Response, tide::Error> {
         .build())
 }
 
+/// Return the Ethereum address of the CAPE contract the EQS is connected to.
+pub async fn get_cape_contract_address(
+    query_result_state: &QueryResultState,
+) -> Result<Address, tide::Error> {
+    query_result_state.contract_address.ok_or_else(|| {
+        tide::Error::from_str(
+            tide::StatusCode::InternalServerError,
+            "EQS not connected to CAPE contract",
+        )
+    })
+}
+
 pub async fn dispatch_url(
     req: tide::Request<WebState>,
     route_pattern: &str,
@@ -234,5 +247,8 @@ pub async fn dispatch_url(
             &req,
             get_wrapped_erc20_address(bindings, query_state).await?,
         ),
+        ApiRouteKey::get_cape_contract_address => {
+            response(&req, get_cape_contract_address(query_state).await?)
+        }
     }
 }


### PR DESCRIPTION
I did briefly try to add the wallet `/getinfo` part as well since there aren't any tests in the EQS. However at some point I had to make changes to seahorse. So I figured I'd go for the bare minimum first, without tests or integration.

```
 curl http://127.0.0.1:50010/get_cape_contract_address                                                                     0.004s  feat/t1120-eqs-cape-address  ❄  20:15:16 
"0xdc64a140aa3e981100a9beca4e685f962f0cf6c9"

Close #1120 