### PR TITLE
Store contract address in wallet metadata file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5278,7 +5278,7 @@ dependencies = [
 [[package]]
 name = "seahorse"
 version = "0.2.3"
-source = "git+https://github.com/EspressoSystems/seahorse.git?branch=release-0.2#56436b8425a1832c9e453a7a44bb8a88ade54100"
+source = "git+https://github.com/EspressoSystems/seahorse.git?branch=release-0.2#e3a4fc9195cf491871fdd3d2f6e34752d8021c92"
 dependencies = [
  "arbitrary",
  "arbitrary-wrappers",

--- a/wallet/src/backend.rs
+++ b/wallet/src/backend.rs
@@ -651,6 +651,15 @@ impl<'a> CapeWalletBackend<'a> for CapeBackend<'a> {
     async fn wait_for_eqs(&self) -> Result<(), CapeWalletError> {
         self.wait_for_eqs().await
     }
+
+    async fn contract_address(&self) -> Result<Erc20Code, CapeWalletError> {
+        Ok(self.storage.lock().await.meta().contract.clone())
+    }
+
+    async fn latest_contract_address(&self) -> Result<Erc20Code, CapeWalletError> {
+        let address: Address = self.get_eqs("get_cape_contract_address").await?;
+        Ok(address.into())
+    }
 }
 
 fn gen_proving_keys(srs: &UniversalParam) -> ProverKeySet<key_set::OrderByOutputs> {

--- a/wallet/src/bin/official-asset-library.rs
+++ b/wallet/src/bin/official-asset-library.rs
@@ -9,6 +9,7 @@ use async_std::task::sleep;
 use cap_rust_sandbox::universal_param::UNIVERSAL_PARAM;
 use cape_wallet::{
     backend::{CapeBackend, CapeBackendConfig},
+    loader::CapeLoader,
     CapeWallet, CapeWalletError, CapeWalletExt,
 };
 use ethers::{prelude::Address, providers::Middleware};
@@ -22,7 +23,6 @@ use rand_chacha::{rand_core::SeedableRng, ChaChaRng};
 use seahorse::{
     asset_library::{Icon, VerifiedAssetLibrary},
     hd::{KeyTree, Mnemonic},
-    loader::{Loader, LoaderMetadata},
     txn_builder::TransactionStatus,
     AssetInfo,
 };
@@ -77,7 +77,7 @@ impl Asset {
 
     async fn create<'a>(
         self,
-        wallet: &mut CapeWallet<'a, CapeBackend<'a, LoaderMetadata>>,
+        wallet: &mut CapeWallet<'a, CapeBackend<'a>>,
         pub_key: &UserPubKey,
         icon_dir: &Path,
         faucet_url: &Url,
@@ -277,7 +277,6 @@ enum Command {
 ///     CAPE_RELAYER_URL
 ///     CAPE_ADDRESS_BOOK_URL
 ///     CAPE_FAUCET_URL
-///     CAPE_CONTRACT_ADDRESS
 ///     CAPE_WEB3_PROVIDER_URL
 #[derive(StructOpt)]
 struct GenerateCommand {
@@ -334,10 +333,6 @@ struct GenerateCommand {
     )]
     faucet_url: Url,
 
-    /// Address of the CAPE smart contract.
-    #[structopt(long, env = "CAPE_CONTRACT_ADDRESS")]
-    contract_address: Address,
-
     /// URL for Ethers HTTP Provider
     #[structopt(long, env = "CAPE_WEB3_PROVIDER_URL")]
     rpc_url: Url,
@@ -352,15 +347,18 @@ impl GenerateCommand {
         // we use a random password and storage location.
         let dir = TempDir::new("asset-library-wallet").unwrap();
         let mut rng = ChaChaRng::from_entropy();
-        let mut loader = Loader::from_literal(
+        let mut loader = CapeLoader::from_literal(
             Some(self.cape_mnemonic.to_string()),
             Alphanumeric.sample_string(&mut rng, 16),
             dir.path().to_owned(),
+            CapeLoader::latest_contract(self.eqs_url.clone())
+                .await
+                .map_err(wallet_error)?,
         );
         let backend = CapeBackend::new(
             &*UNIVERSAL_PARAM,
             CapeBackendConfig {
-                cape_contract: Some((self.rpc_url, self.contract_address)),
+                web3_provider: Some(self.rpc_url),
                 eth_mnemonic: Some(self.eth_mnemonic.to_string()),
                 eqs_url: self.eqs_url,
                 relayer_url: self.relayer_url,

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -17,6 +17,7 @@
 
 pub mod backend;
 pub mod disco;
+pub mod loader;
 pub mod ui;
 pub mod wallet;
 

--- a/wallet/src/loader.rs
+++ b/wallet/src/loader.rs
@@ -1,0 +1,117 @@
+// Copyright (c) 2022 Espresso Systems (espressosys.com)
+// This file is part of the Configurable Asset Privacy for Ethereum (CAPE) library.
+//
+// This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+//! Tools for creating, loading, and verifying CAPE wallets.
+
+use crate::CapeWalletError;
+use cap_rust_sandbox::{ledger::CapeLedger, model::Erc20Code};
+use eqs::errors::EQSNetError;
+use ethers::prelude::Address;
+use net::client::{parse_error_body, response_body};
+use seahorse::{
+    hd::KeyTree,
+    loader::{Loader, LoaderMetadata, WalletLoader},
+    reader::Reader,
+};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+use surf::Url;
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct CapeMetadata {
+    pub load: LoaderMetadata,
+    pub contract: Erc20Code,
+}
+
+pub struct CapeLoader {
+    inner: Loader,
+    contract: Erc20Code,
+}
+
+impl CapeLoader {
+    pub fn new(dir: PathBuf, input: Reader, contract: Erc20Code) -> Self {
+        Self {
+            inner: Loader::new(dir, input),
+            contract,
+        }
+    }
+
+    pub fn from_literal(
+        mnemonic: Option<String>,
+        password: String,
+        dir: PathBuf,
+        contract: Erc20Code,
+    ) -> Self {
+        Self {
+            inner: Loader::from_literal(mnemonic, password, dir),
+            contract,
+        }
+    }
+
+    pub fn recovery(mnemonic: String, password: String, dir: PathBuf, contract: Erc20Code) -> Self {
+        Self {
+            inner: Loader::recovery(mnemonic, password, dir),
+            contract,
+        }
+    }
+
+    pub async fn latest_contract(eqs: Url) -> Result<Erc20Code, CapeWalletError> {
+        let eqs: surf::Client = surf::Config::default()
+            .set_base_url(eqs)
+            .try_into()
+            .expect("Failed to configure EQS client");
+        let eqs = eqs.with(parse_error_body::<EQSNetError>);
+        let mut res = eqs
+            .get("get_cape_contract_address")
+            .send()
+            .await
+            .map_err(|err| CapeWalletError::Failed {
+                msg: format!("EQS error: {}", err),
+            })?;
+        let address: Address =
+            response_body(&mut res)
+                .await
+                .map_err(|err| CapeWalletError::Failed {
+                    msg: format!("Error parsing EQS response: {}", err),
+                })?;
+        Ok(address.into())
+    }
+
+    pub fn path(&self) -> &Path {
+        self.inner.path()
+    }
+}
+
+impl WalletLoader<CapeLedger> for CapeLoader {
+    type Meta = CapeMetadata;
+
+    fn location(&self) -> PathBuf {
+        WalletLoader::<CapeLedger>::location(&self.inner)
+    }
+
+    fn create(&mut self) -> Result<(CapeMetadata, KeyTree), CapeWalletError> {
+        let (load, key) = self.inner.create()?;
+        Ok((
+            CapeMetadata {
+                load,
+                contract: self.contract.clone(),
+            },
+            key,
+        ))
+    }
+
+    fn load(&mut self, meta: &mut CapeMetadata) -> Result<KeyTree, CapeWalletError> {
+        if meta.contract != self.contract {
+            return Err(CapeWalletError::Failed {
+                msg: format!("keystore was created for CAPE contract at {}, but the current CAPE contract is {}",
+                    meta.contract, self.contract)
+            });
+        }
+
+        self.inner.load(&mut meta.load)
+    }
+}

--- a/wallet/src/mocks.rs
+++ b/wallet/src/mocks.rs
@@ -744,6 +744,16 @@ impl<'a, Meta: Serialize + DeserializeOwned + Send> CapeWalletBackend<'a>
         // No need to wait for the mock EQS.
         Ok(())
     }
+
+    async fn contract_address(&self) -> Result<Erc20Code, CapeWalletError> {
+        // We're mocking a deployment of the CAPE contract, so the address can be anything we want.
+        Ok(Erc20Code::default())
+    }
+
+    async fn latest_contract_address(&self) -> Result<Erc20Code, CapeWalletError> {
+        // This just has to match `contract_address`, so that the contract appears up to date.
+        Ok(Erc20Code::default())
+    }
 }
 
 fn cape_to_wallet_err(err: CapeValidationError) -> WalletError<CapeLedger> {

--- a/wallet/src/testing.rs
+++ b/wallet/src/testing.rs
@@ -135,7 +135,7 @@ pub async fn create_test_network<'a>(
     )
 }
 
-pub async fn fund_eth_wallet<'a>(wallet: &mut CapeWallet<'a, CapeBackend<'a, ()>>) {
+pub async fn fund_eth_wallet<'a>(wallet: &mut CapeWallet<'a, CapeBackend<'a>>) {
     // Fund the Ethereum wallets for contract calls.
     let provider = get_provider().interval(Duration::from_millis(100u64));
     let accounts = provider.get_accounts().await.unwrap();
@@ -154,7 +154,7 @@ pub async fn fund_eth_wallet<'a>(wallet: &mut CapeWallet<'a, CapeBackend<'a, ()>
 }
 
 pub async fn get_burn_amount<'a>(
-    wallet: &CapeWallet<'a, CapeBackend<'a, ()>>,
+    wallet: &CapeWallet<'a, CapeBackend<'a>>,
     asset: AssetCode,
 ) -> RecordAmount {
     // get records for this this asset type
@@ -235,7 +235,7 @@ impl Distribution<OperationType> for Standard {
 /// Mint a new token with the given wallet and add it's freezer and audit keys to
 /// to the Asset Policy
 pub async fn mint_token<'a>(
-    wallet: &mut CapeWallet<'a, CapeBackend<'a, ()>>,
+    wallet: &mut CapeWallet<'a, CapeBackend<'a>>,
 ) -> Result<(AssetDefinition, Option<TransactionReceipt<CapeLedger>>), CapeWalletError> {
     let freeze_key = &wallet.freezer_pub_keys().await[0];
     let audit_key = &wallet.auditor_pub_keys().await[0];
@@ -272,7 +272,7 @@ pub async fn mint_token<'a>(
 /// Return records the freezer has access to freeze or unfreeze but does not own.
 /// Will only return records with freeze_flag the same as the frozen arg.
 pub async fn find_freezable_records<'a>(
-    freezer: &CapeWallet<'a, CapeBackend<'a, ()>>,
+    freezer: &CapeWallet<'a, CapeBackend<'a>>,
     frozen: FreezeFlag,
 ) -> Vec<RecordInfo> {
     let pks: HashSet<UserPubKey> = freezer.pub_keys().await.into_iter().collect();
@@ -296,7 +296,7 @@ pub async fn find_freezable_records<'a>(
 }
 
 pub async fn freeze_token<'a>(
-    freezer: &mut CapeWallet<'a, CapeBackend<'a, ()>>,
+    freezer: &mut CapeWallet<'a, CapeBackend<'a>>,
     asset: &AssetCode,
     amount: impl Into<U256>,
     owner_address: UserAddress,
@@ -308,7 +308,7 @@ pub async fn freeze_token<'a>(
 }
 
 pub async fn unfreeze_token<'a>(
-    freezer: &mut CapeWallet<'a, CapeBackend<'a, ()>>,
+    freezer: &mut CapeWallet<'a, CapeBackend<'a>>,
     asset: &AssetCode,
     amount: impl Into<U256>,
     owner_address: UserAddress,
@@ -320,7 +320,7 @@ pub async fn unfreeze_token<'a>(
 }
 
 pub async fn wrap_simple_token<'a>(
-    wrapper: &mut CapeWallet<'a, CapeBackend<'a, ()>>,
+    wrapper: &mut CapeWallet<'a, CapeBackend<'a>>,
     wrapper_addr: &UserAddress,
     cape_asset: AssetDefinition,
     erc20_contract: &SimpleToken<EthMiddleware>,
@@ -351,7 +351,7 @@ pub async fn wrap_simple_token<'a>(
 }
 
 pub async fn sponsor_simple_token<'a>(
-    sponsor: &mut CapeWallet<'a, CapeBackend<'a, ()>>,
+    sponsor: &mut CapeWallet<'a, CapeBackend<'a>>,
     erc20_contract: &SimpleToken<EthMiddleware>,
 ) -> Result<AssetDefinition, CapeWalletError> {
     let sponsor_eth_addr = sponsor.eth_address().await.unwrap();
@@ -366,7 +366,7 @@ pub async fn sponsor_simple_token<'a>(
 }
 
 pub async fn burn_token<'a>(
-    burner: &mut CapeWallet<'a, CapeBackend<'a, ()>>,
+    burner: &mut CapeWallet<'a, CapeBackend<'a>>,
     cape_asset: AssetDefinition,
     amount: impl Into<RecordAmount> + Send + 'static,
 ) -> Result<TransactionReceipt<CapeLedger>, CapeWalletError> {
@@ -383,7 +383,7 @@ pub async fn burn_token<'a>(
 }
 
 pub async fn transfer_token<'a>(
-    sender: &mut CapeWallet<'a, CapeBackend<'a, ()>>,
+    sender: &mut CapeWallet<'a, CapeBackend<'a>>,
     receiver_address: UserAddress,
     amount: impl Into<RecordAmount>,
     asset_code: AssetCode,

--- a/wallet/src/ui.rs
+++ b/wallet/src/ui.rs
@@ -416,6 +416,10 @@ pub struct WalletSummary {
     pub sync_time: usize,
     /// The real-world time (as an event index) according to the EQS.
     pub real_time: usize,
+    /// The contract for which this wallet was created.
+    pub wallet_contract: String,
+    /// The latest contract, in use by the EQS.
+    pub latest_contract: String,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/wallet/src/wallet-api/routes.rs
+++ b/wallet/src/wallet-api/routes.rs
@@ -9,9 +9,10 @@
 
 use crate::web::{NodeOpt, WebState};
 use async_std::fs::{read_dir, File};
-use cap_rust_sandbox::ledger::CapeLedger;
+use cap_rust_sandbox::{ledger::CapeLedger, model::Erc20Code};
 use cape_wallet::{
     disco::{ApiRouteKey, UrlSegmentType},
+    loader::CapeLoader,
     ui::*,
     wallet::{CapeWalletError, CapeWalletExt},
 };
@@ -33,7 +34,6 @@ use seahorse::{
     asset_library::Icon,
     events::{EventIndex, EventSource},
     hd::KeyTree,
-    loader::{Loader, LoaderMetadata},
     txn_builder::{RecordInfo, TransactionReceipt},
     WalletBackend, WalletStorage,
 };
@@ -99,7 +99,10 @@ mod backend {
     use super::*;
     use async_std::sync::{Arc, Mutex};
     use cap_rust_sandbox::universal_param::verifier_keys;
-    use cape_wallet::mocks::{MockCapeBackend, MockCapeNetwork};
+    use cape_wallet::{
+        loader::CapeMetadata,
+        mocks::{MockCapeBackend, MockCapeNetwork},
+    };
     use jf_cap::{
         structs::{FreezeFlag, ReceiverMemo, RecordCommitment, RecordOpening},
         MerkleTree,
@@ -107,13 +110,13 @@ mod backend {
     use reef::traits::Ledger;
     use seahorse::testing::MockLedger;
 
-    pub type Backend = MockCapeBackend<'static, LoaderMetadata>;
+    pub type Backend = MockCapeBackend<'static, CapeMetadata>;
 
     pub async fn new(
         _options: &NodeOpt,
         rng: &mut ChaChaRng,
         faucet_pub_key: UserPubKey,
-        loader: &mut Loader,
+        loader: &mut CapeLoader,
     ) -> Result<Backend, CapeWalletError> {
         let verif_crs = verifier_keys();
 
@@ -137,6 +140,13 @@ mod backend {
 
         MockCapeBackend::new(Arc::new(Mutex::new(ledger)), loader)
     }
+
+    pub async fn latest_contract(_options: &NodeOpt) -> Result<Erc20Code, CapeWalletError> {
+        // The contract address is only used to check if the keystore is current. In testing, the
+        // mock contract is never updated or moved, so any keystore is always current, and it
+        // doesn't matter what we return here.
+        Ok(Erc20Code::default())
+    }
 }
 
 #[cfg(not(test))]
@@ -145,18 +155,18 @@ mod backend {
     use cap_rust_sandbox::universal_param::UNIVERSAL_PARAM;
     use cape_wallet::backend::{CapeBackend, CapeBackendConfig};
 
-    pub type Backend = CapeBackend<'static, LoaderMetadata>;
+    pub type Backend = CapeBackend<'static>;
 
     pub async fn new(
         options: &NodeOpt,
         _rng: &mut ChaChaRng,
         _faucet_pub_key: UserPubKey,
-        loader: &mut Loader,
+        loader: &mut CapeLoader,
     ) -> Result<Backend, CapeWalletError> {
         CapeBackend::new(
             &*UNIVERSAL_PARAM,
             CapeBackendConfig {
-                cape_contract: options.cape_contract(),
+                web3_provider: options.web3_provider(),
                 eqs_url: options.eqs_url(),
                 relayer_url: options.relayer_url(),
                 address_book_url: options.address_book_url(),
@@ -166,6 +176,10 @@ mod backend {
             loader,
         )
         .await
+    }
+
+    pub async fn latest_contract(options: &NodeOpt) -> Result<Erc20Code, CapeWalletError> {
+        CapeLoader::latest_contract(options.eqs_url()).await
     }
 }
 
@@ -374,7 +388,7 @@ pub async fn init_wallet(
     options: &NodeOpt,
     rng: &mut ChaChaRng,
     faucet_pub_key: UserPubKey,
-    mut loader: Loader,
+    mut loader: CapeLoader,
     existing: bool,
 ) -> Result<Wallet, tide::Error> {
     // Store the path so we can have a getlastkeystore endpoint
@@ -466,7 +480,12 @@ pub async fn newwallet(
     };
     let mnemonic = bindings[":mnemonic"].value.as_string()?;
     let password = bindings[":password"].value.as_string()?;
-    let loader = Loader::from_literal(Some(mnemonic.replace('-', " ")), password, path);
+    let loader = CapeLoader::from_literal(
+        Some(mnemonic.replace('-', " ")),
+        password,
+        path,
+        backend::latest_contract(options).await?,
+    );
 
     // If we already have a wallet open, close it before opening a new one, otherwise we can end up
     // with two wallets using the same file at the same time.
@@ -491,7 +510,12 @@ pub async fn openwallet(
         },
     };
     let password = bindings[":password"].value.as_string()?;
-    let loader = Loader::from_literal(None, password, path);
+    let loader = CapeLoader::from_literal(
+        None,
+        password,
+        path,
+        backend::latest_contract(options).await?,
+    );
 
     // If we already have a wallet open, close it before opening a new one, otherwise we can end up
     // with two wallets using the same file at the same time.
@@ -517,7 +541,12 @@ pub async fn resetpassword(
     };
     let mnemonic = bindings[":mnemonic"].value.as_string()?;
     let password = bindings[":password"].value.as_string()?;
-    let loader = Loader::recovery(mnemonic.replace('-', " "), password, path);
+    let loader = CapeLoader::recovery(
+        mnemonic.replace('-', " "),
+        password,
+        path,
+        backend::latest_contract(options).await?,
+    );
 
     // If we already have a wallet open, close it before opening a new one, otherwise we can end up
     // with two wallets using the same file at the same time.

--- a/wallet/src/wallet-api/routes.rs
+++ b/wallet/src/wallet-api/routes.rs
@@ -590,6 +590,11 @@ async fn getinfo(wallet: &mut Option<Wallet>) -> Result<WalletSummary, tide::Err
         assets: known_assets(wallet).await.into_values().collect(),
         sync_time: sync_time.index(EventSource::QueryService),
         real_time: real_time.index(EventSource::QueryService),
+        wallet_contract: format!("{:#x}", Address::from(wallet.contract_address().await?)),
+        latest_contract: format!(
+            "{:#x}",
+            Address::from(wallet.latest_contract_address().await?)
+        ),
     })
 }
 

--- a/wallet/src/wallet-api/web.rs
+++ b/wallet/src/wallet-api/web.rs
@@ -85,10 +85,6 @@ pub struct NodeOpt {
     )]
     pub address_book_url: Url,
 
-    /// Address of the CAPE smart contract.
-    #[structopt(long, env = "CAPE_CONTRACT_ADDRESS")]
-    pub contract_address: Option<Address>,
-
     /// URL for Ethers HTTP Provider
     #[structopt(long, env = "CAPE_WEB3_PROVIDER_URL")]
     pub rpc_url: Option<Url>,
@@ -118,7 +114,6 @@ impl Default for NodeOpt {
             address_book_url: "http://localhost:50078"
                 .parse()
                 .expect("Default address book url couldn't be parsed"),
-            contract_address: None,
             rpc_url: None,
             eth_mnemonic: None,
             min_polling_delay_ms: 500,
@@ -186,12 +181,8 @@ impl NodeOpt {
             .collect()
     }
 
-    pub fn cape_contract(&self) -> Option<(Url, Address)> {
-        match (self.rpc_url.clone(), self.contract_address) {
-            (Some(url), Some(address)) => Some((url, address)),
-            (None, None) => None,
-            _ => panic!("--rpc-url and --contract-address must be given together or not at all"),
-        }
+    pub fn web3_provider(&self) -> Option<Url> {
+        self.rpc_url.clone()
     }
 
     pub fn eqs_url(&self) -> Url {

--- a/wallet/src/wallet.rs
+++ b/wallet/src/wallet.rs
@@ -83,6 +83,12 @@ pub trait CapeWalletBackend<'a>: WalletBackend<'a, CapeLedger> {
 
     /// Wait until the EQS is running.
     async fn wait_for_eqs(&self) -> Result<(), CapeWalletError>;
+
+    /// The contract for which this wallet was created.
+    async fn contract_address(&self) -> Result<Erc20Code, CapeWalletError>;
+
+    /// The latest contract, in use by the EQS.
+    async fn latest_contract_address(&self) -> Result<Erc20Code, CapeWalletError>;
 }
 
 pub type CapeWallet<'a, Backend> = Wallet<'a, Backend, CapeLedger>;
@@ -228,6 +234,12 @@ pub trait CapeWalletExt<'a, Backend: CapeWalletBackend<'a> + Sync + 'a> {
     /// wallet has observed, and `eqs_time` is the total number of events reported by the EQS. It is
     /// guaranteed that `sync_time <= eqs_time`.
     async fn scan_status(&self) -> Result<(EventIndex, EventIndex), CapeWalletError>;
+
+    /// The contract for which this wallet was created.
+    async fn contract_address(&self) -> Result<Erc20Code, CapeWalletError>;
+
+    /// The latest contract, in use by the EQS.
+    async fn latest_contract_address(&self) -> Result<Erc20Code, CapeWalletError>;
 }
 
 #[async_trait]
@@ -476,5 +488,13 @@ impl<'a, Backend: CapeWalletBackend<'a> + Sync + 'a> CapeWalletExt<'a, Backend>
         let eqs_time = self.lock().await.backend().eqs_time().await?;
         let sync_time = self.now().await;
         Ok((sync_time, eqs_time))
+    }
+
+    async fn contract_address(&self) -> Result<Erc20Code, CapeWalletError> {
+        self.lock().await.backend().contract_address().await
+    }
+
+    async fn latest_contract_address(&self) -> Result<Erc20Code, CapeWalletError> {
+        self.lock().await.backend().latest_contract_address().await
     }
 }


### PR DESCRIPTION
~For now, this just stores the contract address when the wallet is created, and fails opening an existing wallet if the contract is out of date. Later I will add the stored contract address and the latest one from the EQS to `getinfo`~

Closes #1121 
Closes #1122 