### PR TITLE
Asynchronous faucet.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2585,6 +2585,7 @@ dependencies = [
  "ark-std",
  "async-channel",
  "async-std",
+ "atomic_store 0.1.2",
  "bincode",
  "cap-rust-sandbox",
  "cape_wallet",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2583,6 +2583,7 @@ name = "faucet"
 version = "0.1.0"
 dependencies = [
  "ark-std",
+ "async-channel",
  "async-std",
  "bincode",
  "cap-rust-sandbox",

--- a/faucet/Cargo.toml
+++ b/faucet/Cargo.toml
@@ -38,6 +38,7 @@ ark-std = "0.3.0"
 
 async-channel = "1.6"
 async-std = "1.10.0"
+atomic_store = { git = "https://github.com/EspressoSystems/atomicstore.git", version = "0.1.0" }
 bincode = "1.3.3"
 cap-rust-sandbox = { path = "../contracts/rust" }
 cape_wallet = { path = "../wallet" }

--- a/faucet/Cargo.toml
+++ b/faucet/Cargo.toml
@@ -12,6 +12,9 @@ authors = ["Espresso Systems <hello@espressosys.com>"]
 edition = "2021"
 license = "GPL-3.0-or-later"
 
+[features]
+slow-tests = []
+
 [[bin]]
 name = "faucet"
 path = "src/faucet.rs"
@@ -33,6 +36,7 @@ doc = false
 [dependencies]
 ark-std = "0.3.0"
 
+async-channel = "1.6"
 async-std = "1.10.0"
 bincode = "1.3.3"
 cap-rust-sandbox = { path = "../contracts/rust" }

--- a/wallet/src/testing.rs
+++ b/wallet/src/testing.rs
@@ -77,7 +77,7 @@ pub async fn retry_delay() {
 
 pub async fn retry<Fut: Future<Output = bool>>(f: impl Fn() -> Fut) {
     let mut backoff = Duration::from_millis(100);
-    for _ in 0..10 {
+    for _ in 0..12 {
         if f().await {
             return;
         }


### PR DESCRIPTION
    Instead of processing requests directly in `tide` request handlers,
    the request handler simply adds the request to a queue, and the
    requests are dequeued and processed by a fixed number of worker
    threads.
    
    This solves two problems:
    * Requests taking a long time to process do not time out the HTTP
      request
    * We limit the CPU usage by limiting the number of worker threads,
      so the server does not get overloaded.
    
    Closes #1151