### PR TITLE
Decrease maximum wallet polling delay.

### DIFF
--- a/wallet/src/backend.rs
+++ b/wallet/src/backend.rs
@@ -334,8 +334,8 @@ impl<'a> WalletBackend<'a, CapeLedger> for CapeBackend<'a> {
 
     async fn subscribe(&self, from: EventIndex, to: Option<EventIndex>) -> Self::EventStream {
         // To avoid overloading the EQS with spurious network traffic, we will increase the backoff
-        // time as long as we are not getting any new events, up to a maximum of 1 minute.
-        let max_backoff = Duration::from_secs(60);
+        // time as long as we are not getting any new events, up to a maximum of 10 seconds.
+        let max_backoff = Duration::from_secs(10);
 
         struct StreamState {
             from: usize,


### PR DESCRIPTION
This delay is meant to decrease pressure on the EQS. We have
observed that even at some scale, the EQS uses barely any of its
allotted CPU. Therefore, we can poll more frequently, which will
lead to the "CAPE Syncing" spinner in the UI appearing for shorter
durations, and ultimately making the UI feel just a bit more
responsive.