### PR TITLE
Remove duplicate definition of Merkle root history size

### DIFF
--- a/contracts/rust/src/deploy.rs
+++ b/contracts/rust/src/deploy.rs
@@ -56,7 +56,7 @@ pub async fn deploy_test_cape_with_deployer(
         deployer.clone(),
         &contract_abi_path("mocks/TestCAPE.sol/TestCAPE"),
         CAPEConstructorArgs::new(
-            CAPE_NUM_ROOTS,
+            CAPE_NUM_ROOTS as u64,
             verifier.address(),
             records_merkle_tree.address(),
         )
@@ -100,7 +100,7 @@ pub async fn deploy_cape_with_deployer(deployer: Arc<EthMiddleware>) -> CAPE<Eth
         deployer.clone(),
         &contract_abi_path("CAPE.sol/CAPE"),
         CAPEConstructorArgs::new(
-            CAPE_NUM_ROOTS,
+            CAPE_NUM_ROOTS as u64,
             verifier.address(),
             records_merkle_tree.address(),
         )

--- a/contracts/rust/src/ledger.rs
+++ b/contracts/rust/src/ledger.rs
@@ -321,7 +321,7 @@ impl Ledger for CapeLedger {
     }
 
     fn record_root_history() -> usize {
-        CapeContractState::RECORD_ROOT_HISTORY_SIZE
+        CAPE_NUM_ROOTS
     }
 
     fn merkle_height() -> u8 {

--- a/contracts/rust/src/model.rs
+++ b/contracts/rust/src/model.rs
@@ -31,7 +31,7 @@ use std::sync::Arc;
 // can be changed later.
 pub const CAPE_MERKLE_HEIGHT: u8 = 24 /*H*/;
 pub const CAPE_BURN_MAGIC_BYTES: &str = "EsSCAPE burn";
-pub const CAPE_NUM_ROOTS: u64 = 40;
+pub const CAPE_NUM_ROOTS: usize = 40;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum CapeModelTxn {
@@ -347,9 +347,6 @@ fn extract_burn_dst(xfr: &TransferNote) -> Option<Option<EthereumAddr>> {
 }
 
 impl CapeContractState {
-    // How many previous record Merkle tree root hashes the validator should remember.
-    pub const RECORD_ROOT_HISTORY_SIZE: usize = 1000;
-
     pub fn new(verif_crs: VerifierKeySet, record_merkle_frontier: MerkleTree) -> Self {
         Self {
             ledger: CapeLedgerState {
@@ -357,7 +354,7 @@ impl CapeContractState {
                 record_merkle_commitment: record_merkle_frontier.commitment(),
                 record_merkle_frontier: record_merkle_frontier.frontier(),
                 past_record_merkle_roots: CapeRecordMerkleHistory(VecDeque::with_capacity(
-                    Self::RECORD_ROOT_HISTORY_SIZE,
+                    CAPE_NUM_ROOTS,
                 )),
             },
             verif_crs,
@@ -665,9 +662,7 @@ impl CapeContractState {
                         builder.into_frontier_and_commitment()
                     };
 
-                    if new_state.ledger.past_record_merkle_roots.0.len()
-                        >= Self::RECORD_ROOT_HISTORY_SIZE
-                    {
+                    if new_state.ledger.past_record_merkle_roots.0.len() >= CAPE_NUM_ROOTS {
                         new_state.ledger.past_record_merkle_roots.0.pop_back();
                     }
                     new_state


### PR DESCRIPTION
Closes #1153 