### PR TITLE
Use rolling log for EQS storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -699,12 +699,11 @@ checksum = "065374052e7df7ee4047b1160cca5e1467a12351a40b3da123c870ba0b8eda2a"
 
 [[package]]
 name = "atomic_store"
-version = "0.1.1"
-source = "git+https://github.com/EspressoSystems/atomicstore.git?tag=0.1.1#e116cea2de934fd315f690d07d45b3bb7a213654"
+version = "0.1.3"
+source = "git+https://github.com/EspressoSystems/atomicstore.git?tag=0.1.3#9da9998dd8d92f61c5b78a8f0676d415e6fafe92"
 dependencies = [
  "ark-serialize",
  "bincode",
- "chrono",
  "glob",
  "serde",
  "snafu",
@@ -712,8 +711,8 @@ dependencies = [
 
 [[package]]
 name = "atomic_store"
-version = "0.1.2"
-source = "git+https://github.com/EspressoSystems/atomicstore.git#55d9753e1fcb35c61566b8e056426e85e9e7eeeb"
+version = "0.1.3"
+source = "git+https://github.com/EspressoSystems/atomicstore.git#9da9998dd8d92f61c5b78a8f0676d415e6fafe92"
 dependencies = [
  "ark-serialize",
  "bincode",
@@ -2137,7 +2136,7 @@ name = "eqs"
 version = "0.0.2"
 dependencies = [
  "async-std",
- "atomic_store 0.1.2",
+ "atomic_store 0.1.3 (git+https://github.com/EspressoSystems/atomicstore.git)",
  "bincode",
  "cap-rust-sandbox",
  "commit",
@@ -2585,7 +2584,7 @@ dependencies = [
  "ark-std",
  "async-channel",
  "async-std",
- "atomic_store 0.1.2",
+ "atomic_store 0.1.3 (git+https://github.com/EspressoSystems/atomicstore.git)",
  "bincode",
  "cap-rust-sandbox",
  "cape_wallet",
@@ -5290,8 +5289,8 @@ dependencies = [
 
 [[package]]
 name = "seahorse"
-version = "0.2.5"
-source = "git+https://github.com/EspressoSystems/seahorse.git?tag=0.2.5#613d1e6274a77ab2c003b2d793cd5de199879cea"
+version = "0.2.6"
+source = "git+https://github.com/EspressoSystems/seahorse.git?branch=mathis-atomicstore-0.1.3#d30dfdb6f83cde030a3a01441a3a4beb793d9e99"
 dependencies = [
  "arbitrary",
  "arbitrary-wrappers",
@@ -5300,7 +5299,7 @@ dependencies = [
  "async-scoped",
  "async-std",
  "async-trait",
- "atomic_store 0.1.1",
+ "atomic_store 0.1.3 (git+https://github.com/EspressoSystems/atomicstore.git?tag=0.1.3)",
  "bincode",
  "bip0039",
  "chacha20",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5290,7 +5290,7 @@ dependencies = [
 [[package]]
 name = "seahorse"
 version = "0.2.6"
-source = "git+https://github.com/EspressoSystems/seahorse.git?branch=mathis-atomicstore-0.1.3#cc92f1d38c1907ce522183f3504fba2e715ae1f2"
+source = "git+https://github.com/EspressoSystems/seahorse.git?tag=0.2.6#9c99d795e3d31a576fdb6b8d7cc07efd3ec0b4ba"
 dependencies = [
  "arbitrary",
  "arbitrary-wrappers",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5290,7 +5290,7 @@ dependencies = [
 [[package]]
 name = "seahorse"
 version = "0.2.6"
-source = "git+https://github.com/EspressoSystems/seahorse.git?branch=mathis-atomicstore-0.1.3#d30dfdb6f83cde030a3a01441a3a4beb793d9e99"
+source = "git+https://github.com/EspressoSystems/seahorse.git?branch=mathis-atomicstore-0.1.3#cc92f1d38c1907ce522183f3504fba2e715ae1f2"
 dependencies = [
  "arbitrary",
  "arbitrary-wrappers",

--- a/contracts/rust/Cargo.toml
+++ b/contracts/rust/Cargo.toml
@@ -63,7 +63,7 @@ rand = "0.8.4"
 rand_chacha = "0.3.1"
 reef = { git = "https://github.com/EspressoSystems/reef.git", tag = "0.2.2" }
 regex = "1.5.5"
-seahorse = { git = "https://github.com/EspressoSystems/seahorse.git", tag = "0.2.5" }
+seahorse = { git = "https://github.com/EspressoSystems/seahorse.git", branch = "mathis-atomicstore-0.1.3" }
 serde = { version = "1.0.124", features = ["derive"] }
 serde_json = "1.0.67"
 sha3 = "0.9.1"

--- a/contracts/rust/Cargo.toml
+++ b/contracts/rust/Cargo.toml
@@ -63,7 +63,7 @@ rand = "0.8.4"
 rand_chacha = "0.3.1"
 reef = { git = "https://github.com/EspressoSystems/reef.git", tag = "0.2.2" }
 regex = "1.5.5"
-seahorse = { git = "https://github.com/EspressoSystems/seahorse.git", branch = "mathis-atomicstore-0.1.3" }
+seahorse = { git = "https://github.com/EspressoSystems/seahorse.git", tag = "0.2.6" }
 serde = { version = "1.0.124", features = ["derive"] }
 serde_json = "1.0.67"
 sha3 = "0.9.1"

--- a/eqs/Cargo.toml
+++ b/eqs/Cargo.toml
@@ -32,7 +32,7 @@ net = { git = "https://github.com/EspressoSystems/net.git", tag = "0.2.2" }
 rand = "0.8.4"
 rand_chacha = { version = "0.3.1", features = ["serde1"] }
 reef = { git = "https://github.com/EspressoSystems/reef.git", tag = "0.2.2" }
-seahorse = { git = "https://github.com/EspressoSystems/seahorse.git", branch = "mathis-atomicstore-0.1.3", features = ["testing"] }
+seahorse = { git = "https://github.com/EspressoSystems/seahorse.git", tag = "0.2.6", features = ["testing"] }
 serde = { version = "1.0.123", features = ["derive", "rc"] }
 serde_derive = "1.0.118"
 serde_json = "1.0.61"

--- a/eqs/Cargo.toml
+++ b/eqs/Cargo.toml
@@ -15,7 +15,7 @@ license = "GPL-3.0-or-later"
 
 [dependencies]
 async-std = { version = "1.10.0", features = ["unstable", "attributes", "tokio1"] }
-atomic_store = { git = "https://github.com/EspressoSystems/atomicstore.git", version = "0.1.0" }
+atomic_store = { git = "https://github.com/EspressoSystems/atomicstore.git", version = "0.1.3" }
 bincode = "1.3.3"
 cap-rust-sandbox = { path = "../contracts/rust" }
 commit = { git = "https://github.com/EspressoSystems/commit.git", tag = "0.1.0" }
@@ -32,7 +32,7 @@ net = { git = "https://github.com/EspressoSystems/net.git", tag = "0.2.2" }
 rand = "0.8.4"
 rand_chacha = { version = "0.3.1", features = ["serde1"] }
 reef = { git = "https://github.com/EspressoSystems/reef.git", tag = "0.2.2" }
-seahorse = { git = "https://github.com/EspressoSystems/seahorse.git", tag = "0.2.5", features = ["testing"] }
+seahorse = { git = "https://github.com/EspressoSystems/seahorse.git", branch = "mathis-atomicstore-0.1.3", features = ["testing"] }
 serde = { version = "1.0.123", features = ["derive", "rc"] }
 serde_derive = "1.0.118"
 serde_json = "1.0.61"

--- a/faucet/Cargo.toml
+++ b/faucet/Cargo.toml
@@ -53,7 +53,7 @@ net = { git = "https://github.com/EspressoSystems/net.git", tag = "0.2.2" }
 rand = "0.8.5"
 rand_chacha = "0.3.1"
 reef = { git = "https://github.com/EspressoSystems/reef.git", tag = "0.2.2" }
-seahorse = { git = "https://github.com/EspressoSystems/seahorse.git", branch = "mathis-atomicstore-0.1.3" }
+seahorse = { git = "https://github.com/EspressoSystems/seahorse.git", tag = "0.2.6" }
 serde = "1.0.136"
 serde_json = "1.0.67"
 snafu = "0.7.0"

--- a/faucet/Cargo.toml
+++ b/faucet/Cargo.toml
@@ -38,7 +38,7 @@ ark-std = "0.3.0"
 
 async-channel = "1.6"
 async-std = "1.10.0"
-atomic_store = { git = "https://github.com/EspressoSystems/atomicstore.git", version = "0.1.0" }
+atomic_store = { git = "https://github.com/EspressoSystems/atomicstore.git", version = "0.1.3" }
 bincode = "1.3.3"
 cap-rust-sandbox = { path = "../contracts/rust" }
 cape_wallet = { path = "../wallet" }
@@ -53,7 +53,7 @@ net = { git = "https://github.com/EspressoSystems/net.git", tag = "0.2.2" }
 rand = "0.8.5"
 rand_chacha = "0.3.1"
 reef = { git = "https://github.com/EspressoSystems/reef.git", tag = "0.2.2" }
-seahorse = { git = "https://github.com/EspressoSystems/seahorse.git", tag = "0.2.5" }
+seahorse = { git = "https://github.com/EspressoSystems/seahorse.git", branch = "mathis-atomicstore-0.1.3" }
 serde = "1.0.136"
 serde_json = "1.0.67"
 snafu = "0.7.0"

--- a/faucet/src/faucet.rs
+++ b/faucet/src/faucet.rs
@@ -301,8 +301,8 @@ impl FaucetQueueIndex {
 
         // Add the key to our persistent log.
         self.queue.store_resource(&(key.clone(), Some(0)))?;
-        self.queue.commit_version().unwrap();
-        self.store.commit_version().unwrap();
+        self.queue.commit_version()?;
+        self.store.commit_version()?;
         // If successful, add it to our in-memory index.
         self.index.insert(key, 0);
         Ok(true)
@@ -324,8 +324,8 @@ impl FaucetQueueIndex {
             // Update the entry in our persistent log.
             self.queue
                 .store_resource(&(key.clone(), Some(grants_given)))?;
-            self.queue.commit_version().unwrap();
-            self.store.commit_version().unwrap();
+            self.queue.commit_version()?;
+            self.store.commit_version()?;
             // If successful, update our in-memory index.
             self.index.insert(key, grants_given);
             Ok(true)
@@ -336,8 +336,8 @@ impl FaucetQueueIndex {
     fn remove(&mut self, key: &UserPubKey) -> Result<(), FaucetError> {
         // Make a persistent note to remove the key.
         self.queue.store_resource(&(key.clone(), None))?;
-        self.queue.commit_version().unwrap();
-        self.store.commit_version().unwrap();
+        self.queue.commit_version()?;
+        self.store.commit_version()?;
         // Update our in-memory set.
         self.index.remove(key);
         Ok(())

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -54,7 +54,7 @@ rand_chacha = "0.3.1"
 reef = { git = "https://github.com/EspressoSystems/reef.git", tag = "0.2.2" }
 regex = "1.5.4"
 relayer = { path = "../relayer", features = ["testing"] }
-seahorse = { git = "https://github.com/EspressoSystems/seahorse.git", branch = "mathis-atomicstore-0.1.3", features = ["testing"] }
+seahorse = { git = "https://github.com/EspressoSystems/seahorse.git", tag = "0.2.6", features = ["testing"] }
 serde = { version = "1.0.123", features = ["derive", "rc"] }
 serde_derive = "1.0.118"
 serde_json = "1.0.61"

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -54,7 +54,7 @@ rand_chacha = "0.3.1"
 reef = { git = "https://github.com/EspressoSystems/reef.git", tag = "0.2.2" }
 regex = "1.5.4"
 relayer = { path = "../relayer", features = ["testing"] }
-seahorse = { git = "https://github.com/EspressoSystems/seahorse.git", tag = "0.2.5", features = ["testing"] }
+seahorse = { git = "https://github.com/EspressoSystems/seahorse.git", branch = "mathis-atomicstore-0.1.3", features = ["testing"] }
 serde = { version = "1.0.123", features = ["derive", "rc"] }
 serde_derive = "1.0.118"
 serde_json = "1.0.61"


### PR DESCRIPTION
- Update atomic store to 0.1.3.
- EQS: keep 5 latest log entries.
- Return Error instead of panicking when commiting faucet grant index.
- [x] Use seahorse `0.2.6` when available.
- https://github.com/EspressoSystems/seahorse/pull/219

Should we make the number of log entries the EQS keep configurable via env var?

Close #1183 