### PR TITLE
Check if storage is working when returning the response to a faucet healthcheck request.

### DIFF
--- a/contracts/rust/src/bin/gen-vk-libraries.rs
+++ b/contracts/rust/src/bin/gen-vk-libraries.rs
@@ -18,7 +18,7 @@ use std::{fs::OpenOptions, io::prelude::*, path::PathBuf};
 
 // depth of the record merkle tree
 const TREE_DEPTH: u8 = 24;
-// list of supported tranaction types, each would result in a different verifying key
+// list of supported transaction types, each would result in a different verifying key
 const SUPPORTED_VKS: [(NoteType, u8, u8, u8); 7] = [
     (NoteType::Transfer, 1, 2, TREE_DEPTH),
     (NoteType::Transfer, 2, 2, TREE_DEPTH),

--- a/faucet/src/faucet.rs
+++ b/faucet/src/faucet.rs
@@ -478,6 +478,13 @@ pub struct HealthCheck {
 /// normally, a response with status 503 and payload {"status":
 /// "unavailable"} should be added.
 async fn healthcheck(req: tide::Request<FaucetState>) -> Result<tide::Response, tide::Error> {
+    // Ensure we can write to storage.
+    let mut index = req.state().queue.index.lock().await;
+    let default_user_pub_key = UserPubKey::default();
+    index.insert(default_user_pub_key.clone())?;
+    index.remove(&default_user_pub_key)?;
+
+    // Return healthcheck response
     response(
         &req,
         &HealthCheck {


### PR DESCRIPTION
Closes #1186.

I am not sure if the storage requests are neutral.
Also I have an error when I run the tests locally. Something similar to the error described in #1179.