### PR TITLE
Drop write lock before persisting to disk

### DIFF
--- a/eqs/src/entry.rs
+++ b/eqs/src/entry.rs
@@ -22,6 +22,8 @@ use cap_rust_sandbox::{
 };
 
 pub async fn run(opt: &EQSOptions) -> std::io::Result<()> {
+    tracing::info!("Starting EQS");
+
     if !opt.temp_test_run {
         let provider = get_provider_from_url(opt.rpc_url());
         ensure_connected_to_contract(&provider, opt.cape_address().unwrap())
@@ -35,6 +37,7 @@ pub async fn run(opt: &EQSOptions) -> std::io::Result<()> {
             Arc::new(RwLock::new(QueryResultState::new(verifier_keys()))),
         )
     } else {
+        let tic = std::time::Instant::now();
         let state_persistence = StatePersistence::load(&opt.store_path(), "eth_query").unwrap();
         let query_result_state = Arc::new(RwLock::new(
             state_persistence.load_latest_state().unwrap_or_else(|err| {
@@ -45,6 +48,8 @@ pub async fn run(opt: &EQSOptions) -> std::io::Result<()> {
                 }
             }),
         ));
+        let toc = std::time::Instant::now();
+        tracing::info!("Restored state in {:?}", toc - tic);
         (state_persistence, query_result_state)
     };
 

--- a/eqs/src/eth_polling.rs
+++ b/eqs/src/eth_polling.rs
@@ -170,6 +170,8 @@ impl EthPolling {
         // select cape events starting from the first block for which we do not have confirmed
         // completion of processing
 
+        tracing::info!("Fetching events from block {} to {}", from_block, to_block);
+
         let new_event_result = self
             .connection
             .contract
@@ -368,8 +370,11 @@ impl EthPolling {
                     updated_state.last_reported_index = Some(current_index);
                     self.last_event_index = Some(current_index);
 
+                    let state_for_write = updated_state.clone();
+                    drop(updated_state);
+
                     // persist the state block updates (will be more fine grained in r3)
-                    self.state_persistence.store_latest_state(&*updated_state);
+                    self.state_persistence.store_latest_state(&state_for_write);
                 }
                 CAPEEvents::Erc20TokensDepositedFilter(filter_data) => {
                     let ro_bytes = filter_data.ro_bytes.clone();
@@ -461,8 +466,11 @@ impl EthPolling {
                     updated_state.last_reported_index = Some(current_index);
                     self.last_event_index = Some(current_index);
 
+                    let state_for_write = updated_state.clone();
+                    drop(updated_state);
+
                     // persist the state block updates (will be more fine grained in r3)
-                    self.state_persistence.store_latest_state(&updated_state);
+                    self.state_persistence.store_latest_state(&state_for_write);
                 }
 
                 CAPEEvents::AssetSponsoredFilter(filter_data) => {
@@ -476,8 +484,11 @@ impl EthPolling {
                     updated_state.last_reported_index = Some(current_index);
                     self.last_event_index = Some(current_index);
 
+                    let state_for_write = updated_state.clone();
+                    drop(updated_state);
+
                     // persist the state block updates (will be more fine grained in r3)
-                    self.state_persistence.store_latest_state(&updated_state);
+                    self.state_persistence.store_latest_state(&state_for_write);
                 }
             }
         }

--- a/eqs/src/state_persistence.rs
+++ b/eqs/src/state_persistence.rs
@@ -53,10 +53,13 @@ impl StatePersistence {
     }
 
     pub fn store_latest_state(&mut self, state: &QueryResultState) {
+        let tic = std::time::Instant::now();
         self.state_snapshot.store_resource(state).unwrap();
         self.state_snapshot.commit_version().unwrap();
         self.atomic_store.commit_version().unwrap();
         self.state_snapshot.prune_file_entries().unwrap();
+        let toc = std::time::Instant::now();
+        tracing::info!("Persisting state took {:?}", toc - tic);
     }
 
     pub fn load_latest_state(&self) -> Result<QueryResultState, PersistenceError> {


### PR DESCRIPTION
Also adds a few info logs related to EQS activity.

I think this is preferable to operating on a copy because all operations on the state go through the RWLock directly. In my experiments this reduced the lock time from up 1 second to about 40ms. The less safe alternative (making a copy and then acquiring a write lock to write back the modified copy) locks for about 20ms. However with the second version it would be possible to operate on more than one copy simultaneously, thereby ending up with a wrong state.