### PR TITLE
Undo WARN log workaround

### DIFF
--- a/eqs/src/entry.rs
+++ b/eqs/src/entry.rs
@@ -22,7 +22,7 @@ use cap_rust_sandbox::{
 };
 
 pub async fn run(opt: &EQSOptions) -> std::io::Result<()> {
-    tracing::warn!("Starting EQS");
+    tracing::info!("Starting EQS");
 
     if !opt.temp_test_run {
         let provider = get_provider_from_url(opt.rpc_url());
@@ -49,7 +49,7 @@ pub async fn run(opt: &EQSOptions) -> std::io::Result<()> {
             }),
         ));
         let toc = std::time::Instant::now();
-        tracing::warn!("Restored state in {:?}", toc - tic);
+        tracing::info!("Restored state in {:?}", toc - tic);
         (state_persistence, query_result_state)
     };
 

--- a/eqs/src/eth_polling.rs
+++ b/eqs/src/eth_polling.rs
@@ -197,7 +197,7 @@ impl EthPolling {
             let current_log_index = meta.log_index.as_u64();
             let current_index = (current_block, current_log_index);
 
-            tracing::warn!(
+            tracing::info!(
                 "Processing block {} event {}",
                 current_block,
                 current_log_index,

--- a/eqs/src/state_persistence.rs
+++ b/eqs/src/state_persistence.rs
@@ -59,7 +59,7 @@ impl StatePersistence {
         self.atomic_store.commit_version().unwrap();
         self.state_snapshot.prune_file_entries().unwrap();
         let toc = std::time::Instant::now();
-        tracing::warn!("Persisting state took {:?}", toc - tic);
+        tracing::info!("Persisting state took {:?}", toc - tic);
     }
 
     pub fn load_latest_state(&self) -> Result<QueryResultState, PersistenceError> {


### PR DESCRIPTION
We can configure the logs the way we want with

    RUST_LOG="info,tide=warn,net=warn"