### PR TITLE
relayer: retry after "nonce too low" errors

### DIFF
--- a/relayer/src/lib.rs
+++ b/relayer/src/lib.rs
@@ -238,7 +238,8 @@ async fn submit_block(web_state: &WebState, block: BlockWithMemos) -> Result<H25
         .await
         .map_err(|err| {
             let msg = err.to_string();
-            if msg.contains("replacement transaction underpriced") {
+            if msg.contains("replacement transaction underpriced") || msg.contains("nonce too low")
+            {
                 Error::Nonce { msg }
             } else if msg.contains("Root not found") {
                 Error::RootNotFound { msg }

--- a/wallet.Dockerfile
+++ b/wallet.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:impish
+FROM ubuntu:jammy
 RUN apt-get update \
   && apt-get install -y libcurl4 \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
We occasionally get a "nonce too low" error. I'm not 100% sure why this happens but it's possible that a transaction was submitted a bit earlier and got mined quickly enough for the subsequent transaction to have a nonce that is in fact too low. It could also be that we are sometimes getting an outdated response on the transaction count query that ethers is using to determine the nonce.

In any event, I think it makes sense to retry.

Example error log on datadog [link](https://app.datadoghq.com/logs?query=host%3A%22%2Fcape%2Fgoerli%2Frelayer%22%20service%3Acloudwatch&agg_m=count&agg_t=count&cols=&context_event=AYI-rBQ0AACXNHKSX5QTAwAD&event=&index=%2A&stream_sort=time%2Cdesc&to_event=AQAAAYI-rZwxokv_mgAAAABBWUktcmE1SEFBQ0tPNHY0Z2xyRGt3QUE&viz=&from_ts=1658906998438&to_ts=1658908941361&live=false).