### PR TITLE
Update ubuntu: impish -> jammy

### DIFF
--- a/wallet.Dockerfile
+++ b/wallet.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:impish
+FROM ubuntu:jammy
 RUN apt-get update \
   && apt-get install -y libcurl4 \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
There are no more updates for impish as of July 14th.

https://fridge.ubuntu.com/2022/07/19/ubuntu-21-10-impish-indri-end-of-life-reached-on-july-14-2022/