### PR TITLE
Update rust 1.63.0 -> 1.66.1

### DIFF
--- a/contracts/rust/src/cape/mod.rs
+++ b/contracts/rust/src/cape/mod.rs
@@ -5,7 +5,6 @@
 // This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 // You should have received a copy of the GNU General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-#![deny(warnings)]
 pub mod events;
 pub mod faucet;
 mod note_types;

--- a/contracts/rust/src/cape_e2e_test_mint.rs
+++ b/contracts/rust/src/cape_e2e_test_mint.rs
@@ -6,7 +6,6 @@
 // You should have received a copy of the GNU General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 #![cfg(test)]
-#![deny(warnings)]
 
 use crate::assertion::EnsureMined;
 use crate::deploy::deploy_test_cape;

--- a/contracts/rust/src/cape_e2e_test_transfer.rs
+++ b/contracts/rust/src/cape_e2e_test_transfer.rs
@@ -6,7 +6,6 @@
 // You should have received a copy of the GNU General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 #![cfg(test)]
-#![deny(warnings)]
 
 use crate::assertion::EnsureMined;
 use crate::deploy::deploy_test_cape;

--- a/contracts/rust/src/model.rs
+++ b/contracts/rust/src/model.rs
@@ -5,8 +5,6 @@
 // This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 // You should have received a copy of the GNU General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-#![deny(warnings)]
-
 use crate::types;
 use ark_serialize::*;
 use core::convert::TryFrom;

--- a/contracts/rust/src/universal_param.rs
+++ b/contracts/rust/src/universal_param.rs
@@ -5,7 +5,6 @@
 // This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 // You should have received a copy of the GNU General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-#![deny(warnings)]
 use jf_cap::proof::universal_setup_for_staging;
 use jf_cap::TransactionVerifyingKey;
 use key_set::{KeySet, VerifierKeySet};

--- a/flake.lock
+++ b/flake.lock
@@ -33,11 +33,11 @@
     },
     "flake-utils_2": {
       "locked": {
-        "lastModified": 1656928814,
-        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
         "type": "github"
       },
       "original": {
@@ -63,11 +63,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1659102345,
-        "narHash": "sha256-Vbzlz254EMZvn28BhpN8JOi5EuKqnHZ3ujFYgFcSGvk=",
+        "lastModified": 1665296151,
+        "narHash": "sha256-uOB0oxqxN9K7XGF1hcnY+PQnlQJ+3bP2vCn/+Ru/bbc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "11b60e4f80d87794a2a4a8a256391b37c59a1ea7",
+        "rev": "14ccaaedd95a488dd7ae142757884d8e125b3363",
         "type": "github"
       },
       "original": {
@@ -115,11 +115,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1660618363,
-        "narHash": "sha256-SdIGzmiMjAfKyZScxb497AA4oHiiaHMPhb9iwLtoaMk=",
+        "lastModified": 1673404037,
+        "narHash": "sha256-9yhRzFiqzVQaJN5jsAIwApDolkORRQ3EJi7D4yu58ig=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "b480a97c66038e9a6ff68cbf0c4fa4a783416e0b",
+        "rev": "a979c85ed4691bf996af88504522b32e9611ccfe",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -46,7 +46,7 @@
         opensslMusl.dev
         opensslMusl.out
       ];
-      stableMuslRustToolchain = pkgs.rust-bin.stable."1.63.0".minimal.override {
+      stableMuslRustToolchain = pkgs.rust-bin.stable.latest.minimal.override {
         extensions = [ "rustfmt" "clippy" "llvm-tools-preview" "rust-src" ];
         targets = [ "x86_64-unknown-linux-musl" ];
       };
@@ -58,7 +58,7 @@
       pythonEnv = pkgs.poetry2nix.mkPoetryEnv { projectDir = ./.; };
       myPython = with pkgs; [ poetry pythonEnv ];
 
-      stableRustToolchain = pkgs.rust-bin.stable."1.63.0".minimal.override {
+      stableRustToolchain = pkgs.rust-bin.stable.latest.minimal.override {
         extensions = [ "rustfmt" "clippy" "llvm-tools-preview" "rust-src" ];
       };
       rustDeps = with pkgs;

--- a/flake.nix
+++ b/flake.nix
@@ -109,7 +109,15 @@
             cargo-clippy = {
               enable = true;
               description = "Lint Rust code.";
-              entry = "cargo-clippy --workspace -- -D warnings";
+              entry = "cargo-clippy --workspace -- -D warnings" + pkgs.lib.strings.concatMapStrings (lint: " -A clippy::${lint} ") [
+                # These lints are new from 1.63 to 1.66.1, we should fix the code and remove the allowed lints.
+                "bool-to-int-with-if"
+                "explicit-auto-deref"
+                "needless_borrow"
+                "partialeq-to-none"
+                "result_large_err"
+                "unnecessary_cast"
+              ];
               files = "\\.rs$";
               pass_filenames = false;
             };

--- a/wallet/src/backend.rs
+++ b/wallet/src/backend.rs
@@ -6,8 +6,6 @@
 // You should have received a copy of the GNU General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 //! An implementation of [seahorse::WalletBackend] for CAPE.
-#![deny(warnings)]
-
 use crate::{loader::CapeMetadata, CapeWalletBackend, CapeWalletError};
 use address_book::InsertPubKey;
 use async_std::{

--- a/wallet/src/bin/random-wallet-in-mem.rs
+++ b/wallet/src/bin/random-wallet-in-mem.rs
@@ -11,7 +11,6 @@
 //
 // This test is still a work in progrogress.  See: https://github.com/EspressoSystems/cape/issues/649
 // for everything left before it works properly.
-#![deny(warnings)]
 
 use cap_rust_sandbox::{deploy::deploy_erc20_token, universal_param::UNIVERSAL_PARAM};
 use cape_wallet::backend::{CapeBackend, CapeBackendConfig};

--- a/wallet/src/bin/random-wallet.rs
+++ b/wallet/src/bin/random-wallet.rs
@@ -8,7 +8,6 @@
 // A wallet that generates random transactions, for testing purposes.
 // This test is still a work in progress and will not work until we have
 // integration with the EQS.  See Issue: https://github.com/EspressoSystems/cape/issues/548
-#![deny(warnings)]
 
 use async_std::task::sleep;
 use cap_rust_sandbox::{deploy::deploy_erc20_token, universal_param::UNIVERSAL_PARAM};

--- a/wallet/src/testing.rs
+++ b/wallet/src/testing.rs
@@ -6,7 +6,6 @@
 // You should have received a copy of the GNU General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 //! Utilities for writing wallet tests
-// #![deny(warnings)]
 
 use crate::backend::CapeBackend;
 use crate::mocks::*;


### PR DESCRIPTION
There would be quite a few lints to fix to get clippy to pass with `-D warnings`. 